### PR TITLE
feat: /tkm:language skill — 한국어 ↔ 영어 토글

### DIFF
--- a/skills/language/SKILL.md
+++ b/skills/language/SKILL.md
@@ -8,12 +8,16 @@ Check the current language and interactively switch between Korean and English.
 
 ## Step 1: Read current language
 
-Read the current language setting from config:
+Read the current language setting from config, respecting `CLAUDE_CONFIG_DIR`:
 
 ```bash
 node -e "
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const claudeDir = process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), '.claude');
 try {
-  const cfg = JSON.parse(require('fs').readFileSync(require('os').homedir()+'/.claude/tokenmon/config.json','utf8'));
+  const cfg = JSON.parse(fs.readFileSync(path.join(claudeDir, 'tokenmon', 'config.json'), 'utf8'));
   console.log(cfg.language ?? 'ko');
 } catch { console.log('ko'); }
 "
@@ -21,7 +25,7 @@ try {
 
 ## Step 2: Confirm toggle
 
-Show the current language and ask the user whether to switch.
+Use **AskUserQuestion** to show the current language and ask the user whether to switch.
 
 - If current is `ko`: "현재 **한국어** 모드입니다. 영어로 전환할까요?"
 - If current is `en`: "Currently in **English** mode. Switch to Korean?"
@@ -49,4 +53,7 @@ Then show the updated status:
 
 ## Step 3b: Keep current language
 
-If the user chose **Keep**, inform them that the language remains unchanged and exit.
+If the user chose **Keep**, respond with the following message (based on current language) and exit:
+
+- If current is `ko`: "현재 언어(한국어)를 유지합니다."
+- If current is `en`: "Keeping current language (English)."


### PR DESCRIPTION
## Summary

- `skills/language/` 디렉토리에 새 스킬 추가
- `/tkm:language` 실행 시 현재 언어를 감지하고 `AskUserQuestion`으로 토글
- 기존 `config set language en/ko` CLI를 래핑한 인터랙티브 UX

## How it works

1. `~/.claude/tokenmon/config.json`에서 현재 `language` 값 읽기
2. 현재 언어를 보여주고 전환 여부 확인
3. `tokenmon config set language <en|ko>` 실행
4. `tokenmon status`로 변경 결과 확인

## Test

```
/tkm:language
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)