### PR TITLE
fix(rewards): persist type-master legendary claimed marker to prevent re-queuing

### DIFF
--- a/src/core/pokedex-rewards.ts
+++ b/src/core/pokedex-rewards.ts
@@ -119,6 +119,7 @@ export function checkTypeMasters(state: State): string[] {
     if (!alreadyPending && !alreadyClaimed) {
       const group = rewardsDB.type_master.special_legends;
       state.legendary_pending.push({ group: groupId, options: [...group.options] });
+      state.pokedex_milestones_claimed.push(`type_master_legendary:${groupId}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix `checkTypeMasters()` so the synthetic `type_master_legendary:${groupId}` marker is persisted when the special legendary group is queued.
- Prevent the same legendary pending group from being re-added on the next session after it was consumed via CLI.

## Root cause
- The type-master legendary unlock logic checked `state.pokedex_milestones_claimed` for a synthetic claimed ID but never wrote that ID into persisted state.

## Fix
- Add `state.pokedex_milestones_claimed.push(\`type_master_legendary:${groupId}\`)` immediately after pushing the special legendary group into `state.legendary_pending`.