### PR TITLE
feat: add shiny (이로치) pokemon system

### DIFF
--- a/docs/pipeline/code-level-design.md
+++ b/docs/pipeline/code-level-design.md
@@ -1,0 +1,491 @@
+# Shiny (이로치) Feature - Code-level Design
+
+---
+
+## Phase 1 (MVP)
+
+---
+
+### 1. `src/core/types.ts`
+
+**변경 유형**: 수정
+
+**변경할 타입 시그니처**:
+
+```typescript
+// PokemonState — shiny 필드 추가
+export interface PokemonState {
+  // ... 기존 필드 유지 ...
+  shiny?: boolean;  // optional: 기존 데이터 하위 호환. true = 이로치 개체
+}
+
+// PokedexEntry — shiny_caught 필드 추가
+export interface PokedexEntry {
+  // ... 기존 필드 유지 ...
+  shiny_caught?: boolean;  // optional: 해당 종의 이로치를 한번이라도 잡았는가
+}
+
+// State — shiny 카운터 3개 추가
+export interface State {
+  // ... 기존 필드 유지 ...
+  shiny_encounter_count: number;
+  shiny_catch_count: number;
+  shiny_escaped_count: number;
+}
+
+// BattleResult — shiny 필드 추가
+export interface BattleResult {
+  // ... 기존 필드 유지 ...
+  shiny: boolean;
+}
+```
+
+```typescript
+// WildPokemon — types.ts에 정의, selectWildPokemon 반환 타입과 resolveBattle 파라미터 양쪽에서 공유
+export interface WildPokemon {
+  name: string;
+  level: number;
+  shiny: boolean;
+}
+```
+
+**인터페이스 포인트**: PokemonState.shiny와 PokedexEntry.shiny_caught는 optional로 선언하여 기존 JSON 역직렬화 하위 호환을 보장한다. State의 카운터 3개는 required지만 DEFAULT_STATE 병합으로 0이 채워진다. BattleResult.shiny는 required -- 새로 생성되는 결과에는 항상 포함되지만, 기존 last_battle 읽기 시 `?? false` 보정이 필요하다. WildPokemon은 types.ts에 정의하여 encounter.ts와 battle.ts에서 공유한다.
+
+---
+
+### 2. `src/core/state.ts`
+
+**변경 유형**: 수정
+
+**변경 포인트 (3곳)**:
+
+(a) `DEFAULT_STATE` 객체에 카운터 추가:
+```typescript
+const DEFAULT_STATE: State = {
+  // ... 기존 필드 ...
+  shiny_encounter_count: 0,
+  shiny_catch_count: 0,
+  shiny_escaped_count: 0,
+};
+```
+
+(b) `readState` 함수의 per-pokemon migration 루프에 shiny 보정 추가:
+```typescript
+// 기존 friendship/ev 보정 루프 내부에 추가
+for (const entry of Object.values(result.pokemon)) {
+  // ... 기존 friendship, ev 보정 ...
+  if (entry.shiny === undefined) (entry as any).shiny = false;
+}
+```
+
+shiny 카운터 3개는 `DEFAULT_STATE`에 0으로 추가하는 것만으로 충분하다. 기존 `readState`가 `{ ...DEFAULT_STATE, ...parsed }` spread 패턴을 사용하므로 누락된 카운터는 자동으로 0이 채워진다. 별도 `?? 0` 보정은 불필요 (기존 encounter_count, catch_count 등과 동일 패턴).
+
+**인터페이스 포인트**: `readState` 반환값에 shiny 카운터가 항상 존재하게 되므로 소비자는 `??` 없이 사용 가능.
+
+---
+
+### 3. `src/core/encounter.ts`
+
+**변경 유형**: 수정
+
+**변경할 함수 시그니처**:
+
+```typescript
+// 신규 함수 — shiny 판정 (export for testability)
+export const SHINY_RATE = 1 / 512;
+
+export function rollShiny(): boolean;
+// pseudo-code: return Math.random() < SHINY_RATE;
+```
+
+```typescript
+// 반환 타입 변경: { name, level } → { name, level, shiny }
+export function selectWildPokemon(
+  state: State,
+  config: Config,
+): { name: string; level: number; shiny: boolean } | null;
+```
+
+**변경 포인트**:
+
+(a) `selectWildPokemon` 내부 — 기존 모든 return 지점에서 반환 객체에 `shiny: rollShiny()` 추가. rollShiny() 호출은 종/레벨 결정 이후 반환 직전 한 번만 수행.
+
+(b) `processEncounter` — resolveBattle 호출을 positional에서 wild 구조체 전달로 변경:
+```typescript
+// 변경 전: resolveBattle(state, config, wild.name, wild.level)
+// 변경 후: resolveBattle(state, config, wild)
+```
+
+**인터페이스 포인트**: processEncounter는 resolveBattle의 호출자이므로 battle.ts 변경과 동시에 반영해야 한다.
+
+---
+
+### 4. `src/core/battle.ts`
+
+**변경 유형**: 수정
+
+**변경할 함수 시그니처**:
+
+```typescript
+// WildPokemon은 types.ts에 정의 (Section 1 참조)
+// resolveBattle 시그니처 변경
+export function resolveBattle(
+  state: State,
+  config: Config,
+  wild: WildPokemon,        // 기존: wildName: string, wildLevel: number
+): BattleResult | null;
+
+// formatBattleMessage는 시그니처 불변, 내부 로직 변경
+export function formatBattleMessage(result: BattleResult): string;
+```
+
+**변경 포인트**:
+
+(a) `resolveBattle` 내부:
+- `wildName` → `wild.name`, `wildLevel` → `wild.level`로 참조 변경
+- 포획 성공 시 PokemonState 생성 블록에 `shiny: wild.shiny` 추가
+- 반환 객체에 `shiny: wild.shiny` 추가
+
+(b) `formatBattleMessage` 내부:
+- 구버전 BattleResult 보정: `const isShiny = result.shiny ?? false;`
+- shiny인 경우 defenderName에 `getPokemonName(result.defender, undefined, isShiny)` 사용
+- shiny이면 배틀 메시지 앞에 `t('battle.shiny_appeared')` 접두
+- 포획 성공 + shiny: `t('battle.shiny_catch')` 추가
+- 패배/도주 + shiny: `t('battle.shiny_escaped')` 추가
+
+---
+
+### 5. `src/core/pokedex.ts`
+
+**변경 유형**: 수정
+
+**추가할 함수**:
+
+```typescript
+/**
+ * Mark a pokemon species as shiny-caught in the pokedex.
+ */
+export function markShinyCaught(state: State, name: string): void;
+// pseudo-code: state.pokedex[name]가 존재하면 shiny_caught = true
+//              존재하지 않으면 markCaught 호출 후 shiny_caught = true
+```
+
+**PokedexCompletion 확장 (Phase 3 대비)**:
+
+```typescript
+export interface PokedexCompletion {
+  // ... 기존 필드 ...
+  shinyCaught: number;      // shiny_caught === true인 종 수
+}
+```
+
+**인터페이스 포인트**: `markShinyCaught`는 hooks/stop.ts에서 호출된다. 기존 `markCaught`와 동일 패턴.
+
+---
+
+### 6. `src/core/stats.ts`
+
+**변경 유형**: 수정
+
+**추가할 함수 (3개)**:
+
+```typescript
+export function recordShinyEncounter(state: State): void;
+// pseudo-code: state.shiny_encounter_count++
+
+export function recordShinyCatch(state: State): void;
+// pseudo-code: state.shiny_catch_count++
+
+export function recordShinyEscaped(state: State): void;
+// pseudo-code: state.shiny_escaped_count++
+```
+
+**패턴 차이 참고**: 기존 `recordEncounter`/`recordBattle`/`recordCatch`는 `state.stats.weekly_*`와 `state.stats.total_*`를 모두 증감한다. `recordShiny*` 함수는 `State` 최상위 카운터(`shiny_encounter_count` 등)만 증감하며, weekly/total 분리 추적은 하지 않는다. 이는 shiny 통계에 weekly 리셋이 불필요하다는 설계 판단에 따른 것이다.
+
+**인터페이스 포인트**: hooks/stop.ts에서 battleResult.shiny 기반으로 호출. 호출 패턴은 기존 record* 함수와 동일.
+
+---
+
+### 7. `src/core/pokemon-data.ts`
+
+**변경 유형**: 수정
+
+**변경할 함수 시그니처**:
+
+```typescript
+// 기존: export function getPokemonName(id: string | number, gen?: string): string;
+// 변경:
+export function getPokemonName(
+  id: string | number,
+  gen?: string,
+  shiny?: boolean,    // NEW: true이면 "★" 접두사 추가
+): string;
+```
+
+**pseudo-code**:
+```
+name = 기존 로직으로 이름 조회
+if shiny: return "★" + name
+return name
+```
+
+**인터페이스 포인트**: 기존 호출 site는 shiny 파라미터 생략 시 undefined → 기존 동작. Phase 1에서는 battle.ts의 formatBattleMessage와 status-line.ts에서만 shiny=true 전달.
+
+---
+
+### 8. `src/hooks/stop.ts`
+
+**변경 유형**: 수정
+
+**추가 import**:
+
+```typescript
+import { markShinyCaught } from '../core/pokedex.js';
+import { recordShinyEncounter, recordShinyCatch, recordShinyEscaped } from '../core/stats.js';
+```
+
+**변경 포인트** — 기존 recordEncounter/recordBattle/recordCatch 호출 이후에 추가:
+
+```typescript
+if (battleResult.shiny) {
+  recordShinyEncounter(state);
+  if (battleResult.caught) {
+    recordShinyCatch(state);
+    markShinyCaught(state, battleResult.defender);
+  } else {
+    recordShinyEscaped(state);
+  }
+}
+```
+
+**인터페이스 포인트**: 기존 record 호출 패턴 바로 아래에 shiny 분기 추가.
+
+---
+
+### 9. `src/status-line.ts`
+
+**변경 유형**: 수정
+
+**변경 포인트**:
+
+파티 이름 표시 — displayName 생성 시:
+```typescript
+// 변경 전: const displayName = getPokemonName(p.name);
+// 변경 후:
+const isShiny = state.pokemon[p.name]?.shiny ?? false;
+const displayName = getPokemonName(p.name, undefined, isShiny);
+```
+
+last_battle의 shiny 보정은 formatBattleMessage 내부에서 `?? false` 처리하므로 status-line.ts 자체 추가 변경 불필요.
+
+---
+
+### 10. `src/cli/tokenmon.ts`
+
+**변경 유형**: 수정
+
+**변경 포인트**:
+
+(a) `cmdStatus` — 파티 표시에서 shiny 구분:
+```typescript
+const isShiny = state.pokemon[pokemon]?.shiny ?? false;
+const displayName = getPokemonName(pokemon, undefined, isShiny);
+```
+
+(b) `cmdPokedex` — 상세 뷰에서 shiny_caught 표시:
+```typescript
+const shinyCaught = pdex?.shiny_caught ?? false;
+if (shinyCaught) {
+  console.log(`  ${t('cli.pokedex.shiny_caught')}`);
+}
+```
+
+(c) `cmdStatus` — shiny 통계 (shiny_catch_count > 0인 경우만):
+```typescript
+if (state.shiny_catch_count > 0) {
+  console.log(t('cli.status.stat_shiny_catches', { count: state.shiny_catch_count }));
+}
+```
+
+---
+
+### 11. `src/i18n/ko.json`
+
+**추가할 키**:
+
+```json
+{
+  "battle.shiny_appeared": "✦ 이로치 {pokemon:이/가} 나타났다!",
+  "battle.shiny_catch": "\n★ 이로치 포획 성공!",
+  "battle.shiny_escaped": "\n이로치 {pokemon:이/가} 도망쳤다...",
+  "cli.pokedex.shiny_caught": "  ★이로치 포획 완료",
+  "cli.status.stat_shiny_catches": "  ★이로치 포획: {count}종"
+}
+```
+
+---
+
+### 12. `src/i18n/en.json`
+
+**추가할 키**:
+
+```json
+{
+  "battle.shiny_appeared": "✦ A shiny {pokemon} appeared!",
+  "battle.shiny_catch": "\n★ Shiny caught!",
+  "battle.shiny_escaped": "\nThe shiny {pokemon} got away...",
+  "cli.pokedex.shiny_caught": "  ★Shiny caught",
+  "cli.status.stat_shiny_catches": "  ★Shiny catches: {count}"
+}
+```
+
+---
+
+### 13. `test/helpers.ts`
+
+**변경 유형**: 수정
+
+`makeState` factory에 shiny 카운터 3개 추가:
+
+```typescript
+export function makeState(overrides: Partial<State> = {}): State {
+  return {
+    // ... 기존 필드 ...
+    shiny_encounter_count: 0,
+    shiny_catch_count: 0,
+    shiny_escaped_count: 0,
+    ...overrides,
+  };
+}
+```
+
+---
+
+## Phase 2 (스프라이트)
+
+---
+
+### 14. `src/sprites/shiny.ts` (신규)
+
+**변경 유형**: 추가
+
+**함수 시그니처**:
+
+```typescript
+export function rgbToHsl(r: number, g: number, b: number): [number, number, number];
+
+export function hslToRgb(h: number, s: number, l: number): [number, number, number];
+
+export function ansi256ToRgb(code: number): [number, number, number];
+
+export function rgbToAnsi256(r: number, g: number, b: number): number;
+
+export const SHINY_HUE_SHIFT = 180;
+
+/**
+ * Shift hue of all ANSI 256 color codes in a text string.
+ * Parses \x1b[38;5;{N}m and \x1b[48;5;{N}m patterns.
+ */
+export function shiftAnsiHue(text: string, degrees?: number): string;
+
+/**
+ * Hue-shift all pixels in a PNG buffer. Returns a new PNG buffer.
+ * Prepared for future kitty/iTerm2/sixel integration.
+ */
+export function hueShiftPng(pngBuffer: Buffer, degrees?: number): Buffer;
+```
+
+**Dependencies**: `pngjs` (기존 sprites/convert.ts에서 이미 사용 중)
+
+---
+
+### 15. `src/status-line.ts` (Phase 2 추가 변경)
+
+**변경 유형**: 수정
+
+**변경할 함수 시그니처**:
+
+```typescript
+function loadSprite(pokemonId: number, isShiny?: boolean): string[];
+```
+
+**변경 포인트**:
+
+```typescript
+function loadSprite(pokemonId: number, isShiny: boolean = false): string[] {
+  // 기존 파일 로드 로직 유지
+  const lines = /* 기존 .txt 파일 읽기 */;
+  if (isShiny && lines.length > 0) {
+    return lines.map(line => shiftAnsiHue(line));
+  }
+  return lines;
+}
+```
+
+**호출부 변경**:
+
+```typescript
+// 변경 전: spriteEntries.push(loadSprite(p.pokemonId));
+// 변경 후:
+const isShiny = state.pokemon[p.name]?.shiny ?? false;
+spriteEntries.push(loadSprite(p.pokemonId, isShiny));
+```
+
+**추가 import**:
+
+```typescript
+import { shiftAnsiHue } from './sprites/shiny.js';
+```
+
+---
+
+## 테스트 전략
+
+### Phase 1 테스트
+
+| 테스트 파일 | 대상 | 핵심 시나리오 |
+|------------|------|-------------|
+| `test/encounter.test.ts` (수정) | `rollShiny`, `selectWildPokemon` | rollShiny boolean 반환, selectWildPokemon에 shiny 필드 존재 |
+| `test/battle.test.ts` (수정) | `resolveBattle`, `formatBattleMessage` | **기존 positional 호출 10+건을 전부 wild 구조체로 변경 필수**. BattleResult.shiny 일치, shiny=true일 때 "✦" 포함, shiny=undefined 시 crash 없음 |
+| `test/pokedex.test.ts` (수정) | `markShinyCaught` | 기존 entry에 shiny_caught=true, 존재하지 않는 종에 entry 생성, 멱등성 |
+| `test/stats.test.ts` (수정) | `recordShiny*` | 각 함수 카운터 1 증가, 기존 record와 독립 |
+| `test/state.test.ts` (수정) | `readState` shiny 보정 | 카운터 누락 시 0, PokemonState.shiny 누락 시 false |
+| `test/pokemon-data.test.ts` (수정) | `getPokemonName` shiny | shiny=true일 때 "★" 접두, false/undefined일 때 기존 동작 |
+
+### Phase 2 테스트
+
+| 테스트 파일 | 대상 | 핵심 시나리오 |
+|------------|------|-------------|
+| `test/shiny-sprite.test.ts` (신규) | `sprites/shiny.ts` | rgbToHsl/hslToRgb round-trip, shiftAnsiHue 구조 유지, hueShiftPng 360도=원본, 0도=불변 |
+
+### 통합 테스트
+
+기존 `processEncounter` 통합 테스트에 shiny 경로 추가 (Math.random stub으로 shiny=true 강제).
+
+**참고**: `test/encounter.test.ts`의 `formatBattleMessage` 테스트에서 BattleResult literal을 직접 구성하는 곳에도 `shiny: false` (또는 `shiny: true`) 필드 추가 필수 — BattleResult.shiny가 required로 변경되므로 누락 시 컴파일 오류 발생.
+
+---
+
+## 변경 순서
+
+```
+Phase 1:
+  1. types.ts           ← 모든 타입 정의 (선행 필수)
+  2. test/helpers.ts    ← makeState factory 동기화
+  3. state.ts           ← DEFAULT_STATE + readState 보정
+  4. encounter.ts       ← rollShiny + selectWildPokemon 반환값
+  5. battle.ts          ← resolveBattle(wild 구조체) + formatBattleMessage
+     (4, 5는 processEncounter 호출 경로에서 동시 변경 필요)
+  6. pokedex.ts         ← markShinyCaught
+  7. stats.ts           ← recordShiny* 3개
+  8. pokemon-data.ts    ← getPokemonName shiny 파라미터
+  9. i18n/ko.json       ← shiny 문자열
+  10. i18n/en.json      ← shiny 문자열
+  11. hooks/stop.ts     ← shiny record 호출 + markShinyCaught
+  12. status-line.ts    ← displayName shiny 마크 (Phase 1)
+  13. cli/tokenmon.ts   ← status/pokedex shiny 표시
+
+Phase 2:
+  14. sprites/shiny.ts  ← 신규: hueShiftPng + shiftAnsiHue
+  15. status-line.ts    ← loadSprite shiny 분기
+```

--- a/docs/pipeline/high-level-design.md
+++ b/docs/pipeline/high-level-design.md
@@ -1,0 +1,382 @@
+# Shiny Pokemon (이로치) Feature - High-level Design (Rev.2)
+
+## 1. Overview
+
+### 기능 요약
+야생 포켓몬 조우 시 1/512 확률로 이로치(shiny) 개체가 출현하는 시스템. 이로치 포켓몬은 텍스트/스프라이트 양쪽에서 시각적으로 구분되며, 도감에서 별도 추적된다.
+
+### 범위
+
+| Phase | 내용 | 마이그레이션 |
+|-------|------|-------------|
+| **Phase 1 (MVP)** | 확률 판정, 상태 플래그, 텍스트 이펙트 (★ 마크, "✦ 이로치 발견!"), i18n, 도감 추적 | 불필요 (DEFAULT_STATE 병합 패턴) |
+| **Phase 2 (스프라이트)** | braille ANSI 코드 치환 + hueShiftPng 공통 함수 준비 (kitty/iTerm2/sixel은 함수만 준비, status-line 미통합) | 없음 |
+| **Phase 3 대비** | 카운터 선행 배치만. 업적/고유 색상/효과음은 나중에 추가 | 없음 |
+
+---
+
+## 2. Data Model Changes
+
+### 2.1 PokemonState 확장
+
+현재 PokemonState는 개체 단위 상태(xp, level, friendship, ev)를 관리한다. 여기에 shiny boolean을 추가한다.
+
+- **추가 개념**: 개체가 이로치인지 여부를 나타내는 플래그
+- **기본값**: false (기존 데이터는 DEFAULT_STATE 병합 패턴으로 자동 보정)
+- **불변 속성**: 한번 판정되면 변경 불가 (조우 시점에 확정)
+
+### 2.2 PokedexEntry 확장
+
+현재 PokedexEntry는 종(species) 단위로 seen/caught를 추적한다. 이로치 포획 여부를 별도 필드로 추가한다.
+
+- **추가 개념**: 해당 종의 이로치를 포획한 적 있는지 여부
+- **기본값**: false
+- **의미**: "이 종의 이로치를 한번이라도 잡았는가" (종 단위 도감 완성도)
+
+### 2.3 State (최상위) 확장 - Phase 3 선행 카운터
+
+Phase 3 업적 시스템을 위해 3개 카운터를 선행 배치한다.
+
+- **shiny_encounter_count**: 이로치 조우 횟수 (배틀 결과 무관)
+- **shiny_catch_count**: 이로치 포획 성공 횟수
+- **shiny_escaped_count**: 이로치를 만났으나 포획 실패 횟수
+
+이 카운터들은 Phase 1에서 증감 로직이 함께 구현되지만, Phase 3 전까지 소비하는 곳은 없다. DEFAULT_STATE에 0으로 선언하면 마이그레이션 없이 동작한다.
+
+### 2.4 파이프라인 전파 구조체 확장
+
+파이프라인 전체에 shiny 정보를 전파하기 위해 두 지점에 shiny boolean을 추가한다.
+
+- **selectWildPokemon 반환값**: 현재 inline `{ name, level }` 형태에 shiny를 추가하여 `{ name, level, shiny }`가 된다. (참고: types.ts에 EncounterResult interface가 정의되어 있으나 현재 미사용 상태이며, 이번 변경과 무관하다.)
+- **BattleResult**: resolveBattle 반환값에 shiny를 추가한다. formatBattleMessage에서 이로치 텍스트 이펙트 생성에 사용한다.
+
+### 2.5 마이그레이션 전략
+
+**마이그레이션 불필요**. 기존 패턴 (`{ ...DEFAULT_STATE, ...parsed }`)이 누락 필드를 기본값으로 채운다. PokemonState 개체별 shiny 필드도 읽기 시점에 `?? false` 보정한다 (기존 friendship/ev 마이그레이션과 동일 패턴).
+
+**BattleResult 하위 호환**: state.last_battle에 저장된 구버전 BattleResult에는 shiny 필드가 없다. formatBattleMessage 등에서 result.shiny를 참조할 때 `?? false`로 보정해야 한다. 이는 status-line.ts가 last_battle을 읽어 formatBattleMessage를 호출하는 경로에서 발생한다.
+
+---
+
+## 3. Core Flow
+
+### 3.1 전체 흐름 다이어그램
+
+```
+ hooks/stop.ts
+     |
+     v
+ encounter.ts: selectWildPokemon()
+     |
+     +--- 종/레벨 결정 (기존 로직)
+     |
+     +--- ★ NEW: rollShiny()  <-- 1/512 독립 확률 판정
+     |
+     v
+ 반환: { name, level, shiny }
+     |
+     v
+ encounter.ts: processEncounter()
+     |
+     +--- encounter_count++ (기존)
+     |
+     +--- ★ NEW: wild 구조체를 그대로 resolveBattle에 전달
+     |
+     v
+ battle.ts: resolveBattle(state, config, wild)   <-- wild = { name, level, shiny }
+     |
+     +--- markSeen() (기존)
+     |
+     +--- 배틀 로직 (기존, shiny는 전투력에 영향 없음)
+     |
+     +--- 포획 성공 시:
+     |      +--- markCaught() (기존)
+     |      +--- ★ NEW: PokemonState에 shiny=true 기록
+     |
+     v
+ 반환: BattleResult { ...기존, shiny }
+     |
+     v
+ hooks/stop.ts (기존 stats 기록 패턴에 shiny 분기 추가)
+     |
+     +--- recordEncounter() (기존)
+     +--- recordBattle() (기존)
+     +--- ★ NEW: shiny이면 recordShinyEncounter()
+     +--- 포획 성공 시:
+     |      +--- recordCatch() (기존)
+     |      +--- ★ NEW: shiny이면 recordShinyCatch()
+     |      +--- ★ NEW: shiny이면 markShinyCaught()
+     +--- 패배/도주 시:
+     |      +--- ★ NEW: shiny이면 recordShinyEscaped()
+     |
+     v
+ battle.ts: formatBattleMessage(result)
+     |
+     +--- ★ NEW: shiny이면 이름에 ★ 접두, "✦ 이로치 발견!" 추가
+     |        (result.shiny ?? false로 구버전 BattleResult 보정)
+     |
+     v
+ hooks/stop.ts: messages에 합류 -> system_message 출력
+```
+
+### 3.2 판정 시점과 이유
+
+**조우(encounter) 시점**에 판정한다.
+
+- 선택지 A: 조우 시 판정 (채택)
+- 선택지 B: 배틀 승리 후 판정
+- 선택지 C: 포획 확정 후 판정
+
+**A를 선택한 이유**: 원작 게임과 동일한 시맨틱. "이로치가 나타났다!" 메시지를 배틀 전에 보여줄 수 있다. 패배/도주 시에도 "이로치를 놓쳤다" 경험이 가능하여 게임플레이 긴장감을 높인다.
+
+### 3.3 selectWildPokemon 변경
+
+현재 반환값 `{ name, level }`에 shiny를 추가하여 `{ name, level, shiny }`가 된다. 이로치 판정은 종/레벨 결정과 완전히 독립적이다 (1/512 단순 확률). 이 함수는 encounter.ts의 processEncounter 내부에서만 호출되므로 변경 영향 범위가 제한적이다.
+
+### 3.4 resolveBattle 호출 패턴 변경
+
+현재 resolveBattle은 positional 파라미터 4개 (state, config, wildName, wildLevel)를 받는다. processEncounter에서는 selectWildPokemon 결과의 name, level을 분해하여 전달한다.
+
+shiny를 5번째 positional boolean으로 추가하는 대신, **selectWildPokemon이 반환하는 구조체 자체를 wild 파라미터 하나로 전달하는 패턴을 채택한다**. 이유:
+
+- processEncounter가 이미 구조체를 받고 있어 자연스러운 전달 경로
+- 향후 wild에 추가 속성이 필요할 때 positional 확장 없이 대응 가능
+- wildName/wildLevel 분해가 불필요해져 호출부가 단순해짐
+
+### 3.5 shiny 카운터 증감 책임
+
+**기존 패턴을 따른다.** 현재 stats.ts에 recordEncounter, recordBattle, recordCatch가 정의되어 있고, 이들은 모두 hooks/stop.ts에서 battleResult를 기반으로 호출된다. resolveBattle 내부에서는 직접 카운터 증감만 수행하고, weekly/total 통계는 stats.ts의 record 함수가 담당한다.
+
+shiny 카운터도 동일 패턴으로 구현한다:
+
+- **stats.ts**: recordShinyEncounter, recordShinyCatch, recordShinyEscaped 함수 추가
+- **hooks/stop.ts**: battleResult.shiny 확인 후 해당 함수 호출
+- **resolveBattle 내부**: shiny 카운터 증감을 수행하지 않음 (기존 패턴과 일관성 유지)
+
+---
+
+## 4. Sprite Hue-shift Architecture (Phase 2)
+
+### 4.1 status-line의 현재 스프라이트 사용 현황
+
+status-line.ts의 loadSprite는 braille (.txt)과 terminal (.txt) 파일만 로드한다. kitty/iTerm2/sixel 렌더러에 대한 호출 경로(generateKitty, generateIterm2, generateSixel)는 status-line.ts에 존재하지 않으며, 현재 미통합 상태이다.
+
+```
+sprites/braille/{id}.txt  -- loadSprite가 우선 탐색
+sprites/terminal/{id}.txt -- braille 없을 때 fallback
+```
+
+### 4.2 Phase 2 범위: braille/terminal만 대상
+
+Phase 2에서 status-line에 실제 통합하는 범위는 **braille와 terminal 텍스트 스프라이트**로 한정한다.
+
+```
+                        ┌───────────────────────────┐
+sprites/raw/{id}.png ──>│  hueShiftPng(buffer, D)   │──> shifted PNG buffer
+                        │  (범용 유틸리티, 준비만)    │
+                        └───────────────────────────┘
+                                    |
+                        Phase 2에서는 직접 소비처 없음
+                        (kitty/iTerm2/sixel이 status-line 통합될 때 자동 적용)
+
+
+sprites/braille/{id}.txt ──> 런타임 로드 ──> ANSI escape 코드 파싱
+                                                    |
+                                                    v
+                                         색상 코드 치환 (HSL hue 회전)
+                                                    |
+                                                    v
+                                         ★ shiny 스프라이트 출력
+
+sprites/terminal/{id}.txt ──> 런타임 로드 ──> ANSI escape 코드 파싱
+                                                    |
+                                                    v
+                                         색상 코드 치환 (HSL hue 회전)
+                                                    |
+                                                    v
+                                         ★ shiny 스프라이트 출력
+```
+
+### 4.3 hueShiftPng 범용 함수 (준비만)
+
+PNG pixel 레벨에서 hue-shift를 수행하는 공통 유틸리티를 준비한다. 이 함수는 RGBA pixel 배열의 각 픽셀에 대해 RGB-to-HSL 변환 후 H 값을 회전시키고 다시 RGB로 변환하여 새 PNG buffer를 생성한다.
+
+Phase 2 시점에서 이 함수의 직접 소비처는 없다. 향후 kitty/iTerm2/sixel이 status-line에 통합될 때 자동으로 적용되는 확장 포인트로 기능한다.
+
+**hue-shift 각도**: 포켓몬별 고유 값이 아닌, 전역 고정값을 Phase 2 기본값으로 사용. Phase 3에서 종별 고유 색상 매핑으로 확장 가능.
+
+### 4.4 Braille/Terminal ANSI 코드 치환
+
+braille와 terminal 스프라이트는 빌드 타임에 사전 생성된 `.txt` 파일로, ANSI 256 escape 코드가 포함된 텍스트다. 두 포맷 모두 동일한 ANSI 코드 치환 로직을 공유한다.
+
+```
+.txt 파일 런타임 로드
+     |
+     v
+ANSI escape 코드 파싱 --> 색상 코드 치환 --> 출력
+                              |
+                 ┌────────────┘
+                 v
+       \x1b[38;5;{N}m  -->  ANSI 256 코드 N을
+                              HSL 변환 -> H 회전 -> RGB -> 새 ANSI 256 코드로 치환
+```
+
+### 4.5 Status-line 통합
+
+status-line.ts의 loadSprite 함수가 스프라이트를 로드하는 시점에서, 해당 포켓몬이 shiny인지 확인 후 ANSI 코드 치환을 적용한다.
+
+```
+loadSprite(pokemonId, isShiny)
+     |
+     +-- isShiny=false --> 기존 경로 (변경 없음)
+     |
+     +-- isShiny=true  --> .txt 로드 --> ANSI 코드 치환 --> 반환
+```
+
+---
+
+## 5. Module Impact Map
+
+### Phase 1 (MVP)
+
+| 모듈 | 변경 성격 | 상세 |
+|------|----------|------|
+| **types.ts** | 수정 | PokemonState, PokedexEntry, State, BattleResult에 shiny 관련 필드 추가 (EncounterResult는 미사용이므로 변경 불필요) |
+| **encounter.ts** | 수정 | selectWildPokemon 반환값에 shiny 추가, rollShiny 판정 함수 추가 |
+| **battle.ts** | 수정 | resolveBattle가 wild 구조체를 받도록 변경, formatBattleMessage에 이로치 텍스트 이펙트 + 구버전 BattleResult 보정 |
+| **pokedex.ts** | 수정 | markShinyCaught 함수 추가, getCompletion에 shiny 통계 선택적 추가 |
+| **state.ts** | 수정 | DEFAULT_STATE에 shiny 카운터 3개 추가, PokemonState 읽기 시 shiny 기본값 보정 |
+| **pokemon-data.ts** | 수정 | getPokemonName에 optional shiny 파라미터 추가 (★ 접두 처리) |
+| **stats.ts** | 수정 | recordShinyEncounter, recordShinyCatch, recordShinyEscaped 함수 추가 |
+| **hooks/stop.ts** | 수정 | battleResult.shiny 기반으로 shiny record 함수 호출 + markShinyCaught 호출 |
+| **status-line.ts** | 수정 | 파티 내 shiny 포켓몬 이름에 ★ 마크 표시, last_battle 읽기 시 shiny 보정 |
+| **cli/tokenmon.ts** | 수정 | 도감/상태 표시에서 shiny 포켓몬 구분 표시 |
+| **i18n/ko.json** | 수정 | 이로치 관련 i18n 문자열 추가 |
+| **i18n/en.json** | 수정 | shiny 관련 i18n 문자열 추가 |
+
+### Phase 2 (스프라이트)
+
+| 모듈 | 변경 성격 | 상세 |
+|------|----------|------|
+| **sprites/shiny.ts** (신규) | 추가 | hueShiftPng 범용 유틸리티 (준비만) + braille/terminal ANSI 코드 치환 함수 |
+| **status-line.ts** | 수정 | loadSprite에 shiny 분기 추가 (braille/terminal 대상) |
+
+### 의존 관계 영향
+
+```
+                         types.ts (Phase 1)
+                            ^
+          ┌─────────────────┼──────────────────┐
+          |                 |                  |
+     encounter.ts      battle.ts          state.ts
+       (Phase 1)       (Phase 1)          (Phase 1)
+          |                 |
+          +-- pokemon-data.ts (Phase 1: getPokemonName)
+          |
+     pokedex.ts (Phase 1)
+          |
+     stats.ts (Phase 1)
+          |
+     hooks/stop.ts (Phase 1: shiny record 함수 호출 + markShinyCaught)
+
+     sprites/shiny.ts (Phase 2, 신규)
+          ^
+          |
+     status-line.ts (Phase 2: loadSprite shiny 분기)
+```
+
+---
+
+## 6. i18n
+
+### 추가 필요한 문자열 카테고리
+
+**배틀 메시지 (battle.*)**
+- 이로치 발견 알림: "✦ 이로치 {pokemon} 발견!" / "✦ A shiny {pokemon} appeared!"
+- 이로치 포획 성공: "★ 이로치 {pokemon} 포획!" / "★ Shiny {pokemon} caught!"
+- 이로치 도주/패배: "이로치 {pokemon}이(가) 도망쳤다..." / "The shiny {pokemon} got away..."
+
+**도감/CLI (cli.*)**
+- 도감 shiny 상태 표시: "★이로치" / "★Shiny"
+- 도감 통계: "이로치 포획: {count}종" / "Shiny caught: {count}"
+
+**이름 접두사 패턴**
+- getPokemonName의 shiny 파라미터가 true일 때 "★" 접두사를 반환값에 추가. 이 접두사는 i18n 문자열이 아닌 하드코딩 유니코드 문자로 처리 (모든 언어에서 동일).
+
+### 한국어 조사 처리
+
+기존 i18n 시스템이 `{pokemon:을/를}` 패턴의 한국어 조사 처리를 지원한다. ★ 접두사가 붙어도 마지막 글자 기준 조사 판정이므로 동작에 문제가 없다.
+
+---
+
+## 7. Phase 3 Readiness
+
+### 7.1 선행 배치 데이터
+
+| 데이터 | 위치 | 용도 (Phase 3) |
+|--------|------|----------------|
+| shiny_encounter_count | State | 업적 트리거 ("이로치 10회 조우") |
+| shiny_catch_count | State | 업적 트리거 ("이로치 5종 포획") |
+| shiny_escaped_count | State | 업적 트리거 ("이로치를 3번 놓치다") |
+| shiny_caught (per species) | PokedexEntry | 도감 완성도 세분화 ("이로치 도감 완성") |
+
+### 7.2 확장 포인트
+
+**업적 시스템**: 새 trigger_type (`shiny_catch_count` 등)을 achievements.json에 추가하면 확장 가능. checkAchievements의 switch문에 case 추가 필요.
+
+**종별 고유 색상**: hueShiftPng(buffer, delta)의 delta를 외부 JSON 테이블에서 주입하면 함수 수정 없이 확장.
+
+**효과음**: playSfx('shiny') 패턴으로 호출 한 줄 추가면 완성.
+
+---
+
+## 8. Risks
+
+| ID | 위험 | 영향도 | 완화 |
+|----|------|--------|------|
+| R1 | getPokemonName 호출 site 산재 — shiny 파라미터 누락 시 ★ 마크 미표시 | 중 | Phase 1에서 battleMessage/status-line만 대상, 점진 확대 |
+| R2 | braille/terminal ANSI 256 양자화로 hue-shift 색상 구분 어려움 | 저 | hue-shift 각도를 60도 이상으로 설정 |
+| R3 | 1/512 x 15% = 세션당 ~0.03%, 장기 플레이어도 못 볼 수 있음 | 저 | 확률을 상수로 분리, 이벤트 시스템에서 부스트 확장 가능 |
+| R4 | State JSON 크기 증가 (boolean 필드 추가) | 매우 낮 | 500종 기준 ~10KB, 무시 가능 |
+| R5 | hueShiftPng 함수 준비 후 소비처 부재로 dead code 상태 | 저 | kitty/iTerm2/sixel status-line 통합 시 자동 소비. 테스트로 함수 정합성 보장 |
+| R6 | 구버전 BattleResult (last_battle)에 shiny 필드 부재 | 중 | formatBattleMessage에서 ?? false 보정. Phase 1 필수 구현 사항 |
+| R7 | 이로치 발견 시 시각 이펙트만 있고 효과음이 없는 UX gap | 저 | Phase 3에서 playSfx('shiny') 추가 예정. Phase 1은 ★ 마크와 텍스트 메시지로 충분한 피드백 제공 |
+
+---
+
+## Architecture Decision Summary
+
+| 결정 | 선택 | 핵심 이유 |
+|------|------|----------|
+| 판정 시점 | 조우 시 | 원작 시맨틱, "놓침" 경험 가능 |
+| shiny 전파 | selectWildPokemon inline 반환값 + BattleResult | 파이프라인 전체에 자연스러운 전파. EncounterResult (미사용)와 무관 |
+| resolveBattle 호출 | wild 구조체로 전달 | positional 확장 대신 구조체 전달. processEncounter 흐름과 자연스러운 연결 |
+| shiny 카운터 증감 책임 | stats.ts record 함수 + hooks/stop.ts 호출 | 기존 recordEncounter/recordBattle/recordCatch 패턴과 일관 |
+| hue-shift 레벨 | PNG pixel 공통 처리 (함수 준비만) | 향후 렌더러 통합 시 자동 적용 |
+| Phase 2 범위 | braille/terminal만 status-line 통합 | kitty/iTerm2/sixel은 status-line 미사용 상태 |
+| braille/terminal 처리 | 런타임 ANSI 코드 치환 | 파일 2배 증가 방지 |
+| 마이그레이션 | 불필요 | DEFAULT_STATE 병합 패턴 활용 + BattleResult 읽기 보정 |
+| Phase 3 준비 | 카운터만 선행 배치 | 최소 비용으로 확장 경로 확보 |
+
+## Implementation Order
+
+```
+Phase 1 (MVP) - 권장 순서:
+  1. types.ts         -- BattleResult에 shiny 추가, PokemonState에 shiny 추가,
+                         PokedexEntry에 shiny_caught 추가, State에 카운터 3개 추가
+  2. state.ts         -- DEFAULT_STATE에 카운터 추가 + PokemonState 읽기 시 shiny 보정
+  3. encounter.ts     -- rollShiny + selectWildPokemon 반환값 확장
+  4. battle.ts        -- resolveBattle가 wild 구조체 수용 + BattleResult에 shiny 포함
+                         + formatBattleMessage 이로치 이펙트 + 구버전 BattleResult 보정
+  5. pokedex.ts       -- markShinyCaught
+  6. stats.ts         -- recordShinyEncounter, recordShinyCatch, recordShinyEscaped
+  7. pokemon-data.ts  -- getPokemonName shiny 파라미터
+  8. i18n/*.json      -- 이로치 관련 문자열
+  9. hooks/stop.ts    -- shiny 기반 record 함수 호출 + markShinyCaught 호출
+ 10. status-line.ts   -- ★ 마크 표시 + last_battle shiny 보정
+ 11. cli/tokenmon.ts  -- 도감/상태에 shiny 정보 표시
+
+Phase 2 (스프라이트):
+  1. sprites/shiny.ts (신규) -- hueShiftPng 범용 함수 + braille/terminal ANSI 치환 함수
+  2. status-line.ts          -- loadSprite에 shiny 분기 (braille/terminal 대상)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tkm",
-  "version": "0.0.2-rc.5",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tkm",
-      "version": "0.0.2-rc.5",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/tokenmon.ts
+++ b/src/cli/tokenmon.ts
@@ -83,7 +83,9 @@ function cmdStatus(): void {
       const bar = xpBar(xp, level, expGroup);
       const evolInfo = evolvesAt != null ? t('cli.status.evolves_at', { level: evolvesAt }) : '';
 
-      console.log(`  ${BOLD}${getPokemonName(pokemon)}${RESET} [#${pokemonId}] ${GRAY}${types}${RESET}`);
+      const isShiny = state.pokemon[pokemon]?.shiny ?? false;
+      const displayName = getPokemonName(pokemon, undefined, isShiny);
+      console.log(`  ${BOLD}${displayName}${RESET} [#${pokemonId}] ${GRAY}${types}${RESET}`);
       console.log(`  Lv.${level} [${GREEN}${bar}${RESET}] XP: ${xp}${evolInfo}`);
     }
   }
@@ -110,6 +112,11 @@ function cmdStatus(): void {
 
   // Region
   console.log(t('cli.status.stat_region', { region: getRegionName(config.current_region ?? '1') }));
+
+  // Shiny stats
+  if (state.shiny_catch_count > 0) {
+    console.log(t('cli.status.stat_shiny_catches', { count: state.shiny_catch_count }));
+  }
 }
 
 function cmdStarter(choiceArg?: string): void {
@@ -408,6 +415,10 @@ function cmdPokedex(pokemonName?: string, filterKey?: string, filterVal?: string
     if (pData.evolves_at) console.log(`  ${t('cli.pokedex.detail_evolves_at', { level: pData.evolves_at })}`);
     if (pData.evolves_condition) console.log(`  ${t('cli.pokedex.detail_evolves_cond', { cond: pData.evolves_condition })}`);
     if (pdex?.first_seen) console.log(`  ${t('cli.pokedex.detail_first_seen', { date: pdex.first_seen })}`);
+    const shinyCaught = pdex?.shiny_caught ?? false;
+    if (shinyCaught) {
+      console.log(`  ${t('cli.pokedex.shiny_caught')}`);
+    }
 
     if (state.pokemon[pokemonName]) {
       const ps = state.pokemon[pokemonName];

--- a/src/core/battle.ts
+++ b/src/core/battle.ts
@@ -5,7 +5,7 @@ import { rollItemDrop, getItemCount, useItem } from './items.js';
 import { getTypeMasterXpMultiplier } from './pokedex-rewards.js';
 import { levelToXp } from './xp.js';
 import { t } from '../i18n/index.js';
-import type { State, Config, BattleResult } from './types.js';
+import type { State, Config, BattleResult, WildPokemon } from './types.js';
 
 /**
  * Calculate Poké Ball cost based on catch_rate.
@@ -203,17 +203,16 @@ export function calculateBattleXp(
 export function resolveBattle(
   state: State,
   config: Config,
-  wildName: string,
-  wildLevel: number,
+  wild: WildPokemon,
 ): BattleResult | null {
   const db = getPokemonDB();
-  const wildData = db.pokemon[wildName];
+  const wildData = db.pokemon[wild.name];
   if (!wildData) return null;
   if (config.party.length === 0) return null;
 
   // Select best fighter using party combat power
   const { multiplier: partyMultiplier, bestFighter } = calculatePartyMultiplier(
-    config, state, wildData.types, wildLevel, wildData.base_stats,
+    config, state, wildData.types, wild.level, wildData.base_stats,
   );
   const attacker = bestFighter;
   const attackerData = db.pokemon[attacker];
@@ -226,7 +225,7 @@ export function resolveBattle(
     attackerData.types,
     wildData.types,
     attackerLevel,
-    wildLevel,
+    wild.level,
     attackerData.base_stats,
     wildData.base_stats,
     state.pokemon[attacker]?.ev ?? 0,
@@ -244,7 +243,7 @@ export function resolveBattle(
   // Calculate XP (with type master 1.2x bonus)
   const xpBonus = Math.max(config.xp_bonus_multiplier, state.xp_bonus_multiplier);
   const typeMasterMult = getTypeMasterXpMultiplier(state, attackerData.types, wildData.types);
-  const totalBattleXp = Math.floor(calculateBattleXp(wildLevel, wildData.rarity, typeDisadvantage, xpBonus, won) * typeMasterMult);
+  const totalBattleXp = Math.floor(calculateBattleXp(wild.level, wildData.rarity, typeDisadvantage, xpBonus, won) * typeMasterMult);
   // All party members receive the full XP (not divided)
   const xpPerPokemon = Math.max(1, totalBattleXp);
 
@@ -271,27 +270,27 @@ export function resolveBattle(
   }
 
   // Mark pokemon as seen
-  markSeen(state, wildName);
+  markSeen(state, wild.name);
 
   // Catch on victory (requires pokeballs based on catch_rate)
   let caught = false;
   let ballCost = 0;
   if (won) {
-    const alreadyCaught = state.pokedex[wildName]?.caught ?? false;
+    const alreadyCaught = state.pokedex[wild.name]?.caught ?? false;
     if (!alreadyCaught) {
       ballCost = getBallCost(wildData.catch_rate);
       const hasBalls = getItemCount(state, 'pokeball') >= ballCost;
       if (hasBalls) {
         for (let i = 0; i < ballCost; i++) useItem(state, 'pokeball');
         caught = true;
-        markCaught(state, wildName);
+        markCaught(state, wild.name);
         state.catch_count++;
-        if (!state.unlocked.includes(wildName)) {
-          state.unlocked.push(wildName);
+        if (!state.unlocked.includes(wild.name)) {
+          state.unlocked.push(wild.name);
         }
-        if (!state.pokemon[wildName]) {
-          const catchXp = levelToXp(wildLevel, wildData.exp_group);
-          state.pokemon[wildName] = { id: wildData.id, xp: catchXp, level: wildLevel, friendship: 0, ev: 0 };
+        if (!state.pokemon[wild.name]) {
+          const catchXp = levelToXp(wild.level, wildData.exp_group);
+          state.pokemon[wild.name] = { id: wildData.id, xp: catchXp, level: wild.level, friendship: 0, ev: 0, shiny: wild.shiny };
         }
       }
       // Not enough balls: markSeen already called above, XP already awarded. No catch.
@@ -303,14 +302,15 @@ export function resolveBattle(
 
   return {
     attacker,
-    defender: wildName,
-    defenderLevel: wildLevel,
+    defender: wild.name,
+    defenderLevel: wild.level,
     winRate,
     won,
     xpReward: xpPerPokemon,
     caught,
     typeMultiplier,
     ballCost,
+    shiny: wild.shiny,
   };
 }
 
@@ -318,7 +318,12 @@ export function resolveBattle(
  * Format battle result as notification message.
  */
 export function formatBattleMessage(result: BattleResult): string {
-  const defenderName = getPokemonName(result.defender);
+  const isShiny = result.shiny ?? false;
+  const defenderName = getPokemonName(result.defender, undefined, isShiny);
+  let prefix = '';
+  if (isShiny) {
+    prefix = t('battle.shiny_appeared', { pokemon: defenderName }) + '\n';
+  }
   if (result.won) {
     let msg = t('battle.win', { defender: defenderName, level: result.defenderLevel, xp: result.xpReward });
     if (result.caught) {
@@ -326,12 +331,19 @@ export function formatBattleMessage(result: BattleResult): string {
       if (result.ballCost > 1) {
         msg += ` (🔴×${result.ballCost})`;
       }
+      if (isShiny) {
+        msg += t('battle.shiny_catch');
+      }
     } else if (result.ballCost > 0 && !result.caught) {
       // Won but couldn't catch — not enough balls
       msg += ` ${t('battle.need_balls', { defender: defenderName })}`;
     }
-    return msg;
+    return prefix + msg;
   }
 
-  return t('battle.lose', { defender: defenderName, level: result.defenderLevel, xp: result.xpReward });
+  let msg = t('battle.lose', { defender: defenderName, level: result.defenderLevel, xp: result.xpReward });
+  if (isShiny) {
+    msg += t('battle.shiny_escaped', { pokemon: defenderName });
+  }
+  return prefix + msg;
 }

--- a/src/core/encounter.ts
+++ b/src/core/encounter.ts
@@ -1,8 +1,14 @@
 import { getPokemonDB, getRegionsDB, getEventsDB } from './pokemon-data.js';
 import { resolveBattle, formatBattleMessage } from './battle.js';
-import type { State, Config, EncounterResult, BattleResult, TimeEvent, DayEvent, StreakEvent, MilestoneEvent } from './types.js';
+import type { State, Config, EncounterResult, BattleResult, WildPokemon, TimeEvent, DayEvent, StreakEvent, MilestoneEvent } from './types.js';
 
 const BASE_ENCOUNTER_RATE = 0.15;
+
+export const SHINY_RATE = 1 / 512;
+
+export function rollShiny(): boolean {
+  return Math.random() < SHINY_RATE;
+}
 
 /**
  * Roll whether an encounter happens.
@@ -92,7 +98,7 @@ export function getActiveEvents(state: State): ActiveEvents {
  * Select a wild pokemon from the current region's pool, weighted by rarity.
  * Applies active event modifiers (type boosts, rare multiplier, streak guarantee).
  */
-export function selectWildPokemon(state: State, config: Config): { name: string; level: number } | null {
+export function selectWildPokemon(state: State, config: Config): WildPokemon | null {
   const pokemonDB = getPokemonDB();
   const regionsDB = getRegionsDB();
   const region = regionsDB.regions[config.current_region];
@@ -113,7 +119,7 @@ export function selectWildPokemon(state: State, config: Config): { name: string;
   if (state.legendary_pool.length > 0 && Math.random() < 0.02) {
     const legendaryPick = state.legendary_pool[Math.floor(Math.random() * state.legendary_pool.length)];
     const legendaryLevel = Math.max(50, maxLv + 5);
-    return { name: legendaryPick, level: legendaryLevel };
+    return { name: legendaryPick, level: legendaryLevel, shiny: rollShiny() };
   }
 
   // Streak guarantee: force rare-only pool
@@ -122,7 +128,7 @@ export function selectWildPokemon(state: State, config: Config): { name: string;
     if (rarePool.length > 0) {
       const pick = rarePool[Math.floor(Math.random() * rarePool.length)];
       const [minLv, maxLv] = region.level_range;
-      return { name: pick.name, level: rollWildLevel(pick.name, minLv, maxLv) };
+      return { name: pick.name, level: rollWildLevel(pick.name, minLv, maxLv), shiny: rollShiny() };
     }
   }
 
@@ -156,13 +162,13 @@ export function selectWildPokemon(state: State, config: Config): { name: string;
   for (const entry of weighted) {
     roll -= entry.weight;
     if (roll <= 0) {
-      return { name: entry.name, level: rollWildLevel(entry.name, minLv, maxLv) };
+      return { name: entry.name, level: rollWildLevel(entry.name, minLv, maxLv), shiny: rollShiny() };
     }
   }
 
   // Fallback
   const fallback = weighted[0];
-  return { name: fallback.name, level: rollWildLevel(fallback.name, minLv, maxLv) };
+  return { name: fallback.name, level: rollWildLevel(fallback.name, minLv, maxLv), shiny: rollShiny() };
 }
 
 /**
@@ -181,7 +187,7 @@ export function processEncounter(
   state.encounter_count++;
 
   // Resolve battle (handles seen/caught/XP internally)
-  return resolveBattle(state, config, wild.name, wild.level);
+  return resolveBattle(state, config, wild);
 }
 
 // Re-export for stop hook

--- a/src/core/pokedex.ts
+++ b/src/core/pokedex.ts
@@ -41,6 +41,20 @@ export function markCaught(state: State, name: string): void {
 }
 
 /**
+ * Mark a pokemon species as shiny-caught in the pokedex.
+ */
+export function markShinyCaught(state: State, name: string): void {
+  if (!state.pokedex) state.pokedex = {};
+  const existing = state.pokedex[name];
+  if (existing) {
+    existing.shiny_caught = true;
+    return;
+  }
+  markCaught(state, name);
+  state.pokedex[name].shiny_caught = true;
+}
+
+/**
  * Auto-populate pokedex from unlocked/owned pokemon.
  * Call this on state load to sync existing data.
  */
@@ -56,6 +70,7 @@ export interface PokedexCompletion {
   caught: number;
   seenPct: number;
   caughtPct: number;
+  shinyCaught: number;
 }
 
 /**
@@ -66,10 +81,12 @@ export function getCompletion(state: State): PokedexCompletion {
   const total = Object.keys(db.pokemon).length;
   let seen = 0;
   let caught = 0;
+  let shinyCaught = 0;
 
   for (const entry of Object.values(state.pokedex ?? {})) {
     if (entry.seen) seen++;
     if (entry.caught) caught++;
+    if (entry.shiny_caught) shinyCaught++;
   }
 
   return {
@@ -78,6 +95,7 @@ export function getCompletion(state: State): PokedexCompletion {
     caught,
     seenPct: total > 0 ? Math.round(seen / total * 1000) / 10 : 0,
     caughtPct: total > 0 ? Math.round(caught / total * 1000) / 10 : 0,
+    shinyCaught,
   };
 }
 

--- a/src/core/pokemon-data.ts
+++ b/src/core/pokemon-data.ts
@@ -161,9 +161,11 @@ export function getGameI18n(locale?: string, gen?: string): GameI18nData {
   return _gameI18n[key];
 }
 
-export function getPokemonName(id: string | number, gen?: string): string {
+export function getPokemonName(id: string | number, gen?: string, shiny?: boolean): string {
   const i18n = getGameI18n(undefined, gen);
-  return i18n.pokemon[String(id)] || String(id);
+  const name = i18n.pokemon[String(id)] || String(id);
+  if (shiny) return '★' + name;
+  return name;
 }
 
 export function getTypeName(typeId: string): string {

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -56,6 +56,9 @@ const DEFAULT_STATE: State = {
   titles: [],
   completed_chains: [],
   star_dismissed: false,
+  shiny_encounter_count: 0,
+  shiny_catch_count: 0,
+  shiny_escaped_count: 0,
 };
 
 const DEFAULT_SESSION: Session = {
@@ -96,10 +99,11 @@ export function readState(gen?: string): State {
     star_dismissed: parsed.star_dismissed ?? false,
   };
 
-  // Migrate per-pokemon fields (friendship, ev)
+  // Migrate per-pokemon fields (friendship, ev, shiny)
   for (const entry of Object.values(result.pokemon)) {
     if (entry.friendship === undefined) (entry as any).friendship = 0;
     if (entry.ev === undefined) (entry as any).ev = 0;
+    if (entry.shiny === undefined) (entry as any).shiny = false;
   }
 
   // Migrate retry_token -> pokeball

--- a/src/core/stats.ts
+++ b/src/core/stats.ts
@@ -117,3 +117,24 @@ export function recordEncounter(state: State): void {
   state.stats.weekly_encounters += 1;
   state.stats.total_encounters += 1;
 }
+
+/**
+ * Record a shiny encounter.
+ */
+export function recordShinyEncounter(state: State): void {
+  state.shiny_encounter_count++;
+}
+
+/**
+ * Record a shiny catch.
+ */
+export function recordShinyCatch(state: State): void {
+  state.shiny_catch_count++;
+}
+
+/**
+ * Record a shiny escape.
+ */
+export function recordShinyEscaped(state: State): void {
+  state.shiny_escaped_count++;
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -61,6 +61,7 @@ export interface PokedexEntry {
   seen: boolean;
   caught: boolean;
   first_seen: string | null;
+  shiny_caught?: boolean;
 }
 
 export interface PokemonState {
@@ -69,6 +70,7 @@ export interface PokemonState {
   level: number;
   friendship: number;
   ev: number;
+  shiny?: boolean;
   evolution_ready?: boolean;
   evolution_options?: string[];
 }
@@ -214,6 +216,9 @@ export interface State {
   titles: string[];
   completed_chains: string[];
   star_dismissed: boolean;
+  shiny_encounter_count: number;
+  shiny_catch_count: number;
+  shiny_escaped_count: number;
 }
 
 export interface Config {
@@ -310,6 +315,13 @@ export interface BattleResult {
   caught: boolean;
   typeMultiplier: number;
   ballCost: number;
+  shiny: boolean;
+}
+
+export interface WildPokemon {
+  name: string;
+  level: number;
+  shiny: boolean;
 }
 
 export interface HookInput {

--- a/src/hooks/stop.ts
+++ b/src/hooks/stop.ts
@@ -11,11 +11,11 @@ import { t, initLocale } from '../i18n/index.js';
 import type { HookInput, HookOutput, ExpGroup } from '../core/types.js';
 import { playCry } from '../audio/play-cry.js';
 import { playSfx } from '../audio/play-sfx.js';
-import { syncPokedexFromUnlocked } from '../core/pokedex.js';
+import { syncPokedexFromUnlocked, markShinyCaught } from '../core/pokedex.js';
 import { processEncounter, formatEncounterMessage } from '../core/encounter.js';
 import { withLock, withLockRetry } from '../core/lock.js';
 import { getSessionGeneration, setActiveGenerationCache, getActiveGeneration } from '../core/paths.js';
-import { recordXp, recordBattle, recordCatch, recordEncounter } from '../core/stats.js';
+import { recordXp, recordBattle, recordCatch, recordEncounter, recordShinyEncounter, recordShinyCatch, recordShinyEscaped } from '../core/stats.js';
 
 function readStdin(): string {
   try {
@@ -234,6 +234,17 @@ async function main(): Promise<void> {
         recordBattle(state, battleResult.won);
         recordXp(state, battleResult.xpReward);
         if (battleResult.caught) recordCatch(state);
+
+        // Record shiny stats
+        if (battleResult.shiny) {
+          recordShinyEncounter(state);
+          if (battleResult.caught) {
+            recordShinyCatch(state);
+            markShinyCaught(state, battleResult.defender);
+          } else {
+            recordShinyEscaped(state);
+          }
+        }
 
         // Auto-add caught pokemon to party if below max
         if (battleResult.caught && config.party.length < config.max_party_size) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -17,6 +17,7 @@
   "cli.status.stat_pokedex": "  Pokedex: {caught}/{total} ({pct}%)",
   "cli.status.stat_pokeballs": "  🔴 Poké Balls: {count}",
   "cli.status.stat_region": "  Current region: {region}",
+  "cli.status.stat_shiny_catches": "  ★Shiny catches: {count}",
 
   "cli.starter.already_chosen": "You have already chosen a starter.",
   "cli.starter.current_party": "Current party: {party}",
@@ -76,6 +77,7 @@
   "cli.pokedex.detail_evolves_cond": "  Evo condition: {cond}",
   "cli.pokedex.detail_first_seen": "  First seen: {date}",
   "cli.pokedex.detail_current_level": "  Current level: Lv.{level} (XP: {xp})",
+  "cli.pokedex.shiny_caught": "  ★Shiny caught",
   "cli.pokedex.list_title": "=== Pokedex ===",
   "cli.pokedex.list_summary": "  Seen: {seen}/{total} ({seenPct}%)  Caught: {caught}/{total} ({caughtPct}%)",
   "cli.pokedex.filter": "  Filter: {filter}",
@@ -339,6 +341,9 @@
   "battle.win_catch": "\n🎉 Caught {defender}! (tokenmon party add {defender})",
   "battle.need_balls": "— {defender} fled!",
   "battle.lose": "⚔️ vs wild {defender} (Lv.{level}) → Defeat... (XP +{xp})",
+  "battle.shiny_appeared": "✦ A shiny {pokemon} appeared!",
+  "battle.shiny_catch": "\n★ Shiny caught!",
+  "battle.shiny_escaped": "\nThe shiny {pokemon} got away...",
 
   "achievement.unlocked": "🏆 Achievement unlocked: {name}! ",
   "achievement.unlocked_pokemon": "🏆 Achievement unlocked: {name}! You got {pokemon}!",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -17,6 +17,7 @@
   "cli.status.stat_pokedex": "  도감: {caught}/{total} ({pct}%)",
   "cli.status.stat_pokeballs": "  🔴 몬스터볼: {count}개",
   "cli.status.stat_region": "  현재 지역: {region}",
+  "cli.status.stat_shiny_catches": "  ★이로치 포획: {count}종",
 
   "cli.starter.already_chosen": "이미 스타터를 선택했습니다.",
   "cli.starter.current_party": "현재 파티: {party}",
@@ -76,6 +77,7 @@
   "cli.pokedex.detail_evolves_cond": "  진화 조건: {cond}",
   "cli.pokedex.detail_first_seen": "  최초 발견: {date}",
   "cli.pokedex.detail_current_level": "  현재 레벨: Lv.{level} (XP: {xp})",
+  "cli.pokedex.shiny_caught": "  ★이로치 포획 완료",
   "cli.pokedex.list_title": "=== 포켓몬 도감 ===",
   "cli.pokedex.list_summary": "  발견: {seen}/{total} ({seenPct}%)  포획: {caught}/{total} ({caughtPct}%)",
   "cli.pokedex.filter": "  필터: {filter}",
@@ -339,6 +341,9 @@
   "battle.win_catch": "\n🎉 {defender:을/를} 포획했습니다! (tokenmon party add {defender})",
   "battle.need_balls": "— {defender}(은/는) 도망쳤다!",
   "battle.lose": "⚔️ vs 야생 {defender} (Lv.{level}) → 패배... (XP +{xp})",
+  "battle.shiny_appeared": "✦ 이로치 {pokemon:이/가} 나타났다!",
+  "battle.shiny_catch": "\n★ 이로치 포획 성공!",
+  "battle.shiny_escaped": "\n이로치 {pokemon:이/가} 도망쳤다...",
 
   "achievement.unlocked": "🏆 업적 달성: {name}! ",
   "achievement.unlocked_pokemon": "🏆 업적 달성: {name}! {pokemon:을/를} 얻었습니다!",

--- a/src/sprites/shiny.ts
+++ b/src/sprites/shiny.ts
@@ -1,0 +1,211 @@
+import { PNG } from 'pngjs';
+
+/**
+ * Default hue-shift angle for shiny pokemon sprites (degrees).
+ */
+export const SHINY_HUE_SHIFT = 180;
+
+/**
+ * Convert RGB (0-255 each) to HSL (h: 0-360, s: 0-1, l: 0-1).
+ */
+export function rgbToHsl(r: number, g: number, b: number): [number, number, number] {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    return [0, 0, l];
+  }
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h: number;
+  if (max === rn) {
+    h = ((gn - bn) / d + (gn < bn ? 6 : 0)) * 60;
+  } else if (max === gn) {
+    h = ((bn - rn) / d + 2) * 60;
+  } else {
+    h = ((rn - gn) / d + 4) * 60;
+  }
+
+  return [h, s, l];
+}
+
+/**
+ * Convert HSL (h: 0-360, s: 0-1, l: 0-1) to RGB (0-255 each).
+ */
+export function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return [v, v, v];
+  }
+
+  const hue2rgb = (p: number, q: number, t: number): number => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hn = h / 360;
+
+  return [
+    Math.round(hue2rgb(p, q, hn + 1 / 3) * 255),
+    Math.round(hue2rgb(p, q, hn) * 255),
+    Math.round(hue2rgb(p, q, hn - 1 / 3) * 255),
+  ];
+}
+
+/**
+ * Convert ANSI 256 color code to RGB (0-255 each).
+ * Handles: 0-15 (standard), 16-231 (6x6x6 cube), 232-255 (grayscale).
+ */
+export function ansi256ToRgb(code: number): [number, number, number] {
+  // Standard colors 0-15 — approximate terminal defaults
+  const STANDARD_COLORS: [number, number, number][] = [
+    [0, 0, 0],       // 0 black
+    [128, 0, 0],     // 1 red
+    [0, 128, 0],     // 2 green
+    [128, 128, 0],   // 3 yellow
+    [0, 0, 128],     // 4 blue
+    [128, 0, 128],   // 5 magenta
+    [0, 128, 128],   // 6 cyan
+    [192, 192, 192], // 7 white
+    [128, 128, 128], // 8 bright black
+    [255, 0, 0],     // 9 bright red
+    [0, 255, 0],     // 10 bright green
+    [255, 255, 0],   // 11 bright yellow
+    [0, 0, 255],     // 12 bright blue
+    [255, 0, 255],   // 13 bright magenta
+    [0, 255, 255],   // 14 bright cyan
+    [255, 255, 255], // 15 bright white
+  ];
+
+  if (code < 16) {
+    return STANDARD_COLORS[code];
+  }
+
+  // Grayscale 232-255
+  if (code >= 232) {
+    const gray = (code - 232) * 10 + 8;
+    return [gray, gray, gray];
+  }
+
+  // 6x6x6 color cube 16-231
+  const idx = code - 16;
+  const ri = Math.floor(idx / 36);
+  const gi = Math.floor((idx % 36) / 6);
+  const bi = idx % 6;
+  const toVal = (v: number): number => v === 0 ? 0 : 55 + v * 40;
+  return [toVal(ri), toVal(gi), toVal(bi)];
+}
+
+// The 6x6x6 cube breakpoints: 0, 95, 135, 175, 215, 255
+// Midpoints between these values are used for nearest-neighbor mapping.
+const CUBE_VALUES = [0, 95, 135, 175, 215, 255];
+
+function rgbComponentToIndex(v: number): number {
+  if (v < 48) return 0;       // midpoint(0, 95) = 47.5
+  if (v < 115) return 1;      // midpoint(95, 135) = 115
+  if (v < 155) return 2;      // midpoint(135, 175) = 155
+  if (v < 195) return 3;      // midpoint(175, 215) = 195
+  if (v < 235) return 4;      // midpoint(215, 255) = 235
+  return 5;
+}
+
+/**
+ * Convert RGB (0-255 each) to nearest ANSI 256 color code.
+ * Uses the exact 6x6x6 cube breakpoints from ansi256ToRgb for round-trip consistency.
+ */
+export function rgbToAnsi256(r: number, g: number, b: number): number {
+  // Grayscale detection
+  if (r === g && g === b) {
+    if (r < 4) return 16;         // closest to cube black (0,0,0)
+    if (r > 246) return 231;      // closest to cube white (255,255,255)
+    // Check if the grayscale ramp or the cube gives a closer match
+    const cubeIdx = rgbComponentToIndex(r);
+    const cubeVal = CUBE_VALUES[cubeIdx];
+    const grayIdx = Math.round((r - 8) / 10);
+    const clampedGrayIdx = Math.max(0, Math.min(23, grayIdx));
+    const grayVal = clampedGrayIdx * 10 + 8;
+    if (Math.abs(cubeVal - r) < Math.abs(grayVal - r)) {
+      return 16 + 36 * cubeIdx + 6 * cubeIdx + cubeIdx;
+    }
+    return 232 + clampedGrayIdx;
+  }
+
+  // 6x6x6 color cube
+  const ri = rgbComponentToIndex(r);
+  const gi = rgbComponentToIndex(g);
+  const bi = rgbComponentToIndex(b);
+  return 16 + 36 * ri + 6 * gi + bi;
+}
+
+/**
+ * Shift hue of all ANSI 256 color codes in a text string.
+ * Parses \x1b[38;5;{N}m (foreground) and \x1b[48;5;{N}m (background) patterns.
+ * For each: ansi256ToRgb -> rgbToHsl -> h += degrees -> hslToRgb -> rgbToAnsi256
+ *
+ * @param text - Input text containing ANSI 256 escape codes
+ * @param degrees - Hue rotation in degrees (default: SHINY_HUE_SHIFT = 180)
+ * @returns Text with shifted ANSI color codes
+ */
+export function shiftAnsiHue(text: string, degrees: number = SHINY_HUE_SHIFT): string {
+  // Match \x1b[38;5;{N}m or \x1b[48;5;{N}m
+  return text.replace(/\x1b\[(38|48);5;(\d+)m/g, (_match, type: string, codeStr: string) => {
+    const code = parseInt(codeStr, 10);
+    const [r, g, b] = ansi256ToRgb(code);
+    const [h, s, l] = rgbToHsl(r, g, b);
+    const newH = ((h + degrees) % 360 + 360) % 360;
+    const [nr, ng, nb] = hslToRgb(newH, s, l);
+    const newCode = rgbToAnsi256(nr, ng, nb);
+    return `\x1b[${type};5;${newCode}m`;
+  });
+}
+
+/**
+ * Hue-shift all pixels in a PNG buffer. Returns a new PNG buffer.
+ * Skips transparent pixels (alpha < 128).
+ * Prepared for future kitty/iTerm2/sixel integration.
+ *
+ * @param pngBuffer - Input PNG buffer
+ * @param degrees - Hue rotation in degrees (default: SHINY_HUE_SHIFT = 180)
+ * @returns New PNG buffer with shifted hues
+ */
+export function hueShiftPng(pngBuffer: Buffer, degrees: number = SHINY_HUE_SHIFT): Buffer {
+  const img = PNG.sync.read(pngBuffer);
+  const { width, height, data } = img;
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      const a = data[idx + 3];
+
+      // Skip transparent pixels
+      if (a < 128) continue;
+
+      const r = data[idx];
+      const g = data[idx + 1];
+      const b = data[idx + 2];
+
+      const [h, s, l] = rgbToHsl(r, g, b);
+      const newH = ((h + degrees) % 360 + 360) % 360;
+      const [nr, ng, nb] = hslToRgb(newH, s, l);
+
+      data[idx] = nr;
+      data[idx + 1] = ng;
+      data[idx + 2] = nb;
+      // alpha unchanged
+    }
+  }
+
+  return PNG.sync.write(img);
+}

--- a/src/status-line.ts
+++ b/src/status-line.ts
@@ -6,6 +6,7 @@ import { getPokemonDB, getPokemonName, getRegionName, getGenerationsDB } from '.
 import { levelToXp, xpToLevel } from './core/xp.js';
 import { SPRITES_BRAILLE_DIR, SPRITES_TERMINAL_DIR, getActiveGeneration } from './core/paths.js';
 import { formatBattleMessage } from './core/battle.js';
+import { shiftAnsiHue } from './sprites/shiny.js';
 import { t, initLocale } from './i18n/index.js';
 import type { ExpGroup } from './core/types.js';
 
@@ -31,12 +32,16 @@ function getEmoji(types: string[]): string {
   return TYPE_EMOJI[types?.[0]] ?? '⭐';
 }
 
-function loadSprite(pokemonId: number): string[] {
+function loadSprite(pokemonId: number, isShiny: boolean = false): string[] {
   const brailleFile = join(SPRITES_BRAILLE_DIR, `${pokemonId}.txt`);
   const terminalFile = join(SPRITES_TERMINAL_DIR, `${pokemonId}.txt`);
   const file = existsSync(brailleFile) ? brailleFile : existsSync(terminalFile) ? terminalFile : null;
   if (!file) return [];
-  return readFileSync(file, 'utf-8').split('\n').filter(l => l.trim().length > 0);
+  const lines = readFileSync(file, 'utf-8').split('\n').filter(l => l.trim().length > 0);
+  if (isShiny && lines.length > 0) {
+    return lines.map(line => shiftAnsiHue(line));
+  }
+  return lines;
 }
 
 function visibleLength(s: string): number {
@@ -155,7 +160,8 @@ function main(): void {
     for (let i = 0; i < pokeData.length; i++) {
       const p = pokeData[i];
       if (spriteMode === 'all' || i === 0) {
-        spriteEntries.push(loadSprite(p.pokemonId));
+        const isShinySprite = state.pokemon[p.name]?.shiny ?? false;
+        spriteEntries.push(loadSprite(p.pokemonId, isShinySprite));
       }
     }
 
@@ -198,7 +204,8 @@ function main(): void {
       ? (spriteMode === 'emoji_all' || (spriteMode === 'emoji_ace' && isAce)) ? `${emoji} ` : ''
       : '';
 
-    const displayName = getPokemonName(p.name);
+    const isShiny = state.pokemon[p.name]?.shiny ?? false;
+    const displayName = getPokemonName(p.name, undefined, isShiny);
     let info: string;
     switch (infoMode) {
       case 'all_full':

--- a/test/battle.test.ts
+++ b/test/battle.test.ts
@@ -1,10 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { makeState as _makeState, makeConfig as _makeConfig } from './helpers.js';
-import { calculateWinRate, calculateBattleXp, selectBattlePokemon, calculatePartyMultiplier, resolveBattle } from '../src/core/battle.js';
+import { calculateWinRate, calculateBattleXp, selectBattlePokemon, calculatePartyMultiplier, resolveBattle, formatBattleMessage } from '../src/core/battle.js';
 import { getTypeEffectiveness, getRawTypeMultiplier, applyTypeDampening } from '../src/core/type-chart.js';
+import { initLocale } from '../src/i18n/index.js';
 
 import type { State, Config } from '../src/core/types.js';
+
+initLocale('ko');
 
 function makeState(overrides: Partial<State> = {}): State {
   return _makeState({
@@ -194,7 +197,7 @@ describe('battle', () => {
     it('returns BattleResult', () => {
       const state = makeState();
       const config = makeConfig();
-      const result = resolveBattle(state, config, '396', 5);
+      const result = resolveBattle(state, config, { name: '396', level: 5, shiny: false });
       assert.ok(result !== null);
       assert.equal(typeof result!.won, 'boolean');
       assert.equal(typeof result!.winRate, 'number');
@@ -204,7 +207,7 @@ describe('battle', () => {
     it('increments battle_count', () => {
       const state = makeState();
       const config = makeConfig();
-      resolveBattle(state, config, '396', 5);
+      resolveBattle(state, config, { name: '396', level: 5, shiny: false });
       assert.equal(state.battle_count, 1);
     });
 
@@ -212,14 +215,14 @@ describe('battle', () => {
       const state = makeState();
       const config = makeConfig();
       const prevXp = state.pokemon['387'].xp;
-      resolveBattle(state, config, '396', 5);
+      resolveBattle(state, config, { name: '396', level: 5, shiny: false });
       assert.ok(state.pokemon['387'].xp > prevXp);
     });
 
     it('marks wild pokemon as seen', () => {
       const state = makeState();
       const config = makeConfig();
-      resolveBattle(state, config, '396', 5);
+      resolveBattle(state, config, { name: '396', level: 5, shiny: false });
       assert.ok(state.pokedex['396']?.seen);
     });
   });
@@ -235,7 +238,7 @@ describe('battle', () => {
       let caughtResult = false;
       for (let i = 0; i < 50 && !caughtResult; i++) {
         const ballsBefore = state.items.pokeball;
-        const result = resolveBattle(state, config, '396', 1);
+        const result = resolveBattle(state, config, { name: '396', level: 1, shiny: false });
         if (result?.won && result?.caught) {
           caughtResult = true;
           // Ball consumed: before-catch ball count minus after-catch (ignoring drops)
@@ -256,7 +259,7 @@ describe('battle', () => {
       for (let i = 0; i < 50; i++) {
         // Reset pokeballs to 0 before each battle to isolate the test
         state.items.pokeball = 0;
-        const result = resolveBattle(state, config, '396', 1);
+        const result = resolveBattle(state, config, { name: '396', level: 1, shiny: false });
         if (result?.won) {
           hadWin = true;
           assert.equal(result.caught, false, 'Should not catch without pokeball');
@@ -277,7 +280,7 @@ describe('battle', () => {
       let hadWin = false;
       for (let i = 0; i < 50; i++) {
         const ballsBefore = state.items.pokeball;
-        const result = resolveBattle(state, config, '396', 1);
+        const result = resolveBattle(state, config, { name: '396', level: 1, shiny: false });
         if (result?.won) {
           hadWin = true;
           assert.equal(result.caught, false, 'Already caught pokemon should not trigger catch');
@@ -321,7 +324,7 @@ describe('battle', () => {
       // Run battles until we get a win
       let won = false;
       for (let i = 0; i < 50 && !won; i++) {
-        const result = resolveBattle(state, config, '396', 1); // low level wild for easy win
+        const result = resolveBattle(state, config, { name: '396', level: 1, shiny: false }); // low level wild for easy win
         if (result?.won) won = true;
       }
       if (won) {
@@ -339,7 +342,7 @@ describe('battle', () => {
       const config = makeConfig({ party: ['387'] });
       // Run battles against high level - likely to lose
       for (let i = 0; i < 20; i++) {
-        resolveBattle(state, config, '390', 100);
+        resolveBattle(state, config, { name: '390', level: 100, shiny: false });
       }
       // EV should only increase for wins, check it's bounded
       assert.ok(state.pokemon['387'].ev <= state.battle_wins, 'EV should not exceed win count');
@@ -354,9 +357,57 @@ describe('battle', () => {
       const config = makeConfig({ party: ['387'] });
       // Force a win against low level
       for (let i = 0; i < 10; i++) {
-        resolveBattle(state, config, '396', 1);
+        resolveBattle(state, config, { name: '396', level: 1, shiny: false });
       }
       assert.equal(state.pokemon['387'].ev, 252, 'EV should not exceed 252');
+    });
+  });
+
+  describe('shiny battle path', () => {
+    it('resolveBattle with shiny:true wild returns BattleResult.shiny === true', () => {
+      const state = makeState();
+      const config = makeConfig();
+      const result = resolveBattle(state, config, { name: '396', level: 5, shiny: true });
+      assert.ok(result !== null);
+      assert.equal(result!.shiny, true);
+    });
+
+    it('catch success + shiny:true records PokemonState.shiny === true', () => {
+      const state = makeState({
+        pokemon: { '387': { id: 387, xp: 500000, level: 80, friendship: 0, ev: 0 } },
+        items: { pokeball: 50 },
+      });
+      const config = makeConfig({ party: ['387'] });
+      let caughtShiny = false;
+      for (let i = 0; i < 100 && !caughtShiny; i++) {
+        const result = resolveBattle(state, config, { name: '396', level: 1, shiny: true });
+        if (result?.won && result?.caught) {
+          caughtShiny = true;
+          assert.equal(state.pokemon['396']?.shiny, true, 'PokemonState.shiny should be true after shiny catch');
+        }
+      }
+      assert.ok(caughtShiny, 'Should catch at least one shiny pokemon');
+    });
+
+    it('formatBattleMessage includes "✦" when shiny=true', () => {
+      const msg = formatBattleMessage({
+        attacker: '387', defender: '396', defenderLevel: 5,
+        winRate: 0.6, won: true, xpReward: 65, caught: true, typeMultiplier: 1.0,
+        ballCost: 0, shiny: true,
+      });
+      assert.ok(msg.includes('✦'), `expected "✦" in shiny message: ${msg}`);
+    });
+
+    it('formatBattleMessage with shiny=undefined (legacy BattleResult) does not crash and omits "✦"', () => {
+      const legacyResult = {
+        attacker: '387', defender: '396', defenderLevel: 5,
+        winRate: 0.6, won: true, xpReward: 65, caught: true, typeMultiplier: 1.0,
+        ballCost: 0,
+      } as any;
+      // Should not throw
+      const msg = formatBattleMessage(legacyResult);
+      assert.equal(typeof msg, 'string');
+      assert.ok(!msg.includes('✦'), `"✦" should not appear when shiny is undefined: ${msg}`);
     });
   });
 });

--- a/test/encounter.test.ts
+++ b/test/encounter.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { makeState as _makeState, makeConfig as _makeConfig } from './helpers.js';
-import { rollEncounter, selectWildPokemon, processEncounter, getMinWildLevel } from '../src/core/encounter.js';
+import { rollEncounter, selectWildPokemon, processEncounter, getMinWildLevel, rollShiny, SHINY_RATE } from '../src/core/encounter.js';
 import { formatBattleMessage } from '../src/core/battle.js';
 import { initLocale } from '../src/i18n/index.js';
 
@@ -94,6 +94,23 @@ describe('encounter', () => {
       const total = Object.values(counts).reduce((a, b) => a + b, 0);
       assert.ok(common / total > 0.3, `Common ratio too low: ${common}/${total}`);
     });
+
+    it('returns object with shiny boolean field', () => {
+      const state = makeState();
+      const config = makeConfig({ current_region: '1' });
+      for (let i = 0; i < 50; i++) {
+        const wild = selectWildPokemon(state, config);
+        assert.ok(wild !== null);
+        assert.equal(typeof wild!.shiny, 'boolean', 'shiny field must be a boolean');
+      }
+    });
+  });
+
+  describe('rollShiny', () => {
+    it('returns boolean', () => {
+      const result = rollShiny();
+      assert.equal(typeof result, 'boolean');
+    });
   });
 
   describe('getMinWildLevel', () => {
@@ -166,6 +183,23 @@ describe('encounter', () => {
       assert.ok(caught, 'Should catch at least one pokemon in 500 attempts');
     });
 
+    it('shiny=true path when Math.random forced below SHINY_RATE', () => {
+      const state = makeState();
+      const config = makeConfig();
+      const originalRandom = Math.random;
+      try {
+        // Force Math.random to always return a value below SHINY_RATE
+        // This makes rollShiny() always return true, and also affects encounter/battle rolls
+        // We use a small number that is < SHINY_RATE (~0.00195)
+        Math.random = () => 0.0001;
+        const result = processEncounter(state, config);
+        assert.ok(result !== null, 'Should get an encounter when Math.random is always low');
+        assert.equal(result!.shiny, true, 'BattleResult.shiny should be true when Math.random < SHINY_RATE');
+      } finally {
+        Math.random = originalRandom;
+      }
+    });
+
     it('increments encounter_count and battle_count', () => {
       const state = makeState();
       const config = makeConfig();
@@ -183,6 +217,7 @@ describe('encounter', () => {
       const msg = formatBattleMessage({
         attacker: '387', defender: '396', defenderLevel: 5,
         winRate: 0.6, won: true, xpReward: 65, caught: true, typeMultiplier: 1.0,
+        ballCost: 0, shiny: false,
       });
       assert.ok(msg.includes('찌르꼬'), `expected '찌르꼬' in: ${msg}`);
       assert.ok(msg.includes('승리'));
@@ -193,6 +228,7 @@ describe('encounter', () => {
       const msg = formatBattleMessage({
         attacker: '387', defender: '396', defenderLevel: 5,
         winRate: 0.3, won: false, xpReward: 16, caught: false, typeMultiplier: 1.0,
+        ballCost: 0, shiny: false,
       });
       assert.ok(msg.includes('패배'));
     });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -58,6 +58,9 @@ export function makeState(overrides: Partial<State> = {}): State {
     titles: [],
     completed_chains: [],
     star_dismissed: false,
+    shiny_encounter_count: 0,
+    shiny_catch_count: 0,
+    shiny_escaped_count: 0,
     ...overrides,
   };
 }

--- a/test/pokedex.test.ts
+++ b/test/pokedex.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { makeState } from './helpers.js';
-import { markSeen, markCaught, getCompletion, syncPokedexFromUnlocked } from '../src/core/pokedex.js';
+import { markSeen, markCaught, markShinyCaught, getCompletion, syncPokedexFromUnlocked } from '../src/core/pokedex.js';
 
 describe('pokedex', () => {
   describe('markSeen', () => {
@@ -91,6 +91,44 @@ describe('pokedex', () => {
       assert.equal(c.seen, 2);
       assert.equal(c.caught, 1);
       assert.equal(c.total, 112);
+    });
+  });
+
+  describe('markShinyCaught', () => {
+    it('sets shiny_caught=true on existing entry', () => {
+      const state = makeState({
+        pokedex: { '387': { seen: true, caught: true, first_seen: '2026-01-01' } },
+      });
+      markShinyCaught(state, '387');
+      assert.equal(state.pokedex['387'].shiny_caught, true);
+    });
+
+    it('is idempotent when already shiny_caught=true', () => {
+      const state = makeState({
+        pokedex: { '387': { seen: true, caught: true, first_seen: '2026-01-01', shiny_caught: true } },
+      });
+      markShinyCaught(state, '387');
+      assert.equal(state.pokedex['387'].shiny_caught, true);
+      assert.equal(state.pokedex['387'].caught, true);
+    });
+
+    it('after markShinyCaught getCompletion.shinyCaught increments', () => {
+      const state = makeState({
+        pokedex: {
+          '387': { seen: true, caught: true, first_seen: '2026-01-01' },
+          '393': { seen: true, caught: true, first_seen: '2026-01-02' },
+        },
+      });
+      const before = getCompletion(state);
+      assert.equal(before.shinyCaught, 0);
+
+      markShinyCaught(state, '387');
+      const after = getCompletion(state);
+      assert.equal(after.shinyCaught, 1);
+
+      markShinyCaught(state, '393');
+      const after2 = getCompletion(state);
+      assert.equal(after2.shinyCaught, 2);
     });
   });
 

--- a/test/pokemon-data.test.ts
+++ b/test/pokemon-data.test.ts
@@ -3,6 +3,12 @@ import assert from 'node:assert/strict';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getPokemonName } from '../src/core/pokemon-data.js';
+import { initLocale } from '../src/i18n/index.js';
+import { setActiveGenerationCache } from '../src/core/paths.js';
+
+setActiveGenerationCache('gen4');
+initLocale('ko');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, '..');
@@ -226,6 +232,25 @@ describe('pokemon-data (M3a)', () => {
       for (const [name, p] of Object.entries(pokemon) as [string, any][]) {
         assert.ok(validGroups.includes(p.exp_group), `${name} has invalid exp_group: "${p.exp_group}"`);
       }
+    });
+  });
+
+  describe('getPokemonName shiny prefix', () => {
+    it('getPokemonName(id, undefined, true) includes "★" prefix', () => {
+      const name = getPokemonName('387', undefined, true);
+      assert.ok(name.startsWith('★'), `expected "★" prefix in: ${name}`);
+    });
+
+    it('getPokemonName(id, undefined, false) does not include "★" prefix', () => {
+      const name = getPokemonName('387', undefined, false);
+      assert.ok(!name.startsWith('★'), `unexpected "★" prefix in: ${name}`);
+    });
+
+    it('getPokemonName(id) without shiny parameter preserves existing behavior', () => {
+      const name = getPokemonName('387');
+      assert.ok(!name.startsWith('★'), `unexpected "★" prefix without shiny param in: ${name}`);
+      assert.equal(typeof name, 'string');
+      assert.ok(name.length > 0);
     });
   });
 });

--- a/test/shiny-sprite.test.ts
+++ b/test/shiny-sprite.test.ts
@@ -1,0 +1,291 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  rgbToHsl,
+  hslToRgb,
+  ansi256ToRgb,
+  rgbToAnsi256,
+  shiftAnsiHue,
+  hueShiftPng,
+  SHINY_HUE_SHIFT,
+} from '../src/sprites/shiny.js';
+
+describe('sprites/shiny', () => {
+  // -------------------------------------------------------
+  // 1. rgbToHsl / hslToRgb round-trip
+  // -------------------------------------------------------
+  describe('rgbToHsl / hslToRgb round-trip', () => {
+    const testCases: [number, number, number][] = [
+      [255, 0, 0],       // pure red
+      [0, 255, 0],       // pure green
+      [0, 0, 255],       // pure blue
+      [255, 255, 0],     // yellow
+      [0, 255, 255],     // cyan
+      [255, 0, 255],     // magenta
+      [255, 255, 255],   // white
+      [0, 0, 0],         // black
+      [128, 128, 128],   // gray
+      [100, 200, 50],    // arbitrary color
+      [37, 142, 219],    // another arbitrary color
+      [210, 105, 30],    // chocolate
+    ];
+
+    for (const [r, g, b] of testCases) {
+      it(`round-trip for RGB(${r}, ${g}, ${b})`, () => {
+        const [h, s, l] = rgbToHsl(r, g, b);
+        const [rr, rg, rb] = hslToRgb(h, s, l);
+        assert.ok(Math.abs(rr - r) <= 1, `R: expected ~${r}, got ${rr}`);
+        assert.ok(Math.abs(rg - g) <= 1, `G: expected ~${g}, got ${rg}`);
+        assert.ok(Math.abs(rb - b) <= 1, `B: expected ~${b}, got ${rb}`);
+      });
+    }
+  });
+
+  // -------------------------------------------------------
+  // 2. shiftAnsiHue preserves non-ANSI text
+  // -------------------------------------------------------
+  describe('shiftAnsiHue structure preservation', () => {
+    it('does not modify plain text without ANSI codes', () => {
+      const plain = 'Hello, world! This is plain text. 12345 #$%';
+      assert.equal(shiftAnsiHue(plain), plain);
+    });
+
+    it('does not modify reset sequences', () => {
+      const text = '\x1b[0m';
+      assert.equal(shiftAnsiHue(text), text);
+    });
+
+    it('preserves text around ANSI codes', () => {
+      const text = 'before\x1b[38;5;196mcolored\x1b[0mafter';
+      const shifted = shiftAnsiHue(text);
+      assert.ok(shifted.startsWith('before'), 'text before ANSI code preserved');
+      assert.ok(shifted.includes('colored'), 'text content preserved');
+      assert.ok(shifted.endsWith('after'), 'text after ANSI code preserved');
+    });
+
+    it('preserves braille characters', () => {
+      const braille = '\u2800\u2801\u2802\u2803';
+      const text = `\x1b[38;5;196m${braille}\x1b[0m`;
+      const shifted = shiftAnsiHue(text);
+      assert.ok(shifted.includes(braille), 'braille characters preserved');
+    });
+  });
+
+  // -------------------------------------------------------
+  // 3. shiftAnsiHue color change
+  // -------------------------------------------------------
+  describe('shiftAnsiHue color shift', () => {
+    it('shifts foreground ANSI 256 codes', () => {
+      // Code 196 = bright red in 6x6x6 cube
+      const text = '\x1b[38;5;196mhello\x1b[0m';
+      const shifted = shiftAnsiHue(text);
+      // The code should change
+      assert.notEqual(shifted, text, 'color code should be shifted');
+      // Still has the same ANSI structure
+      assert.ok(/\x1b\[38;5;\d+m/.test(shifted), 'foreground escape format preserved');
+    });
+
+    it('shifts background ANSI 256 codes', () => {
+      const text = '\x1b[48;5;21mworld\x1b[0m';
+      const shifted = shiftAnsiHue(text);
+      assert.notEqual(shifted, text, 'background code should be shifted');
+      assert.ok(/\x1b\[48;5;\d+m/.test(shifted), 'background escape format preserved');
+    });
+
+    it('shifts both fg and bg in a single string', () => {
+      const text = '\x1b[38;5;196m\x1b[48;5;21mtest\x1b[0m';
+      const shifted = shiftAnsiHue(text);
+      // Both should have been replaced
+      const fgMatch = shifted.match(/\x1b\[38;5;(\d+)m/);
+      const bgMatch = shifted.match(/\x1b\[48;5;(\d+)m/);
+      assert.ok(fgMatch, 'fg code present');
+      assert.ok(bgMatch, 'bg code present');
+      assert.notEqual(fgMatch![1], '196', 'fg code should differ from original');
+      assert.notEqual(bgMatch![1], '21', 'bg code should differ from original');
+    });
+
+    it('360-degree shift produces same codes', () => {
+      const text = '\x1b[38;5;196mhello\x1b[48;5;82mworld\x1b[0m';
+      const shifted = shiftAnsiHue(text, 360);
+      assert.equal(shifted, text, '360-degree shift should be identity');
+    });
+
+    it('0-degree shift produces same codes', () => {
+      const text = '\x1b[38;5;196mhello\x1b[48;5;82mworld\x1b[0m';
+      const shifted = shiftAnsiHue(text, 0);
+      assert.equal(shifted, text, '0-degree shift should be identity');
+    });
+  });
+
+  // -------------------------------------------------------
+  // 4. hueShiftPng 360 degrees = original
+  // -------------------------------------------------------
+  describe('hueShiftPng', () => {
+    it('360-degree shift produces identical pixels', async () => {
+      let PNG: typeof import('pngjs').PNG;
+      try {
+        PNG = (await import('pngjs')).PNG;
+      } catch {
+        return; // pngjs not available, skip
+      }
+
+      // Create a 4x4 PNG with various colors
+      const img = new PNG({ width: 4, height: 4 });
+      const colors: [number, number, number, number][] = [
+        [255, 0, 0, 255],     // red
+        [0, 255, 0, 255],     // green
+        [0, 0, 255, 255],     // blue
+        [255, 255, 0, 255],   // yellow
+        [255, 0, 255, 255],   // magenta
+        [0, 255, 255, 255],   // cyan
+        [128, 64, 32, 255],   // brown
+        [200, 100, 150, 255], // pink
+        [0, 0, 0, 255],       // black
+        [255, 255, 255, 255], // white
+        [128, 128, 128, 255], // gray
+        [50, 100, 200, 255],  // arbitrary
+        [0, 0, 0, 0],         // transparent
+        [255, 0, 0, 64],      // semi-transparent (below 128 threshold)
+        [100, 200, 50, 255],  // lime-ish
+        [210, 105, 30, 255],  // chocolate
+      ];
+
+      for (let i = 0; i < 16; i++) {
+        const [r, g, b, a] = colors[i];
+        img.data[i * 4] = r;
+        img.data[i * 4 + 1] = g;
+        img.data[i * 4 + 2] = b;
+        img.data[i * 4 + 3] = a;
+      }
+
+      const originalBuf = PNG.sync.write(img);
+      const shiftedBuf = hueShiftPng(originalBuf, 360);
+      const shiftedImg = PNG.sync.read(shiftedBuf);
+
+      for (let i = 0; i < 16; i++) {
+        const oR = img.data[i * 4];
+        const oG = img.data[i * 4 + 1];
+        const oB = img.data[i * 4 + 2];
+        const oA = img.data[i * 4 + 3];
+        const sR = shiftedImg.data[i * 4];
+        const sG = shiftedImg.data[i * 4 + 1];
+        const sB = shiftedImg.data[i * 4 + 2];
+        const sA = shiftedImg.data[i * 4 + 3];
+
+        assert.equal(sA, oA, `pixel ${i}: alpha unchanged`);
+        if (oA < 128) {
+          // Transparent pixels should be untouched
+          assert.equal(sR, oR, `pixel ${i}: transparent R unchanged`);
+          assert.equal(sG, oG, `pixel ${i}: transparent G unchanged`);
+          assert.equal(sB, oB, `pixel ${i}: transparent B unchanged`);
+        } else {
+          assert.ok(Math.abs(sR - oR) <= 1, `pixel ${i}: R expected ~${oR}, got ${sR}`);
+          assert.ok(Math.abs(sG - oG) <= 1, `pixel ${i}: G expected ~${oG}, got ${sG}`);
+          assert.ok(Math.abs(sB - oB) <= 1, `pixel ${i}: B expected ~${oB}, got ${sB}`);
+        }
+      }
+    });
+
+    // -------------------------------------------------------
+    // 5. hueShiftPng 0 degrees = unchanged
+    // -------------------------------------------------------
+    it('0-degree shift produces identical pixels', async () => {
+      let PNG: typeof import('pngjs').PNG;
+      try {
+        PNG = (await import('pngjs')).PNG;
+      } catch {
+        return; // pngjs not available, skip
+      }
+
+      // Create a 2x2 PNG
+      const img = new PNG({ width: 2, height: 2 });
+      const colors: [number, number, number, number][] = [
+        [255, 0, 0, 255],
+        [0, 255, 0, 255],
+        [0, 0, 255, 255],
+        [128, 128, 128, 255],
+      ];
+
+      for (let i = 0; i < 4; i++) {
+        const [r, g, b, a] = colors[i];
+        img.data[i * 4] = r;
+        img.data[i * 4 + 1] = g;
+        img.data[i * 4 + 2] = b;
+        img.data[i * 4 + 3] = a;
+      }
+
+      const originalBuf = PNG.sync.write(img);
+      const shiftedBuf = hueShiftPng(originalBuf, 0);
+      const shiftedImg = PNG.sync.read(shiftedBuf);
+
+      for (let i = 0; i < 4; i++) {
+        const oR = img.data[i * 4];
+        const oG = img.data[i * 4 + 1];
+        const oB = img.data[i * 4 + 2];
+        const sR = shiftedImg.data[i * 4];
+        const sG = shiftedImg.data[i * 4 + 1];
+        const sB = shiftedImg.data[i * 4 + 2];
+
+        assert.ok(Math.abs(sR - oR) <= 1, `pixel ${i}: R expected ~${oR}, got ${sR}`);
+        assert.ok(Math.abs(sG - oG) <= 1, `pixel ${i}: G expected ~${oG}, got ${sG}`);
+        assert.ok(Math.abs(sB - oB) <= 1, `pixel ${i}: B expected ~${oB}, got ${sB}`);
+      }
+    });
+
+    it('preserves transparent pixels unchanged', async () => {
+      let PNG: typeof import('pngjs').PNG;
+      try {
+        PNG = (await import('pngjs')).PNG;
+      } catch {
+        return;
+      }
+
+      const img = new PNG({ width: 2, height: 1 });
+      // Opaque red
+      img.data[0] = 255; img.data[1] = 0; img.data[2] = 0; img.data[3] = 255;
+      // Fully transparent
+      img.data[4] = 50; img.data[5] = 100; img.data[6] = 200; img.data[7] = 0;
+
+      const buf = PNG.sync.write(img);
+      const shifted = hueShiftPng(buf, 180);
+      const result = PNG.sync.read(shifted);
+
+      // Transparent pixel should be completely untouched
+      assert.equal(result.data[4], 50, 'transparent pixel R unchanged');
+      assert.equal(result.data[5], 100, 'transparent pixel G unchanged');
+      assert.equal(result.data[6], 200, 'transparent pixel B unchanged');
+      assert.equal(result.data[7], 0, 'transparent pixel A unchanged');
+
+      // Opaque pixel should have changed (red -> cyan-ish with 180 degree shift)
+      assert.notEqual(result.data[0], 255, 'opaque pixel R should change');
+    });
+  });
+
+  // -------------------------------------------------------
+  // Additional utility tests
+  // -------------------------------------------------------
+  describe('ansi256ToRgb / rgbToAnsi256', () => {
+    it('round-trips for 6x6x6 cube colors', () => {
+      // Test a selection of 6x6x6 cube codes
+      for (const code of [16, 21, 46, 82, 124, 196, 201, 226, 231]) {
+        const [r, g, b] = ansi256ToRgb(code);
+        const result = rgbToAnsi256(r, g, b);
+        assert.equal(result, code, `round-trip for code ${code}: got ${result}`);
+      }
+    });
+
+    it('round-trips for grayscale', () => {
+      for (const code of [232, 240, 248, 255]) {
+        const [r, g, b] = ansi256ToRgb(code);
+        const result = rgbToAnsi256(r, g, b);
+        assert.equal(result, code, `grayscale round-trip for code ${code}: got ${result}`);
+      }
+    });
+  });
+
+  describe('SHINY_HUE_SHIFT constant', () => {
+    it('equals 180', () => {
+      assert.equal(SHINY_HUE_SHIFT, 180);
+    });
+  });
+});

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 
 // Set up isolated test directory before importing state module
@@ -168,6 +168,44 @@ await test('pruneSessionGenMap keeps all entries younger than maxAge', () => {
 
 await test('pruneSessionGenMap returns {} for empty map', () => {
   assert.deepEqual(pruneSessionGenMap({}, 7 * 24 * 3600 * 1000), {});
+});
+
+// --- Shiny migration tests ---
+
+await test('readState: shiny counters missing in JSON are filled with 0', () => {
+  freshDir();
+  // Write a state file WITHOUT shiny counters
+  const path = statePath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify({
+    pokemon: {},
+    unlocked: [],
+    session_count: 1,
+    // no shiny_encounter_count, shiny_catch_count, shiny_escaped_count
+  }), 'utf-8');
+
+  const state = readState();
+  assert.equal(state.shiny_encounter_count, 0, 'shiny_encounter_count should default to 0');
+  assert.equal(state.shiny_catch_count, 0, 'shiny_catch_count should default to 0');
+  assert.equal(state.shiny_escaped_count, 0, 'shiny_escaped_count should default to 0');
+});
+
+await test('readState: PokemonState.shiny missing is corrected to false', () => {
+  freshDir();
+  const path = statePath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  // Write a pokemon entry without shiny field
+  writeFileSync(path, JSON.stringify({
+    pokemon: {
+      '387': { id: 387, xp: 5000, level: 15, friendship: 0, ev: 0 },
+    },
+    unlocked: ['387'],
+  }), 'utf-8');
+
+  const state = readState();
+  assert.equal(state.pokemon['387'].shiny, false, 'PokemonState.shiny should default to false');
 });
 
 // Cleanup

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -10,6 +10,9 @@ import {
   recordBattle,
   recordCatch,
   recordEncounter,
+  recordShinyEncounter,
+  recordShinyCatch,
+  recordShinyEscaped,
 } from '../src/core/stats.js';
 
 describe('stats', () => {
@@ -183,6 +186,35 @@ describe('stats', () => {
       recordEncounter(state);
       assert.equal(state.stats.weekly_encounters, 1);
       assert.equal(state.stats.total_encounters, 1);
+    });
+  });
+
+  describe('shiny record functions', () => {
+    it('recordShinyEncounter increments shiny_encounter_count by 1', () => {
+      const state = makeState();
+      assert.equal(state.shiny_encounter_count, 0);
+      recordShinyEncounter(state);
+      assert.equal(state.shiny_encounter_count, 1);
+      recordShinyEncounter(state);
+      assert.equal(state.shiny_encounter_count, 2);
+    });
+
+    it('recordShinyCatch increments shiny_catch_count by 1', () => {
+      const state = makeState();
+      assert.equal(state.shiny_catch_count, 0);
+      recordShinyCatch(state);
+      assert.equal(state.shiny_catch_count, 1);
+      recordShinyCatch(state);
+      assert.equal(state.shiny_catch_count, 2);
+    });
+
+    it('recordShinyEscaped increments shiny_escaped_count by 1', () => {
+      const state = makeState();
+      assert.equal(state.shiny_escaped_count, 0);
+      recordShinyEscaped(state);
+      assert.equal(state.shiny_escaped_count, 1);
+      recordShinyEscaped(state);
+      assert.equal(state.shiny_escaped_count, 2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- 야생 포켓몬 조우 시 1/512 확률로 이로치(shiny) 개체가 출현하는 시스템 추가
- 이로치 포켓몬의 텍스트 이펙트(★ 마크, ✦ 이로치 발견!), 도감 추적, 스프라이트 색상 변환 구현
- Phase 3(업적, 고유 색상, 효과음) 대비 데이터 구조 선행 배치

## Changes

### Phase 1 - MVP (핵심 로직)

| 모듈 | 변경 내용 |
|------|----------|
| `src/core/types.ts` | `WildPokemon` interface 신규, `PokemonState.shiny`, `PokedexEntry.shiny_caught`, `BattleResult.shiny`, `State`에 shiny 카운터 3개 추가 |
| `src/core/encounter.ts` | `rollShiny()` 확률 판정 함수 추가, `selectWildPokemon` 반환값을 `WildPokemon` 타입으로 확장 |
| `src/core/battle.ts` | `resolveBattle`를 `wild` 구조체 전달 패턴으로 리팩터, `formatBattleMessage`에 이로치 텍스트 이펙트 + 구버전 BattleResult 하위호환 보정 |
| `src/core/pokedex.ts` | `markShinyCaught` 함수 추가, `getCompletion`에 `shinyCaught` 통계 추가 |
| `src/core/pokemon-data.ts` | `getPokemonName`에 optional `shiny` 파라미터 추가 (★ 접두 처리) |
| `src/core/stats.ts` | `recordShinyEncounter`, `recordShinyCatch`, `recordShinyEscaped` 함수 추가 |
| `src/core/state.ts` | `DEFAULT_STATE`에 shiny 카운터 3개 추가, `PokemonState` 읽기 시 `shiny` 기본값 마이그레이션 |
| `src/hooks/stop.ts` | `battleResult.shiny` 기반 shiny record 함수 호출 + `markShinyCaught` 호출 |
| `src/i18n/ko.json`, `en.json` | 이로치 관련 i18n 문자열 6개 추가 (battle.shiny_appeared, battle.shiny_catch, battle.shiny_escaped 등) |
| `src/cli/tokenmon.ts` | status/pokedex 명령어에서 이로치 포켓몬 구분 표시 |
| `src/status-line.ts` | 파티 내 이로치 포켓몬 이름에 ★ 마크 표시 |

### Phase 2 - 스프라이트 색상 변환

| 모듈 | 변경 내용 |
|------|----------|
| `src/sprites/shiny.ts` (신규) | `rgbToHsl`/`hslToRgb` 색상 변환, `ansi256ToRgb`/`rgbToAnsi256` ANSI 256 변환, `shiftAnsiHue` braille/terminal 스프라이트 hue-shift, `hueShiftPng` PNG 범용 hue-shift (kitty/iTerm2/sixel 대비 준비) |
| `src/status-line.ts` | `loadSprite`에 `isShiny` 분기 추가 — braille/terminal 스프라이트에 hue-shift 적용 |

### 설계 문서

| 파일 | 내용 |
|------|------|
| `docs/pipeline/high-level-design.md` | 전체 아키텍처, 데이터 모델, 흐름 다이어그램, Phase 3 준비 사항 |
| `docs/pipeline/code-level-design.md` | 코드 레벨 구현 명세 |

### 테스트 (41개 추가)

| 파일 | 추가 테스트 |
|------|------------|
| `test/battle.test.ts` | shiny battle path (4개): shiny BattleResult 반환, shiny catch 시 PokemonState 기록, formatBattleMessage ✦ 이펙트, legacy BattleResult 하위호환 |
| `test/encounter.test.ts` | rollShiny 반환 타입, selectWildPokemon shiny 필드 검증, Math.random 강제로 shiny path 검증 (3개) |
| `test/pokedex.test.ts` | markShinyCaught (3개): 기존 entry 설정, 멱등성, getCompletion.shinyCaught 증가 |
| `test/pokemon-data.test.ts` | getPokemonName shiny prefix (3개): ★ 접두 추가/미추가/기본 동작 |
| `test/state.test.ts` | shiny 마이그레이션 (2개): 누락된 shiny 카운터 기본값, PokemonState.shiny 기본값 |
| `test/stats.test.ts` | shiny record 함수 (3개): recordShinyEncounter/Catch/Escaped 증감 |
| `test/shiny-sprite.test.ts` (신규) | sprites/shiny.ts 전체 커버리지 (23개): RGB-HSL 왕복, ANSI 구조 보존, 색상 변환, hueShiftPng 360도/0도 항등, 투명 픽셀 보존, ansi256 왕복 |

## Test Plan
- [x] 신규 테스트 41개 모두 pass 확인
- [x] 전체 테스트 수행 시 기존 2개 fail (streak timezone 이슈)만 존재 — 이번 변경과 무관
- [ ] 수동 테스트: `tokenmon status`에서 이로치 포켓몬에 ★ 마크 표시 확인
- [ ] 수동 테스트: 이로치 조우 시 "✦ 이로치 발견!" 메시지 출력 확인
- [ ] 수동 테스트: braille/terminal 스프라이트 hue-shift 시각 확인

## Related
- 설계 문서: `docs/pipeline/high-level-design.md`, `docs/pipeline/code-level-design.md`
- Phase 3 예정: 업적 시스템 연동, 종별 고유 색상 매핑, 효과음

🤖 Generated with [Claude Code](https://claude.com/claude-code)