### PR TITLE
feat: show minutes in PP bar remaining time

### DIFF
--- a/src/core/pp.ts
+++ b/src/core/pp.ts
@@ -19,8 +19,9 @@ export function ppBar(stdinData: StdinData, blocks: number = 6): string | null {
         const mins = Math.max(1, Math.round(remainingSec / 60));
         timeStr = ` (~${mins}m)`;
       } else {
-        const hours = Math.floor(remainingSec / 3600);
-        const mins = Math.round((remainingSec % 3600) / 60);
+        const totalMins = Math.max(1, Math.round(remainingSec / 60));
+        const hours = Math.floor(totalMins / 60);
+        const mins = totalMins % 60;
         timeStr = mins > 0 ? ` (~${hours}h${mins}m)` : ` (~${hours}h)`;
       }
     }

--- a/src/core/pp.ts
+++ b/src/core/pp.ts
@@ -20,7 +20,8 @@ export function ppBar(stdinData: StdinData, blocks: number = 6): string | null {
         timeStr = ` (~${mins}m)`;
       } else {
         const hours = Math.floor(remainingSec / 3600);
-        timeStr = ` (~${hours}h)`;
+        const mins = Math.round((remainingSec % 3600) / 60);
+        timeStr = mins > 0 ? ` (~${hours}h${mins}m)` : ` (~${hours}h)`;
       }
     }
   }

--- a/test/pp-bar.test.ts
+++ b/test/pp-bar.test.ts
@@ -100,7 +100,7 @@ describe('ppBar', () => {
     assert.ok(result.includes('(~45m)'));
   });
 
-  it('shows floor hours for > 1h remaining', () => {
+  it('shows hours and minutes for > 1h remaining', () => {
     const futureTs = Math.floor(Date.now() / 1000) + 7260; // 2h01m
     const data: StdinData = {
       rate_limits: {
@@ -109,6 +109,6 @@ describe('ppBar', () => {
     };
     const result = ppBar(data);
     assert.ok(result);
-    assert.ok(result.includes('(~2h)'));
+    assert.ok(result.includes('(~2h1m)'));
   });
 });

--- a/test/pp-bar.test.ts
+++ b/test/pp-bar.test.ts
@@ -3,6 +3,16 @@ import assert from 'node:assert/strict';
 import { ppBar } from '../src/core/pp.js';
 import type { StdinData } from '../src/core/types.js';
 
+function withMockedNow<T>(nowMs: number, run: () => T): T {
+  const realNow = Date.now;
+  Date.now = () => nowMs;
+  try {
+    return run();
+  } finally {
+    Date.now = realNow;
+  }
+}
+
 describe('ppBar', () => {
   it('70% remaining shows battery bar + percentage + time', () => {
     const futureTs = Math.floor(Date.now() / 1000) + 7200; // +2h
@@ -110,5 +120,27 @@ describe('ppBar', () => {
     const result = ppBar(data);
     assert.ok(result);
     assert.ok(result.includes('(~2h1m)'));
+  });
+
+  it('rounds 1h59m30s up to 2h instead of showing 1h60m', () => {
+    const result = withMockedNow(0, () => ppBar({
+      rate_limits: {
+        five_hour: { used_percentage: 30, resets_at: 7170 },
+      },
+    }));
+    assert.ok(result);
+    assert.ok(result.includes('(~2h)'));
+    assert.ok(!result.includes('1h60m'));
+  });
+
+  it('keeps exact 2h remaining formatted without minutes', () => {
+    const result = withMockedNow(0, () => ppBar({
+      rate_limits: {
+        five_hour: { used_percentage: 30, resets_at: 7200 },
+      },
+    }));
+    assert.ok(result);
+    assert.ok(result.includes('(~2h)'));
+    assert.ok(!result.includes('2h0m'));
   });
 });


### PR DESCRIPTION
## Summary
- PP 바의 rate limit 리셋 시간을 시간 단위(`~2h`)에서 시간+분 단위(`~2h31m`)로 변경
- 정시(0분)일 때는 기존처럼 `~2h`만 표시

## Test plan
- [x] 기존 PP bar 테스트 업데이트 및 전체 835개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)