### PR TITLE
fix: statusLine에서 CLAUDE_PLUGIN_DATA 환경변수 무시되는 버그 수정

### DIFF
--- a/src/core/paths.ts
+++ b/src/core/paths.ts
@@ -13,9 +13,14 @@ function isUserScope(): boolean {
 }
 
 // Data directory resolution by scope:
+// Explicit → $CLAUDE_PLUGIN_DATA (set by statusLine command)
 // User scope  → ~/.claude/tokenmon/
 // Local scope → {project}/.tokenmon/ (next to .claude-plugin/)
 function resolveDataDir(): string {
+  if (process.env.CLAUDE_PLUGIN_DATA) {
+    return process.env.CLAUDE_PLUGIN_DATA;
+  }
+
   if (isUserScope()) {
     return join(CLAUDE_DIR, 'tokenmon');
   }


### PR DESCRIPTION
## 문제

`statusLine` 커맨드에서 `CLAUDE_PLUGIN_DATA` 환경변수를 명시적으로 전달해도 `resolveDataDir()`가 이를 무시하고 자체 로직으로 경로를 재계산합니다.

결과적으로 user scope 감지 시 `~/.claude/tokenmon/`을 바라보게 되어, 실제 데이터가 있는 `{plugin_root}/.tokenmon/`을 찾지 못해 status bar에 포켓몬이 표시되지 않습니다.

## 원인

`src/core/paths.ts`의 `resolveDataDir()`가 `CLAUDE_PLUGIN_DATA` 환경변수를 확인하지 않았음.

## 수정

`CLAUDE_PLUGIN_DATA`가 설정된 경우 해당 경로를 최우선으로 사용하도록 변경.

```ts
function resolveDataDir(): string {
  if (process.env.CLAUDE_PLUGIN_DATA) {
    return process.env.CLAUDE_PLUGIN_DATA;
  }
  // ...
}
```

## 재현 환경

- Claude Code WSL2 환경
- user scope로 설치된 tkm 플러그인
- status bar에 포켓몬 미표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)