### PR TITLE
fix: preserve sprite alignment during weather effects

### DIFF
--- a/src/core/layout.ts
+++ b/src/core/layout.ts
@@ -5,7 +5,11 @@ export type LayoutTier = 1 | 2 | 3 | 4;
 export type SpriteMode = Config['sprite_mode'];
 
 export const SPRITE_WIDTH = 20; // character count (used for padding)
-export const SPRITE_COL_WIDTH = SPRITE_WIDTH + 1; // +1 for braille separator (braille = 1-wide per Unicode EAW:N)
+// Braille is EAW:Neutral per Unicode spec — treated as 1-wide for layout math.
+// Actual rendered width is terminal/font-dependent (some CJK terminals render
+// braille as 2-wide). The render loop uses \u2800 everywhere so that all
+// transparent cells share whatever width the terminal picks for braille.
+export const SPRITE_COL_WIDTH = SPRITE_WIDTH + 1; // +1 for braille separator
 
 /**
  * Determine the display tier based on terminal width, party size, and sprite_mode.

--- a/src/status-line.ts
+++ b/src/status-line.ts
@@ -178,7 +178,7 @@ function wrapPrint(parts: string[], maxWidth: number): void {
 
 // ── Weather particle effects ──
 
-// All particle chars must be braille (U+2800–28FF, width 2) to preserve SPRITE_WIDTH alignment
+// Particle chars use braille (U+2800–28FF) to match sprite char width in all terminals
 const WEATHER_PARTICLES: Record<WeatherCondition, { chars: string[]; color: string; density: number }> = {
   rain:         { chars: ['⠡', '⠑', '⠊', '⠉'],        color: '\x1b[34m',  density: 0.12 },
   thunderstorm: { chars: ['⠡', '⠑', '⠋', '⠛'],        color: '\x1b[33m',  density: 0.15 },
@@ -189,7 +189,7 @@ const WEATHER_PARTICLES: Record<WeatherCondition, { chars: string[]; color: stri
   cloudy:       { chars: ['⠒', '⠤', '⠶'],              color: '\x1b[90m',  density: 0.06 },
 };
 
-function scatterWeatherParticles(line: string, condition: WeatherCondition): string {
+export function scatterWeatherParticles(line: string, condition: WeatherCondition): string {
   const fx = WEATHER_PARTICLES[condition];
   if (!fx || fx.chars.length === 0) return line;
   const RESET = '\x1b[0m';
@@ -430,7 +430,14 @@ function main(): void {
         if (weatherCondition) {
           rowStr = scatterWeatherParticles(rowStr, weatherCondition);
         }
-        console.log(rowStr.replace(/\u2800/g, ' '));
+        // Keep \u2800 (braille blank) in output instead of converting to ASCII space.
+        // In some CJK terminals, non-zero braille (sprite art) and \u2800 are both
+        // rendered at the same width while ASCII space is narrower — mixing them
+        // causes per-row width variance proportional to sprite opacity, which is
+        // invisible without weather but blatant once particles land on random cells.
+        // Keeping every transparent position as \u2800 guarantees uniform row width
+        // regardless of the terminal's actual braille glyph width.
+        console.log(rowStr);
       }
     }
   }
@@ -543,9 +550,14 @@ function main(): void {
   wrapPrint(infoParts, printWidth);
 }
 
-try {
-  main();
-} catch {
-  // Output minimal status on crash to prevent Claude Code from breaking
-  console.log('tokenmon: error');
+// Only run main() when invoked as entry script — avoids side effects on import
+// (tests import scatterWeatherParticles directly).
+const isEntryScript = import.meta.url === `file://${process.argv[1]}`;
+if (isEntryScript) {
+  try {
+    main();
+  } catch {
+    // Output minimal status on crash to prevent Claude Code from breaking
+    console.log('tokenmon: error');
+  }
 }

--- a/test/weather-particles.test.ts
+++ b/test/weather-particles.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Regression tests for weather particle rendering.
+ *
+ * These lock in the property that matters for sprite alignment:
+ * after scattering weather particles onto a composed sprite row,
+ * every rendered row must retain a constant visible width and must
+ * NOT introduce ASCII spaces into transparent positions — that's
+ * the bug that caused rows to drift in CJK terminals where braille
+ * renders 2-wide but space is 1-wide.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { scatterWeatherParticles } from '../src/status-line.js';
+import type { WeatherCondition } from '../src/core/types.js';
+
+// Strip SGR ANSI escapes to count visible characters
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[^m]*m/g, '');
+}
+
+// Build a 3-sprite composed row: each sprite is 20 chars wide,
+// mixing non-zero braille ("opaque pixel") with \u2800 ("transparent").
+// Sprites joined by a single \u2800 (the inter-sprite separator).
+function composeSampleRow(opaqueCounts: number[]): string {
+  const sprites = opaqueCounts.map((n) => {
+    const opaque = '\x1b[38;5;66m⣿\x1b[0m'.repeat(n);
+    const blanks = '\u2800'.repeat(20 - n);
+    return opaque + blanks;
+  });
+  return sprites.join('\u2800');
+}
+
+const CONDITIONS: WeatherCondition[] = [
+  'rain',
+  'thunderstorm',
+  'snow',
+  'fog',
+  'sandstorm',
+  'clear',
+  'cloudy',
+];
+
+describe('weather particles', () => {
+  describe('visible width invariant', () => {
+    // Multiple rows with different opacity patterns — this mirrors how real
+    // sprites vary row-by-row (e.g. Bulbasaur row 4 has 7 opaque braille,
+    // row 5 has 8). The critical property: all rows should stay the same
+    // visible width after particle scatter.
+    const opacityProfiles = [
+      [3, 5, 2], // row with few opaque
+      [7, 8, 6], // mid-opacity row
+      [10, 12, 9], // high-opacity row
+      [0, 0, 0], // entirely blank row
+      [20, 20, 20], // entirely opaque row
+    ];
+
+    for (const condition of CONDITIONS) {
+      it(`${condition} preserves visible width across all row shapes`, () => {
+        // Expected width = 3 sprites × 20 chars + 2 separators = 62
+        const expectedWidth = 62;
+        for (const profile of opacityProfiles) {
+          const row = composeSampleRow(profile);
+          // Run many times to exercise randomness
+          for (let i = 0; i < 50; i++) {
+            const scattered = scatterWeatherParticles(row, condition);
+            const visible = stripAnsi(scattered);
+            assert.equal(
+              visible.length,
+              expectedWidth,
+              `${condition} row profile=${JSON.stringify(profile)} iter=${i}: ` +
+                `width ${visible.length} != ${expectedWidth}`,
+            );
+          }
+        }
+      });
+    }
+  });
+
+  describe('no ASCII space leak', () => {
+    // The regression: converting \u2800 -> ASCII space was the bug.
+    // Ensure scatterWeatherParticles never introduces ASCII space into
+    // transparent positions — every non-particle, non-opaque cell must
+    // remain \u2800 so the terminal renders it with braille width.
+    for (const condition of CONDITIONS) {
+      it(`${condition} never introduces ASCII space`, () => {
+        const row = composeSampleRow([5, 7, 4]);
+        for (let i = 0; i < 50; i++) {
+          const scattered = scatterWeatherParticles(row, condition);
+          // Original row had no ASCII space; scatter must not add any.
+          // Particles are wrapped in SGR, so after stripping ANSI the
+          // result should only contain non-zero braille (opaque + particle)
+          // and \u2800 (untouched transparent).
+          const visible = stripAnsi(scattered);
+          assert.ok(
+            !visible.includes(' '),
+            `${condition} iter=${i}: scatter output contains ASCII space`,
+          );
+        }
+      });
+    }
+  });
+
+  describe('particle uses braille codepoint', () => {
+    // Particles must be drawn from U+2800–U+28FF so they share
+    // whatever width the terminal assigns to sprite braille chars.
+    for (const condition of CONDITIONS) {
+      it(`${condition} particle chars are all braille range`, () => {
+        // Force 100% density by scattering enough to reliably hit every cell
+        const row = '\u2800'.repeat(100);
+        const scattered = scatterWeatherParticles(row, condition);
+        // Find every char inside SGR color + char + reset sequences
+        const particleRe = /\x1b\[[^m]*m(.)\x1b\[0m/g;
+        let match;
+        while ((match = particleRe.exec(scattered)) !== null) {
+          const cp = match[1].codePointAt(0) ?? 0;
+          assert.ok(
+            cp >= 0x2800 && cp <= 0x28ff,
+            `${condition}: particle char U+${cp.toString(16)} not in braille range`,
+          );
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

날씨 효과 활성화 시 스프라이트가 행별로 밀려 보이는 문제 수정.

### Root cause

Unicode EAW 기준으로 braille(U+2800–U+28FF)은 Neutral(1-wide)이고 `src/core/layout.ts`도 그렇게 가정하지만, 일부 CJK 터미널 폰트는 non-zero braille과 `\u2800`을 같은 글리프 너비로 렌더링하면서 ASCII space는 그대로 좁게 표시합니다. 그런 터미널에서는 기존 파이프라인이 한 행에 두 가지 너비를 섞었습니다:

- 불투명 셀: non-zero braille (터미널이 정한 너비, 예: 2 cols)
- 투명 셀: ASCII space (1 col, `\u2800` → space 변환 후)

행마다 불투명/투명 비율이 달라서 행마다 총 컬럼 수가 달라집니다. 날씨 없을 때는 "대충 맞아" 보여서 신고되지 않았고, weather particle이 랜덤한 `\u2800` 셀을 braille로 바꾸면서 이 비율이 행마다 무작위로 변해 밀림이 드러났습니다.

### Fix

`\u2800`을 그대로 출력합니다. 모든 투명 셀이 터미널이 braille에 부여한 너비를 공유하므로 sprite art / particle과 동일한 너비가 됩니다. 불투명도나 particle 수와 관계없이 행 너비가 균일해지고, 스펙 준수(1-wide) 터미널에서는 모든 braille이 동일 너비로 해석되므로 동작 변화도 없습니다.

### Changes

- `src/status-line.ts`: `\u2800` → space 변환 제거 + 이유 주석. `scatterWeatherParticles` export 및 `main()` entry-script 가드 (테스트에서 import 시 side effect 방지)
- `src/core/layout.ts`: braille 너비가 EAW 스펙을 넘어 터미널 의존적일 수 있음을 주석으로 명시
- `test/weather-particles.test.ts`: 7가지 날씨 전체에 대해 회귀 테스트 추가
  - 다양한 불투명도 프로필에서 visible width 불변성
  - ASCII space 누출 없음
  - Particle 문자가 braille 범위 내에 있음

## Test plan

- [x] rain, thunderstorm, snow, fog, sandstorm, clear, cloudy 7가지 날씨 모두 정렬 정상
- [x] 신규 회귀 테스트 21개 통과
- [x] 전체 테스트 856개 통과 (기존 835 + 신규 21)
- [x] CJK 터미널에서 시각 확인 (reporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)