### PR TITLE
feat: 진화체 야생 출현 최소 레벨 보장

### DIFF
--- a/src/core/encounter.ts
+++ b/src/core/encounter.ts
@@ -30,15 +30,24 @@ export function rollEncounter(state: State, config: Config): boolean {
 
 /**
  * Get the minimum wild level for a pokemon based on its evolution stage.
- * Stage 0 → 1 (no restriction), stage N → evolves_at level of previous stage.
+ * Stage 0 → 1 (no restriction).
+ * Stage N → evolves_at of the previous stage entry in the line.
+ * Cross-gen evolutions (line is incomplete or loops back to self) → falls back to 1.
  */
-function getMinWildLevel(name: string): number {
+export function getMinWildLevel(name: string): number {
   const db = getPokemonDB();
   const pData = db.pokemon[name];
   if (!pData || pData.stage === 0) return 1;
+
   const prevId = pData.line[pData.stage - 1];
+  // Guard: cross-gen evolutions where line doesn't include pre-evos from prior gen
+  if (!prevId || prevId === name) return 1;
+
   const prevData = db.pokemon[prevId];
-  return prevData?.evolves_at ?? 1;
+  // Guard: prevData loops back to same or higher stage (malformed line)
+  if (!prevData || prevData.stage >= pData.stage) return 1;
+
+  return prevData.evolves_at ?? 1;
 }
 
 /**

--- a/test/encounter.test.ts
+++ b/test/encounter.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { makeState as _makeState, makeConfig as _makeConfig } from './helpers.js';
-import { rollEncounter, selectWildPokemon, processEncounter } from '../src/core/encounter.js';
+import { rollEncounter, selectWildPokemon, processEncounter, getMinWildLevel } from '../src/core/encounter.js';
 import { formatBattleMessage } from '../src/core/battle.js';
 import { initLocale } from '../src/i18n/index.js';
 
@@ -64,14 +64,16 @@ describe('encounter', () => {
       }
     });
 
-    it('level is within region level_range', () => {
+    it('level is at least regionMin and at least evoMin', () => {
       const config = makeConfig({ current_region: '2' });
       const region = regionsDB.regions['2'];
       for (let i = 0; i < 50; i++) {
         const wild = selectWildPokemon(config);
         assert.ok(wild !== null);
         assert.ok(wild!.level >= region.level_range[0]);
-        assert.ok(wild!.level <= region.level_range[1]);
+        // evoMin may exceed regionMax for high-stage pokemon — that's intentional
+        const evoMin = getMinWildLevel(wild!.name);
+        assert.ok(wild!.level >= evoMin, `${wild!.name} level ${wild!.level} < evoMin ${evoMin}`);
       }
     });
 
@@ -88,6 +90,43 @@ describe('encounter', () => {
       const common = counts['common'] ?? 0;
       const total = Object.values(counts).reduce((a, b) => a + b, 0);
       assert.ok(common / total > 0.3, `Common ratio too low: ${common}/${total}`);
+    });
+  });
+
+  describe('getMinWildLevel', () => {
+    it('stage 0 returns 1', () => {
+      // 396 찌르꼬 is stage 0
+      assert.equal(getMinWildLevel('396'), 1);
+    });
+
+    it('stage 1 returns pre-evo evolves_at', () => {
+      // 397 찌르버드: stage 1, prev is 396 (evolves_at: 14)
+      assert.equal(getMinWildLevel('397'), 14);
+    });
+
+    it('stage 2 returns stage-1 evolves_at', () => {
+      // 398 찌르호크: stage 2, prev is 397 (evolves_at: 34)
+      assert.equal(getMinWildLevel('398'), 34);
+    });
+
+    it('cross-gen evolution falls back to 1', () => {
+      // 407 Roserade: stage 2, line=["406","407"] — line[1] is itself
+      assert.equal(getMinWildLevel('407'), 1);
+      // 424 Ambipom: stage 1, line=["424"] — line[0] is itself
+      assert.equal(getMinWildLevel('424'), 1);
+    });
+
+    it('stage-1 pokemon never spawns below pre-evo evolves_at', () => {
+      const config = makeConfig({ current_region: '1' });
+      for (let i = 0; i < 200; i++) {
+        const wild = selectWildPokemon(config);
+        if (!wild) continue;
+        const evoMin = getMinWildLevel(wild.name);
+        assert.ok(
+          wild.level >= evoMin,
+          `${wild.name} appeared at Lv.${wild.level} but evoMin is ${evoMin}`,
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## 문제

지역 레벨 범위에서만 레벨을 랜덤으로 뽑아서, 진화체 포켓몬이 말도 안 되는 낮은 레벨로 야생 출현함.
예) Lv.1 찌르버드, Lv.1 찌르호크

## 수정

`encounter.ts`에 `getMinWildLevel()` 헬퍼 추가.
- `stage === 0` → 제한 없음 (지역 범위 그대로)
- `stage > 0` → 이전 단계의 `evolves_at` 레벨을 최소값으로 적용

```
찌르꼬 (stage 0, evolves_at: 14) → 최소 레벨 제한 없음
찌르버드 (stage 1) → min(region_min, 14)
찌르호크 (stage 2) → min(region_min, 34)
```

지역 레벨 범위 상한보다 최소값이 높으면 최소값에 고정 (레벨 범위 역전 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)