### PR TITLE
fix: 코드 리뷰 CRITICAL/HIGH/MEDIUM 이슈 수정

### DIFF
--- a/src/core/encounter.ts
+++ b/src/core/encounter.ts
@@ -108,6 +108,14 @@ export function selectWildPokemon(state: State, config: Config): { name: string;
   // Get active events
   const events = getActiveEvents(state);
 
+  // Legendary pool substitution (2% chance, checked before streak guarantee)
+  const [minLv, maxLv] = region.level_range;
+  if (state.legendary_pool.length > 0 && Math.random() < 0.02) {
+    const legendaryPick = state.legendary_pool[Math.floor(Math.random() * state.legendary_pool.length)];
+    const legendaryLevel = Math.max(50, maxLv + 5);
+    return { name: legendaryPick, level: legendaryLevel };
+  }
+
   // Streak guarantee: force rare-only pool
   if (events.streakEvents.length > 0) {
     const rarePool = pool.filter(p => p.rarity === 'rare' || p.rarity === 'legendary' || p.rarity === 'mythical');
@@ -140,15 +148,6 @@ export function selectWildPokemon(state: State, config: Config): { name: string;
     }
 
     weighted.push({ name: p.name, weight: w });
-  }
-
-  // Legendary pool substitution (2% chance)
-  const [minLv, maxLv] = region.level_range;
-  if (state.legendary_pool.length > 0 && Math.random() < 0.02) {
-    const legendaryPick = state.legendary_pool[Math.floor(Math.random() * state.legendary_pool.length)];
-    // Legendary encounters are high-level (region max + 5, minimum 50)
-    const legendaryLevel = Math.max(50, maxLv + 5);
-    return { name: legendaryPick, level: legendaryLevel };
   }
 
   // Normalize and select

--- a/src/core/notifications.ts
+++ b/src/core/notifications.ts
@@ -108,9 +108,16 @@ export function dismissAll(state: State): void {
 
 /**
  * Update state.notifications with freshly checked notifications.
+ * Also prunes dismissed_notifications to prevent unbounded growth.
  */
 export function refreshNotifications(state: State, config: Config): void {
   state.notifications = checkPendingNotifications(state, config);
+
+  // Prune: keep only dismissed IDs that match current active notifications + cap at 100
+  const activeIds = new Set(state.notifications.map(n => n.id));
+  if (state.dismissed_notifications.length > 100) {
+    state.dismissed_notifications = state.dismissed_notifications.filter(id => activeIds.has(id));
+  }
 }
 
 /**

--- a/src/core/pokedex-rewards.ts
+++ b/src/core/pokedex-rewards.ts
@@ -208,7 +208,9 @@ export function getTypeMasterProgress(state: State): Array<{ type: string; caugh
   // Sort: mastered first, then by completion percentage descending
   progress.sort((a, b) => {
     if (a.mastered !== b.mastered) return a.mastered ? -1 : 1;
-    return (b.caught / b.total) - (a.caught / a.total);
+    const aPct = a.total > 0 ? a.caught / a.total : 0;
+    const bPct = b.total > 0 ? b.caught / b.total : 0;
+    return bPct - aPct;
   });
 
   return progress;

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from 'fs';
-import { execSync } from 'child_process';
 import { readState, writeState, writeSession } from '../core/state.js';
 import { readConfig, writeConfig } from '../core/config.js';
 import { checkAchievements, formatAchievementMessage } from '../core/achievements.js';
@@ -131,21 +130,9 @@ function main(): void {
       messages.push(`🎪 ${label}`);
     }
 
-    // GitHub star prompt (after 5+ sessions, not dismissed)
+    // GitHub star prompt (after 5+ sessions, not dismissed, no blocking network call)
     if (state.session_count >= 5 && !state.star_dismissed) {
-      try {
-        const starred = execSync(
-          'gh api user/starred/ThunderConch/tkm --silent 2>/dev/null && echo "yes" || echo "no"',
-          { encoding: 'utf-8', timeout: 3000 },
-        ).trim();
-        if (starred === 'yes') {
-          state.star_dismissed = true; // already starred, don't ask again
-        } else {
-          messages.push(t('star.prompt'));
-        }
-      } catch {
-        // gh not available or network error — skip silently
-      }
+      messages.push(t('star.prompt'));
     }
 
     writeState(state);

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -179,7 +179,7 @@ async function main(): Promise<void> {
         unlockedAchievements: Object.keys(state.achievements).filter(k => state.achievements[k]),
         items: state.items ?? {},
       };
-      const evolution = checkEvolution(pokemonName, evoContext);
+      const evolution = checkEvolution(pokemonName, evoContext, state);
       if (evolution) {
         applyEvolution(state, config, evolution, newXp);
         messages.push(t('hook.evolution', { pokemon: getPokemonName(pokemonName), newPokemon: getPokemonName(evolution.newPokemon) }));
@@ -225,8 +225,8 @@ async function main(): Promise<void> {
         recordXp(state, battleResult.xpReward);
         if (battleResult.caught) recordCatch(state);
 
-        // Auto-add caught pokemon to party if < 6
-        if (battleResult.caught && config.party.length < 6) {
+        // Auto-add caught pokemon to party if below max
+        if (battleResult.caught && config.party.length < config.max_party_size) {
           if (!config.party.includes(battleResult.defender)) {
             config.party.push(battleResult.defender);
             messages.push(t('hook.party_join', { pokemon: getPokemonName(battleResult.defender) }));


### PR DESCRIPTION
## Summary
- **[CRITICAL]** `checkEvolution()`에 `state` 파라미터 미전달 → 분기 진화 감지 불가 수정
- **[HIGH]** 파티 자동추가 `< 6` 하드코딩 → `config.max_party_size` 사용
- **[HIGH]** `dismissed_notifications` 무한 증가 → 100개 초과 시 pruning
- **[HIGH]** `session-start` GitHub star `execSync` 블로킹 제거
- **[MEDIUM]** 전설 풀 체크를 스트릭 보장 앞으로 이동 (7일 스트릭 시 전설 출현 가능)
- **[LOW]** `getTypeMasterProgress` 정렬 division-by-zero 가드

## Test plan
- [x] 439 tests pass, 0 fail
- [ ] 분기 진화 포켓몬 (Kirlia/Snorunt/Burmy) 레벨업 시 evolution_ready 플래그 설정 확인
- [ ] max_party_size 확장 후 7번째 포켓몬 자동 합류 확인
- [ ] 전설 풀 + 7일 스트릭 동시 활성 시 전설 출현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)