### PR TITLE
feat(battle): 상태이상 v3a — 수면/얼음

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -67,7 +67,11 @@
     "category": "physical",
     "power": 75,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "9": {
     "id": 9,
@@ -385,6 +389,21 @@
     "accuracy": 100,
     "pp": 25
   },
+  "47": {
+    "id": 47,
+    "name": "sing",
+    "nameKo": "노래하기",
+    "nameEn": "Sing",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 55,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "51": {
     "id": 51,
     "name": "acid",
@@ -468,7 +487,11 @@
     "category": "special",
     "power": 90,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "59": {
     "id": 59,
@@ -479,7 +502,11 @@
     "category": "special",
     "power": 110,
     "accuracy": 70,
-    "pp": 5
+    "pp": 5,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "60": {
     "id": 60,
@@ -654,6 +681,21 @@
       "chance": 100
     }
   },
+  "79": {
+    "id": 79,
+    "name": "sleep-powder",
+    "nameKo": "수면가루",
+    "nameEn": "Sleep Powder",
+    "type": "grass",
+    "category": "status",
+    "power": 0,
+    "accuracy": 75,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "80": {
     "id": 80,
     "name": "petal-dance",
@@ -790,6 +832,21 @@
     "power": 90,
     "accuracy": 100,
     "pp": 10
+  },
+  "95": {
+    "id": 95,
+    "name": "hypnosis",
+    "nameKo": "최면술",
+    "nameEn": "Hypnosis",
+    "type": "psychic",
+    "category": "status",
+    "power": 0,
+    "accuracy": 60,
+    "pp": 20,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
   },
   "98": {
     "id": 98,
@@ -1004,6 +1061,21 @@
     "accuracy": 100,
     "pp": 10
   },
+  "142": {
+    "id": 142,
+    "name": "lovely-kiss",
+    "nameKo": "악마의키스",
+    "nameEn": "Lovely Kiss",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 75,
+    "pp": 10,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "143": {
     "id": 143,
     "name": "sky-attack",
@@ -1047,6 +1119,21 @@
     "power": 70,
     "accuracy": 100,
     "pp": 10
+  },
+  "147": {
+    "id": 147,
+    "name": "spore",
+    "nameKo": "버섯포자",
+    "nameEn": "Spore",
+    "type": "grass",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
   },
   "150": {
     "id": 150,
@@ -1211,7 +1298,11 @@
     "category": "special",
     "power": 40,
     "accuracy": 100,
-    "pp": 25
+    "pp": 25,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "182": {
     "id": 182,
@@ -3476,7 +3567,11 @@
     "category": "special",
     "power": 70,
     "accuracy": 100,
-    "pp": 20
+    "pp": 20,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "574": {
     "id": 574,

--- a/docs/superpowers/plans/2026-04-10-status-effects-v3a.md
+++ b/docs/superpowers/plans/2026-04-10-status-effects-v3a.md
@@ -1,0 +1,1044 @@
+# Status Effects v3a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Sleep and Freeze to the existing v2 Tokenmon battle status system, including engine rules, move data, UI labels, i18n, and regression tests.
+
+**Architecture:** Extend the existing v2 non-volatile status pipeline instead of introducing a new subsystem. Sleep and freeze remain pure `statusCondition`-driven effects, with `sleepCounter` stored on `BattlePokemon`, pre-move skip helpers in `src/core/status-effects.ts`, and narrow battle-engine integration inside `executeMove()`.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, JSON move data, existing i18n JSON dictionaries, battle TUI renderer.
+
+---
+
+## File Map
+
+- `src/core/types.ts`: status union + `BattlePokemon.sleepCounter`
+- `src/core/status-effects.ts`: sleep/freeze rules, immunities, exception moves, status application helpers
+- `src/core/turn-battle.ts`: pre-move sleep/freeze integration and fire-thaw battle flow
+- `src/core/gym-ai.ts`: confirm no heuristic change is needed
+- `src/i18n/en.json`: English messages and labels
+- `src/i18n/ko.json`: Korean messages and labels
+- `src/battle-tui/renderer.ts`: battle log status color rendering
+- `src/status-line.ts`: compact status badges
+- `data/moves.json`: new sleep moves + freeze secondary effects
+- `test/status-effects.test.ts`: unit coverage for sleep/freeze helpers
+- `test/turn-battle.test.ts`: battle-flow regressions
+
+### Task 1: Extend Types
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Extend `StatusCondition` in `src/core/types.ts`**
+
+```ts
+// src/core/types.ts
+export type StatusCondition =
+  | 'burn'
+  | 'poison'
+  | 'badly_poisoned'
+  | 'paralysis'
+  | 'sleep'
+  | 'freeze';
+```
+
+- [ ] **Step 2: Extend `BattlePokemon` with `sleepCounter`**
+
+```ts
+// src/core/types.ts
+export interface BattlePokemon {
+  id: number;
+  name: string;
+  displayName: string;
+  types: string[];
+  level: number;
+  maxHp: number;
+  currentHp: number;
+  attack: number;
+  defense: number;
+  spAttack: number;
+  spDefense: number;
+  speed: number;
+  moves: BattleMove[];
+  fainted: boolean;
+  statusCondition: StatusCondition | null;
+  toxicCounter: number;
+  sleepCounter: number;
+}
+```
+
+- [ ] **Step 3: Initialize `sleepCounter` in `createBattlePokemon()`**
+
+```ts
+// src/core/turn-battle.ts
+export function createBattlePokemon(
+  input: CreateBattlePokemonInput,
+  moves: MoveData[],
+): BattlePokemon {
+  const { id, types, level, baseStats } = input;
+  const maxHp = calculateHp(baseStats.hp, level);
+
+  const spAttackBase = baseStats.sp_attack ?? baseStats.attack;
+  const spDefenseBase = baseStats.sp_defense ?? baseStats.defense;
+
+  return {
+    id,
+    name: String(id),
+    displayName: input.displayName ?? String(id),
+    types,
+    level,
+    maxHp,
+    currentHp: maxHp,
+    attack: calculateStat(baseStats.attack, level),
+    defense: calculateStat(baseStats.defense, level),
+    spAttack: calculateStat(spAttackBase, level),
+    spDefense: calculateStat(spDefenseBase, level),
+    speed: calculateStat(baseStats.speed, level),
+    moves: moves.map((m) => ({ data: m, currentPp: m.pp })),
+    fainted: false,
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+  };
+}
+```
+
+- [ ] **Step 4: Update `makeTestPokemon()` to include `sleepCounter`**
+
+```ts
+// test/turn-battle.test.ts
+function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
+  return {
+    id: 1,
+    name: '1',
+    displayName: 'Attacker',
+    types: ['normal'],
+    level: 50,
+    maxHp: 120,
+    currentHp: 120,
+    attack: 60,
+    defense: 50,
+    spAttack: 55,
+    spDefense: 50,
+    speed: 70,
+    moves: [{ data: makeMoveData(), currentPp: 35 }],
+    fainted: false,
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Add type-level regression tests for the new default field**
+
+```ts
+// test/turn-battle.test.ts
+describe('createBattlePokemon', () => {
+  it('initializes status counters to zero', () => {
+    const bp = createBattlePokemon(
+      {
+        id: 4,
+        types: ['fire'],
+        level: 50,
+        baseStats: { hp: 39, attack: 52, defense: 43, speed: 65 },
+        displayName: 'Charmander',
+      },
+      [makeMoveData()],
+    );
+
+    assert.equal(bp.statusCondition, null);
+    assert.equal(bp.toxicCounter, 0);
+    assert.equal(bp.sleepCounter, 0);
+  });
+});
+```
+
+- [ ] **Step 6: Run the focused tests**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS after the remaining plan tasks are complete
+
+### Task 2: Status Effects Module Updates
+
+**Files:**
+- Modify: `src/core/status-effects.ts`
+- Modify: `test/status-effects.test.ts`
+
+- [ ] **Step 1: Replace `src/core/status-effects.ts` with the full updated implementation**
+
+```ts
+// src/core/status-effects.ts
+import { t } from '../i18n/index.js';
+import type { BattleMove, BattlePokemon, StatusCondition } from './types.js';
+
+const STATUS_IMMUNITIES: Record<StatusCondition, string[]> = {
+  poison: ['poison', 'steel'],
+  badly_poisoned: ['poison', 'steel'],
+  burn: ['fire'],
+  paralysis: ['electric'],
+  sleep: [],
+  freeze: ['ice'],
+};
+
+export const FROZEN_EXCEPTION_MOVES = new Set([
+  'flame-wheel',
+  'sacred-fire',
+  'scald',
+  'flare-blitz',
+  'steam-eruption',
+  'burn-up',
+]);
+
+export function isStatusImmune(pokemon: BattlePokemon, status: StatusCondition): boolean {
+  const immuneTypes = STATUS_IMMUNITIES[status];
+  return pokemon.types.some((type) => immuneTypes.includes(type));
+}
+
+export function tryApplyStatus(target: BattlePokemon, status: StatusCondition, messages: string[]): boolean {
+  if (target.fainted) return false;
+  if (target.statusCondition !== null) {
+    messages.push(t('status.already', { name: target.displayName }));
+    return false;
+  }
+  if (isStatusImmune(target, status)) {
+    messages.push(t('status.immune', { name: target.displayName }));
+    return false;
+  }
+
+  target.statusCondition = status;
+
+  if (status === 'badly_poisoned') {
+    target.toxicCounter = 1;
+  }
+
+  if (status === 'sleep') {
+    target.sleepCounter = Math.floor(Math.random() * 3) + 1;
+  } else {
+    target.sleepCounter = 0;
+  }
+
+  messages.push(t(`status.${status}.inflicted`, { name: target.displayName }));
+  return true;
+}
+
+export function getParalysisSpeedMultiplier(pokemon: BattlePokemon): number {
+  return pokemon.statusCondition === 'paralysis' ? 0.5 : 1.0;
+}
+
+export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
+  return pokemon.statusCondition === 'burn' ? 0.5 : 1.0;
+}
+
+export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'sleep') return false;
+
+  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+
+  if (pokemon.sleepCounter === 0) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.sleep.wake', { name: pokemon.displayName }));
+    return true;
+  }
+
+  messages.push(t('status.sleep.still_asleep', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkFreezeSkip(
+  pokemon: BattlePokemon,
+  move: BattleMove,
+  messages: string[],
+): boolean {
+  if (pokemon.statusCondition !== 'freeze') return false;
+
+  if (FROZEN_EXCEPTION_MOVES.has(move.data.name)) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  if (Math.random() < 0.2) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  messages.push(t('status.freeze.still_frozen', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkParalysisSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'paralysis') return false;
+  if (Math.random() < 0.25) {
+    messages.push(t('status.paralysis.immobile', { name: pokemon.displayName }));
+    return true;
+  }
+  return false;
+}
+
+export function applyEndOfTurnEffects(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.fainted || pokemon.statusCondition === null) return false;
+  let damage = 0;
+  switch (pokemon.statusCondition) {
+    case 'burn':
+      damage = Math.max(1, Math.floor(pokemon.maxHp / 16));
+      messages.push(t('status.burn.damage', { name: pokemon.displayName }));
+      break;
+    case 'poison':
+      damage = Math.max(1, Math.floor(pokemon.maxHp / 8));
+      messages.push(t('status.poison.damage', { name: pokemon.displayName }));
+      break;
+    case 'badly_poisoned':
+      damage = Math.max(1, Math.floor((pokemon.maxHp * pokemon.toxicCounter) / 16));
+      messages.push(t('status.poison.damage', { name: pokemon.displayName }));
+      pokemon.toxicCounter++;
+      break;
+    case 'paralysis':
+    case 'sleep':
+    case 'freeze':
+      return false;
+  }
+  if (damage > 0) {
+    pokemon.currentHp = Math.max(0, pokemon.currentHp - damage);
+    if (pokemon.currentHp <= 0) {
+      pokemon.fainted = true;
+      messages.push(t('status.fainted_by_status', { name: pokemon.displayName }));
+      return true;
+    }
+  }
+  return false;
+}
+
+export function rollMoveEffect(
+  move: { effect?: { type: StatusCondition; chance: number } },
+  target: BattlePokemon,
+  messages: string[],
+): void {
+  if (!move.effect) return;
+  if (Math.random() * 100 >= move.effect.chance) return;
+  tryApplyStatus(target, move.effect.type, messages);
+}
+```
+
+- [ ] **Step 2: Update the test helper in `test/status-effects.test.ts`**
+
+```ts
+// test/status-effects.test.ts
+function makePokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
+  return {
+    id: 1, name: '1', displayName: 'Test', types: ['normal'], level: 50,
+    maxHp: 160, currentHp: 160, attack: 60, defense: 50, spAttack: 55,
+    spDefense: 50, speed: 70, moves: [], fainted: false,
+    statusCondition: null, toxicCounter: 0, sleepCounter: 0, ...overrides,
+  };
+}
+```
+
+- [ ] **Step 3: Update imports and add full helper coverage in `test/status-effects.test.ts`**
+
+```ts
+// test/status-effects.test.ts
+import {
+  isStatusImmune,
+  tryApplyStatus,
+  checkParalysisSkip,
+  checkSleepSkip,
+  checkFreezeSkip,
+  FROZEN_EXCEPTION_MOVES,
+  getBurnAttackMultiplier,
+  getParalysisSpeedMultiplier,
+  applyEndOfTurnEffects,
+} from '../src/core/status-effects.js';
+```
+
+```ts
+// test/status-effects.test.ts
+describe('isStatusImmune', () => {
+  it('ice type immune to freeze', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['ice'] }), 'freeze'), true);
+  });
+
+  it('normal type not immune to sleep', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'sleep'), false);
+  });
+});
+
+describe('tryApplyStatus', () => {
+  it('inits sleepCounter for sleep in the 1..3 range', () => {
+    const mon = makePokemon();
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.6; // floor(1.8) + 1 = 2
+      assert.equal(tryApplyStatus(mon, 'sleep', []), true);
+      assert.equal(mon.statusCondition, 'sleep');
+      assert.equal(mon.sleepCounter, 2);
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('blocks freeze on ice types', () => {
+    const mon = makePokemon({ types: ['ice'] });
+    assert.equal(tryApplyStatus(mon, 'freeze', []), false);
+    assert.equal(mon.statusCondition, null);
+  });
+});
+
+describe('checkSleepSkip', () => {
+  it('sleeping pokemon stays asleep when counter remains above zero', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 3 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, 'sleep');
+    assert.equal(mon.sleepCounter, 2);
+    assert.ok(messages.some((m) => m.includes('잠들어')));
+  });
+
+  it('sleeping pokemon wakes when counter reaches zero but still skips turn', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 1 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, null);
+    assert.equal(mon.sleepCounter, 0);
+    assert.ok(messages.some((m) => m.includes('깨어났다')));
+  });
+});
+
+describe('checkFreezeSkip', () => {
+  it('frozen pokemon skips when thaw roll fails', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as any;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      assert.equal(checkFreezeSkip(mon, move, messages), true);
+      assert.equal(mon.statusCondition, 'freeze');
+      assert.ok(messages.some((m) => m.includes('얼어붙어')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('frozen pokemon thaws on successful thaw roll', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as any;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.1;
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('exception moves can be used while frozen and thaw the user', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'scald' } } as any;
+    const messages: string[] = [];
+    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
+    assert.equal(checkFreezeSkip(mon, move, messages), false);
+    assert.equal(mon.statusCondition, null);
+    assert.ok(messages.some((m) => m.includes('녹았다')));
+  });
+});
+```
+
+- [ ] **Step 4: Run the focused unit suite**
+
+Run: `node --import tsx --test test/status-effects.test.ts`  
+Expected: PASS after the corresponding i18n keys exist
+
+### Task 3: i18n Messages
+
+**Files:**
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/ko.json`
+
+- [ ] **Step 1: Add English sleep/freeze keys**
+
+```json
+"status.sleep.inflicted": "{name} fell asleep!",
+"status.sleep.wake": "{name} woke up!",
+"status.sleep.still_asleep": "{name} is fast asleep!",
+"status.freeze.inflicted": "{name} was frozen solid!",
+"status.freeze.thawed": "{name} thawed out!",
+"status.freeze.still_frozen": "{name} is frozen solid!",
+"status.label.sleep": "SLP",
+"status.label.freeze": "FRZ",
+"status.name.sleep": "sleep",
+"status.name.freeze": "freeze"
+```
+
+- [ ] **Step 2: Add Korean sleep/freeze keys**
+
+```json
+"status.sleep.inflicted": "{name:은/는} 잠들었다!",
+"status.sleep.wake": "{name:은/는} 잠에서 깨어났다!",
+"status.sleep.still_asleep": "{name:은/는} 곤히 잠들어 있다!",
+"status.freeze.inflicted": "{name:은/는} 얼어붙었다!",
+"status.freeze.thawed": "{name:은/는} 얼음이 녹았다!",
+"status.freeze.still_frozen": "{name:은/는} 얼어붙어 움직일 수 없다!",
+"status.label.sleep": "수면",
+"status.label.freeze": "빙결",
+"status.name.sleep": "수면",
+"status.name.freeze": "빙결"
+```
+
+- [ ] **Step 3: Place the keys into the existing status section**
+
+Use the existing ordering style around:
+
+```json
+"status.paralysis.inflicted": "...",
+"status.burn.inflicted": "...",
+"status.poison.inflicted": "...",
+"status.badly_poisoned.inflicted": "...",
+"status.already": "...",
+"status.immune": "...",
+"status.fainted_by_status": "...",
+"status.name.burn": "...",
+"status.name.poison": "...",
+"status.name.paralysis": "...",
+"status.label.burn": "...",
+"status.label.poison": "...",
+"status.label.badly_poisoned": "...",
+"status.label.paralysis": "..."
+```
+
+- [ ] **Step 4: Validate JSON formatting**
+
+Run: `node -e "JSON.parse(require('node:fs').readFileSync('src/i18n/en.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/ko.json','utf8'))"`  
+Expected: no output, exit code 0
+
+### Task 4: Move Data
+
+**Files:**
+- Modify: `data/moves.json`
+
+- [ ] **Step 1: Add the missing sleep-inducing status moves**
+
+```json
+"47": {
+  "id": 47,
+  "name": "sing",
+  "nameKo": "노래하기",
+  "nameEn": "Sing",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 55,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"79": {
+  "id": 79,
+  "name": "sleep-powder",
+  "nameKo": "수면가루",
+  "nameEn": "Sleep Powder",
+  "type": "grass",
+  "category": "status",
+  "power": 0,
+  "accuracy": 75,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"95": {
+  "id": 95,
+  "name": "hypnosis",
+  "nameKo": "최면술",
+  "nameEn": "Hypnosis",
+  "type": "psychic",
+  "category": "status",
+  "power": 0,
+  "accuracy": 60,
+  "pp": 20,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"142": {
+  "id": 142,
+  "name": "lovely-kiss",
+  "nameKo": "악마의키스",
+  "nameEn": "Lovely Kiss",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 75,
+  "pp": 10,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"147": {
+  "id": 147,
+  "name": "spore",
+  "nameKo": "버섯포자",
+  "nameEn": "Spore",
+  "type": "grass",
+  "category": "status",
+  "power": 0,
+  "accuracy": 100,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+}
+```
+
+- [ ] **Step 2: Add freeze secondary effects to the existing ice attacks**
+
+```json
+"8": {
+  "id": 8,
+  "name": "ice-punch",
+  "nameKo": "냉동펀치",
+  "nameEn": "Ice Punch",
+  "type": "ice",
+  "category": "physical",
+  "power": 75,
+  "accuracy": 100,
+  "pp": 15,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"58": {
+  "id": 58,
+  "name": "ice-beam",
+  "nameKo": "냉동빔",
+  "nameEn": "Ice Beam",
+  "type": "ice",
+  "category": "special",
+  "power": 90,
+  "accuracy": 100,
+  "pp": 10,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"59": {
+  "id": 59,
+  "name": "blizzard",
+  "nameKo": "눈보라",
+  "nameEn": "Blizzard",
+  "type": "ice",
+  "category": "special",
+  "power": 110,
+  "accuracy": 70,
+  "pp": 5,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"181": {
+  "id": 181,
+  "name": "powder-snow",
+  "nameKo": "눈싸라기",
+  "nameEn": "Powder Snow",
+  "type": "ice",
+  "category": "special",
+  "power": 40,
+  "accuracy": 100,
+  "pp": 25,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"573": {
+  "id": 573,
+  "name": "freeze-dry",
+  "nameKo": "프리즈드라이",
+  "nameEn": "Freeze-Dry",
+  "type": "ice",
+  "category": "special",
+  "power": 70,
+  "accuracy": 100,
+  "pp": 20,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+- [ ] **Step 3: Do not add `yawn` in v3a**
+
+Keep `yawn` out of this file change. Delayed sleep belongs to a later version.
+
+- [ ] **Step 4: Validate the move JSON**
+
+Run: `node -e "JSON.parse(require('node:fs').readFileSync('data/moves.json','utf8'))"`  
+Expected: no output, exit code 0
+
+### Task 5: Battle Engine Integration
+
+**Files:**
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Update status helper imports in `src/core/turn-battle.ts`**
+
+```ts
+// src/core/turn-battle.ts
+import {
+  getParalysisSpeedMultiplier,
+  getBurnAttackMultiplier,
+  checkSleepSkip,
+  checkFreezeSkip,
+  checkParalysisSkip,
+  applyEndOfTurnEffects,
+  rollMoveEffect,
+} from './status-effects.js';
+```
+
+- [ ] **Step 2: Insert sleep/freeze checks before paralysis**
+
+```ts
+// src/core/turn-battle.ts — inside executeMove()
+  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkParalysisSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+```
+
+- [ ] **Step 3: Thaw frozen defenders before fire damage**
+
+```ts
+// src/core/turn-battle.ts — after moveTypeImmune is computed, before damage
+  if (
+    defender.statusCondition === 'freeze' &&
+    move.data.type === 'fire' &&
+    !moveTypeImmune
+  ) {
+    defender.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: defender.displayName }));
+  }
+
+  const damage = calculateDamage(attacker, defender, move);
+  defender.currentHp = Math.max(0, defender.currentHp - damage);
+```
+
+- [ ] **Step 4: Import `t` if it is not already available in this module**
+
+```ts
+// src/core/turn-battle.ts
+import { t } from '../i18n/index.js';
+```
+
+- [ ] **Step 5: Extend `makeTestPokemon()` and add targeted regression tests**
+
+```ts
+// test/turn-battle.test.ts
+describe('resolveTurn with status effects', () => {
+  it('sleep skips the turn without consuming PP', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 2,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.equal(player.sleepCounter, 1);
+  });
+
+  it('wake-up turn still skips the move', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 1,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.ok(result.messages.some((m) => m.includes('깨어났다')));
+  });
+
+  it('freeze skips the turn without consuming PP when thaw roll fails', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.moves[0].currentPp, 10);
+      assert.equal(player.statusCondition, 'freeze');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('freeze exception moves act normally and thaw the user', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{
+        data: makeMoveData({
+          name: 'scald',
+          nameKo: '열탕',
+          type: 'water',
+          category: 'special',
+          power: 80,
+          accuracy: 100,
+          pp: 15,
+        }),
+        currentPp: 15,
+      }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 14);
+  });
+
+  it('fire-type attacks thaw frozen defenders before damage', () => {
+    const player = makeTestPokemon({
+      displayName: 'Fire',
+      speed: 999,
+      moves: [{ data: makeFireMove({ power: 60 }), currentPp: 25 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Frozen Target',
+      types: ['grass'],
+      statusCondition: 'freeze' as StatusCondition,
+      currentHp: 100,
+    });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+    assert.ok(opp.currentHp < 100, 'Damage should still apply after thaw');
+    assert.ok(result.messages.some((m) => m.includes('녹았다')));
+  });
+
+  it('ice-type targets remain immune to freeze secondary effects', () => {
+    const effectMove = makeMoveData({ type: 'ice', category: 'special', power: 90 });
+    (effectMove as any).effect = { type: 'freeze', chance: 100 };
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      moves: [{ data: effectMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Ice Target',
+      types: ['ice'],
+      statusCondition: null,
+    });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+  });
+});
+```
+
+- [ ] **Step 6: Run the battle regression suite**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS after all i18n and status helper changes are in place
+
+### Task 6: Battle UI Update
+
+**Files:**
+- Modify: `src/battle-tui/renderer.ts`
+- Modify: `src/status-line.ts`
+
+- [ ] **Step 1: Extend the renderer color map**
+
+```ts
+// src/battle-tui/renderer.ts
+function statusLabel(mon: BattlePokemon): string {
+  if (!mon.statusCondition) return '';
+  const colors: Record<string, string> = {
+    burn: '\x1b[31m',
+    poison: '\x1b[35m',
+    badly_poisoned: '\x1b[35m',
+    paralysis: '\x1b[33m',
+    sleep: '\x1b[33m',
+    freeze: '\x1b[36m',
+  };
+  const color = colors[mon.statusCondition] || '';
+  const label = t(`status.label.${mon.statusCondition}`);
+  return `${color}[${label}]\x1b[0m`;
+}
+```
+
+- [ ] **Step 2: Extend the compact status badge map**
+
+```ts
+// src/status-line.ts
+const statusLabels: Record<string, string> = {
+  burn: '\x1b[31m[BRN]\x1b[0m',
+  poison: '\x1b[35m[PSN]\x1b[0m',
+  badly_poisoned: '\x1b[35m[TOX]\x1b[0m',
+  paralysis: '\x1b[33m[PRZ]\x1b[0m',
+  sleep: '\x1b[33m[SLP]\x1b[0m',
+  freeze: '\x1b[36m[FRZ]\x1b[0m',
+};
+```
+
+- [ ] **Step 3: Verify labels align with i18n**
+
+`renderer.ts` uses localized `status.label.*`; `status-line.ts` keeps the fixed compact battle abbreviations. Confirm both surfaces are intentional and unchanged for existing statuses.
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify: `src/core/types.ts`
+- Verify: `src/core/status-effects.ts`
+- Verify: `src/core/turn-battle.ts`
+- Verify: `src/i18n/en.json`
+- Verify: `src/i18n/ko.json`
+- Verify: `src/battle-tui/renderer.ts`
+- Verify: `src/status-line.ts`
+- Verify: `data/moves.json`
+- Verify: `test/status-effects.test.ts`
+- Verify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Run the status unit tests**
+
+Run: `node --import tsx --test test/status-effects.test.ts`  
+Expected: PASS
+
+- [ ] **Step 2: Run the battle engine regression tests**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS
+
+- [ ] **Step 3: Run the TypeScript checker**
+
+Run: `npx tsc --noEmit`  
+Expected: PASS
+
+- [ ] **Step 4: Re-validate JSON files**
+
+Run:
+
+```bash
+node -e "JSON.parse(require('node:fs').readFileSync('data/moves.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/en.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/ko.json','utf8'))"
+```
+
+Expected: no output, exit code 0
+
+- [ ] **Step 5: Spot-check move data and exception behavior**
+
+Run:
+
+```bash
+rg -n '"name": "(ice-beam|blizzard|ice-punch|powder-snow|freeze-dry|hypnosis|sing|spore|sleep-powder|lovely-kiss)"' data/moves.json
+```
+
+Expected: all ten move blocks present
+
+- [ ] **Step 6: Verify acceptance criteria explicitly**
+
+Checklist:
+
+- Sleep and freeze are in `StatusCondition`
+- `sleepCounter` exists everywhere a `BattlePokemon` is built
+- sleep applies with a `1..3` counter
+- wake turn still skips the move
+- freeze has 20% thaw
+- frozen exception moves thaw and act
+- fire hits thaw frozen defenders before damage
+- ice types are immune to freeze
+- five sleep moves exist in `moves.json`
+- five ice attacks have 10% freeze effects
+- UI labels exist for sleep and freeze
+- English and Korean i18n keys exist
+
+- [ ] **Step 7: Commit with a Lore-format message**
+
+```bash
+git add src/core/types.ts src/core/status-effects.ts src/core/turn-battle.ts src/i18n/en.json src/i18n/ko.json src/battle-tui/renderer.ts src/status-line.ts data/moves.json test/status-effects.test.ts test/turn-battle.test.ts
+git commit -m "Add sleep and freeze to complete the v2 non-volatile status set
+
+The battle engine already has a stable status-application and pre-move skip
+pipeline, so this change extends that path with sleep counters, freeze thaw
+rules, and the small set of frozen exception moves instead of adding a second
+status subsystem.
+
+Constraint: Must preserve the existing one-non-volatile-status invariant
+Constraint: Must not extend MoveData just to support frozen exception moves
+Rejected: Wake-and-act-on-zero sleep convention | introduces a free-action edge case into the current PP-skip invariant
+Confidence: high
+Scope-risk: moderate
+Directive: Keep sleep/freeze checks before PP consumption for chosen moves
+Tested: node --import tsx --test test/status-effects.test.ts
+Tested: node --import tsx --test test/turn-battle.test.ts
+Tested: npx tsc --noEmit
+Not-tested: interactive TUI rendering in a live gym battle"
+```
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-10-status-effects-v3a.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/src/battle-tui/renderer.ts
+++ b/src/battle-tui/renderer.ts
@@ -25,13 +25,15 @@ function padRight(text: string, width: number): string {
 
 function statusLabel(mon: BattlePokemon): string {
   if (!mon.statusCondition) return '';
-  const label = t(`status.label.${mon.statusCondition}`);
   const colors: Record<string, string> = {
     burn: '\x1b[31m',
     poison: '\x1b[35m',
     badly_poisoned: '\x1b[35m',
     paralysis: '\x1b[33m',
+    sleep: '\x1b[33m',
+    freeze: '\x1b[36m',
   };
+  const label = t(`status.label.${mon.statusCondition}`);
   const color = colors[mon.statusCondition] || '';
   return ` ${color}[${label}]${RESET}`;
 }

--- a/src/core/battle-state-io.ts
+++ b/src/core/battle-state-io.ts
@@ -38,9 +38,11 @@ export interface BattleStateFile {
 /**
  * Backfill status fields on a BattlePokemon parsed from an older save.
  * `statusCondition` and `toxicCounter` were added in status-effects-v2;
- * earlier battle-state.json files lack them. We normalize `undefined` to
- * the schema defaults so downstream checks (e.g. `statusCondition !== null`)
- * do not mistake a pre-status battle for "already has a status".
+ * `sleepCounter` was added in status-effects-v3a. Earlier battle-state.json
+ * files lack these. We normalize `undefined` to schema defaults so downstream
+ * checks (e.g. `statusCondition !== null`) do not mistake a pre-status battle
+ * for "already has a status", and so arithmetic on `sleepCounter` does not
+ * produce NaN (which would trap a sleeping mon in permanent sleep on resume).
  */
 export function normalizeBattlePokemon(mon: BattlePokemon): void {
   if (mon.statusCondition === undefined) {
@@ -48,6 +50,9 @@ export function normalizeBattlePokemon(mon: BattlePokemon): void {
   }
   if (mon.toxicCounter === undefined) {
     mon.toxicCounter = 0;
+  }
+  if (mon.sleepCounter === undefined || !Number.isFinite(mon.sleepCounter)) {
+    mon.sleepCounter = 0;
   }
 }
 

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -62,7 +62,11 @@ export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
 export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
   if (pokemon.statusCondition !== 'sleep') return false;
 
-  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+  // Harden against corrupted/legacy saves where sleepCounter may be
+  // undefined/NaN — treat non-finite counters as "wake up now" rather than
+  // trapping the mon in permanent sleep.
+  const current = Number.isFinite(pokemon.sleepCounter) ? pokemon.sleepCounter : 0;
+  pokemon.sleepCounter = Math.max(0, current - 1);
 
   if (pokemon.sleepCounter === 0) {
     pokemon.statusCondition = null;

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -14,6 +14,8 @@ export const FROZEN_EXCEPTION_MOVES = new Set([
   'flame-wheel',
   'sacred-fire',
   'scald',
+  'pyro-ball',
+  'matcha-gotcha',
   'flare-blitz',
   'steam-eruption',
   'burn-up',

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -1,12 +1,23 @@
 import { t } from '../i18n/index.js';
-import type { BattlePokemon, StatusCondition } from './types.js';
+import type { BattleMove, BattlePokemon, StatusCondition } from './types.js';
 
 const STATUS_IMMUNITIES: Record<StatusCondition, string[]> = {
   poison: ['poison', 'steel'],
   badly_poisoned: ['poison', 'steel'],
   burn: ['fire'],
   paralysis: ['electric'],
+  sleep: [],
+  freeze: ['ice'],
 };
+
+export const FROZEN_EXCEPTION_MOVES = new Set([
+  'flame-wheel',
+  'sacred-fire',
+  'scald',
+  'flare-blitz',
+  'steam-eruption',
+  'burn-up',
+]);
 
 export function isStatusImmune(pokemon: BattlePokemon, status: StatusCondition): boolean {
   const immuneTypes = STATUS_IMMUNITIES[status];
@@ -23,10 +34,19 @@ export function tryApplyStatus(target: BattlePokemon, status: StatusCondition, m
     messages.push(t('status.immune', { name: target.displayName }));
     return false;
   }
+
   target.statusCondition = status;
+
   if (status === 'badly_poisoned') {
     target.toxicCounter = 1;
   }
+
+  if (status === 'sleep') {
+    target.sleepCounter = Math.floor(Math.random() * 3) + 1;
+  } else {
+    target.sleepCounter = 0;
+  }
+
   messages.push(t(`status.${status}.inflicted`, { name: target.displayName }));
   return true;
 }
@@ -37,6 +57,44 @@ export function getParalysisSpeedMultiplier(pokemon: BattlePokemon): number {
 
 export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
   return pokemon.statusCondition === 'burn' ? 0.5 : 1.0;
+}
+
+export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'sleep') return false;
+
+  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+
+  if (pokemon.sleepCounter === 0) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.sleep.wake', { name: pokemon.displayName }));
+    return true;
+  }
+
+  messages.push(t('status.sleep.still_asleep', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkFreezeSkip(
+  pokemon: BattlePokemon,
+  move: BattleMove,
+  messages: string[],
+): boolean {
+  if (pokemon.statusCondition !== 'freeze') return false;
+
+  if (FROZEN_EXCEPTION_MOVES.has(move.data.name)) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  if (Math.random() < 0.2) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  messages.push(t('status.freeze.still_frozen', { name: pokemon.displayName }));
+  return true;
 }
 
 export function checkParalysisSkip(pokemon: BattlePokemon, messages: string[]): boolean {
@@ -66,6 +124,8 @@ export function applyEndOfTurnEffects(pokemon: BattlePokemon, messages: string[]
       pokemon.toxicCounter++;
       break;
     case 'paralysis':
+    case 'sleep':
+    case 'freeze':
       return false;
   }
   if (damage > 0) {

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -243,11 +243,14 @@ function executeMove(
     }
   }
 
-  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+  // Sleep and freeze are full incapacitation in mainline — they stop the turn
+  // even when Struggle would otherwise be forced. Paralysis is only a partial
+  // skip, so it keeps the Struggle bypass to preserve the no-PP invariant.
+  if (checkSleepSkip(attacker, messages)) {
     return { defenderFainted: false };
   }
 
-  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+  if (checkFreezeSkip(attacker, move, messages)) {
     return { defenderFainted: false };
   }
 
@@ -272,9 +275,13 @@ function executeMove(
   const effMsg = getEffectivenessMessage(move.data.type, defender.types);
   const moveTypeImmune = effMsg === 'effect_immune';
 
+  // Fire-type thaw: only damaging fire hits thaw the defender. A non-damaging
+  // fire status move (e.g. will-o-wisp) must not thaw a frozen target, or it
+  // would then apply a new burn status in the same action.
   if (
     defender.statusCondition === 'freeze' &&
     move.data.type === 'fire' &&
+    move.data.power > 0 &&
     !moveTypeImmune
   ) {
     defender.statusCondition = null;

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -1,3 +1,4 @@
+import { t } from '../i18n/index.js';
 import { getTypeEffectiveness } from './type-chart.js';
 import type {
   BaseStats,
@@ -12,6 +13,8 @@ import type {
 import {
   getParalysisSpeedMultiplier,
   getBurnAttackMultiplier,
+  checkSleepSkip,
+  checkFreezeSkip,
   checkParalysisSkip,
   applyEndOfTurnEffects,
   rollMoveEffect,
@@ -66,6 +69,7 @@ export function createBattlePokemon(
     fainted: false,
     statusCondition: null,
     toxicCounter: 0,
+    sleepCounter: 0,
   };
 }
 
@@ -239,9 +243,14 @@ function executeMove(
     }
   }
 
-  // Paralysis full-skip check — only applies to chosen moves, never to
-  // mandatory Struggle. This preserves the invariant that a no-PP turn always
-  // resolves through Struggle recoil.
+  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+    return { defenderFainted: false };
+  }
+
   if (!isStruggle && checkParalysisSkip(attacker, messages)) {
     return { defenderFainted: false };
   }
@@ -263,7 +272,15 @@ function executeMove(
   const effMsg = getEffectivenessMessage(move.data.type, defender.types);
   const moveTypeImmune = effMsg === 'effect_immune';
 
-  // Damage calculation
+  if (
+    defender.statusCondition === 'freeze' &&
+    move.data.type === 'fire' &&
+    !moveTypeImmune
+  ) {
+    defender.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: defender.displayName }));
+  }
+
   const damage = calculateDamage(attacker, defender, move);
   defender.currentHp = Math.max(0, defender.currentHp - damage);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -467,7 +467,13 @@ export interface StdinData {
 
 export type MoveCategory = 'physical' | 'special' | 'status';
 
-export type StatusCondition = 'burn' | 'poison' | 'badly_poisoned' | 'paralysis';
+export type StatusCondition =
+  | 'burn'
+  | 'poison'
+  | 'badly_poisoned'
+  | 'paralysis'
+  | 'sleep'
+  | 'freeze';
 
 export interface MoveData {
   id: number;
@@ -511,6 +517,7 @@ export interface BattlePokemon {
   fainted: boolean;
   statusCondition: StatusCondition | null;
   toxicCounter: number;
+  sleepCounter: number;
 }
 
 export interface BattleTeam {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -588,6 +588,12 @@
 
   "status.paralysis.inflicted": "{name} is paralyzed! It may be unable to move!",
   "status.paralysis.immobile": "{name} is paralyzed! It can't move!",
+  "status.sleep.inflicted": "{name} fell asleep!",
+  "status.sleep.wake": "{name} woke up!",
+  "status.sleep.still_asleep": "{name} is fast asleep!",
+  "status.freeze.inflicted": "{name} was frozen solid!",
+  "status.freeze.thawed": "{name} thawed out!",
+  "status.freeze.still_frozen": "{name} is frozen solid!",
   "status.burn.inflicted": "{name} was burned!",
   "status.burn.damage": "{name} is hurt by its burn!",
   "status.poison.inflicted": "{name} was poisoned!",
@@ -599,8 +605,12 @@
   "status.name.burn": "burn",
   "status.name.poison": "poison",
   "status.name.paralysis": "paralysis",
+  "status.name.sleep": "sleep",
+  "status.name.freeze": "freeze",
   "status.label.burn": "BRN",
   "status.label.poison": "PSN",
   "status.label.badly_poisoned": "TOX",
-  "status.label.paralysis": "PRZ"
+  "status.label.paralysis": "PRZ",
+  "status.label.sleep": "SLP",
+  "status.label.freeze": "FRZ"
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -588,6 +588,12 @@
 
   "status.paralysis.inflicted": "{name:은/는} 마비되었다!",
   "status.paralysis.immobile": "{name:은/는} 몸이 저려 움직일 수 없다!",
+  "status.sleep.inflicted": "{name:은/는} 잠들었다!",
+  "status.sleep.wake": "{name:은/는} 잠에서 깨어났다!",
+  "status.sleep.still_asleep": "{name:은/는} 곤히 잠들어 있다!",
+  "status.freeze.inflicted": "{name:은/는} 얼어붙었다!",
+  "status.freeze.thawed": "{name:은/는} 얼음이 녹았다!",
+  "status.freeze.still_frozen": "{name:은/는} 얼어붙어 움직일 수 없다!",
   "status.burn.inflicted": "{name:은/는} 화상을 입었다!",
   "status.burn.damage": "{name:은/는} 화상 데미지를 입었다!",
   "status.poison.inflicted": "{name:은/는} 독에 걸렸다!",
@@ -599,8 +605,12 @@
   "status.name.burn": "화상",
   "status.name.poison": "독",
   "status.name.paralysis": "마비",
+  "status.name.sleep": "수면",
+  "status.name.freeze": "빙결",
   "status.label.burn": "화상",
   "status.label.poison": "독",
   "status.label.badly_poisoned": "맹독",
-  "status.label.paralysis": "마비"
+  "status.label.paralysis": "마비",
+  "status.label.sleep": "수면",
+  "status.label.freeze": "빙결"
 }

--- a/src/status-line.ts
+++ b/src/status-line.ts
@@ -467,6 +467,8 @@ function renderBattleMode(battleData: {
     poison: '\x1b[35m[PSN]\x1b[0m',
     badly_poisoned: '\x1b[35m[TOX]\x1b[0m',
     paralysis: '\x1b[33m[PRZ]\x1b[0m',
+    sleep: '\x1b[33m[SLP]\x1b[0m',
+    freeze: '\x1b[36m[FRZ]\x1b[0m',
   };
   const oppStatusMark = oppMon.statusCondition ? ' ' + (statusLabels[oppMon.statusCondition] || '') : '';
   const playerStatusMark = playerMon.statusCondition ? ' ' + (statusLabels[playerMon.statusCondition] || '') : '';

--- a/test/battle-state-migration.test.ts
+++ b/test/battle-state-migration.test.ts
@@ -100,4 +100,44 @@ describe('battle state migration', () => {
     mon.statusCondition = 'burn';
     assert.equal(mon.statusCondition, 'burn');
   });
+
+  it('normalizeBattlePokemon backfills missing sleepCounter to 0 (v3a)', () => {
+    const mon = makeLegacyPokemon();
+    assert.equal((mon as any).sleepCounter, undefined);
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+  });
+
+  it('normalizeBattlePokemon coerces NaN/infinite sleepCounter to 0', () => {
+    const mon = makeLegacyPokemon();
+    mon.sleepCounter = NaN as unknown as number;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+
+    mon.sleepCounter = Infinity;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+  });
+
+  it('normalizeBattlePokemon preserves existing sleepCounter', () => {
+    const mon = makeLegacyPokemon();
+    mon.sleepCounter = 2;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 2);
+  });
+
+  it('resumed legacy sleeping mon can wake up without NaN soft-lock', async () => {
+    // Regression for v3a R2 finding: a legacy save with statusCondition='sleep'
+    // but sleepCounter=undefined would otherwise decrement to NaN and trap the
+    // mon in permanent sleep. After migration, the mon should wake up on the
+    // first checkSleepSkip call (counter 0 → wake).
+    const { checkSleepSkip } = await import('../src/core/status-effects.js');
+    const mon = makeLegacyPokemon();
+    mon.statusCondition = 'sleep';
+    normalizeBattlePokemon(mon);
+    const msgs: string[] = [];
+    const skipped = checkSleepSkip(mon, msgs);
+    assert.equal(skipped, true, 'Should skip this turn');
+    assert.equal(mon.statusCondition, null, 'Should wake up (not stuck in permanent sleep)');
+  });
 });

--- a/test/status-effects.test.ts
+++ b/test/status-effects.test.ts
@@ -1,10 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { initLocale } from '../src/i18n/index.js';
-import type { BattlePokemon, StatusCondition } from '../src/core/types.js';
+import type { BattleMove, BattlePokemon } from '../src/core/types.js';
 import {
-  isStatusImmune, tryApplyStatus, checkParalysisSkip,
-  getBurnAttackMultiplier, getParalysisSpeedMultiplier,
+  isStatusImmune,
+  tryApplyStatus,
+  checkParalysisSkip,
+  checkSleepSkip,
+  checkFreezeSkip,
+  FROZEN_EXCEPTION_MOVES,
+  getBurnAttackMultiplier,
+  getParalysisSpeedMultiplier,
   applyEndOfTurnEffects,
 } from '../src/core/status-effects.js';
 
@@ -15,7 +21,7 @@ function makePokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
     id: 1, name: '1', displayName: 'Test', types: ['normal'], level: 50,
     maxHp: 160, currentHp: 160, attack: 60, defense: 50, spAttack: 55,
     spDefense: 50, speed: 70, moves: [], fainted: false,
-    statusCondition: null, toxicCounter: 0, ...overrides,
+    statusCondition: null, toxicCounter: 0, sleepCounter: 0, ...overrides,
   };
 }
 
@@ -27,10 +33,16 @@ describe('isStatusImmune', () => {
   it('steel type NOT immune to burn', () => { assert.equal(isStatusImmune(makePokemon({ types: ['steel'] }), 'burn'), false); });
   it('fire type immune to burn', () => { assert.equal(isStatusImmune(makePokemon({ types: ['fire'] }), 'burn'), true); });
   it('electric type immune to paralysis', () => { assert.equal(isStatusImmune(makePokemon({ types: ['electric'] }), 'paralysis'), true); });
+  it('ice type immune to freeze', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['ice'] }), 'freeze'), true);
+  });
   it('normal type not immune', () => {
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'burn'), false);
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'poison'), false);
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'paralysis'), false);
+  });
+  it('normal type not immune to sleep', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'sleep'), false);
   });
   it('dual-type with immune type blocks', () => { assert.equal(isStatusImmune(makePokemon({ types: ['water', 'poison'] }), 'poison'), true); });
 });
@@ -57,6 +69,23 @@ describe('tryApplyStatus', () => {
     tryApplyStatus(mon, 'badly_poisoned', []);
     assert.equal(mon.statusCondition, 'badly_poisoned');
     assert.equal(mon.toxicCounter, 1);
+  });
+  it('inits sleepCounter for sleep in the 1..3 range', () => {
+    const mon = makePokemon();
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.6; // floor(1.8) + 1 = 2
+      assert.equal(tryApplyStatus(mon, 'sleep', []), true);
+      assert.equal(mon.statusCondition, 'sleep');
+      assert.equal(mon.sleepCounter, 2);
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+  it('blocks freeze on ice types', () => {
+    const mon = makePokemon({ types: ['ice'] });
+    assert.equal(tryApplyStatus(mon, 'freeze', []), false);
+    assert.equal(mon.statusCondition, null);
   });
   it('does not apply to fainted', () => {
     assert.equal(tryApplyStatus(makePokemon({ fainted: true }), 'burn', []), false);
@@ -118,5 +147,67 @@ describe('checkParalysisSkip', () => {
     let skips = 0;
     for (let i = 0; i < 1000; i++) if (checkParalysisSkip(mon, [])) skips++;
     assert.ok(skips > 150 && skips < 350, `Expected ~250 skips, got ${skips}`);
+  });
+});
+
+describe('checkSleepSkip', () => {
+  it('sleeping pokemon stays asleep when counter remains above zero', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 3 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, 'sleep');
+    assert.equal(mon.sleepCounter, 2);
+    assert.ok(messages.some((m) => m.includes('잠들어')));
+  });
+
+  it('sleeping pokemon wakes when counter reaches zero but still skips turn', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 1 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, null);
+    assert.equal(mon.sleepCounter, 0);
+    assert.ok(messages.some((m) => m.includes('깨어났다')));
+  });
+});
+
+describe('checkFreezeSkip', () => {
+  it('frozen pokemon skips when thaw roll fails', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as BattleMove;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      assert.equal(checkFreezeSkip(mon, move, messages), true);
+      assert.equal(mon.statusCondition, 'freeze');
+      assert.ok(messages.some((m) => m.includes('얼어붙어')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('frozen pokemon thaws on successful thaw roll', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as BattleMove;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.1;
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('exception moves can be used while frozen and thaw the user', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'scald' } } as BattleMove;
+    const messages: string[] = [];
+    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
+    assert.equal(checkFreezeSkip(mon, move, messages), false);
+    assert.equal(mon.statusCondition, null);
+    assert.ok(messages.some((m) => m.includes('녹았다')));
   });
 });

--- a/test/status-effects.test.ts
+++ b/test/status-effects.test.ts
@@ -202,12 +202,14 @@ describe('checkFreezeSkip', () => {
   });
 
   it('exception moves can be used while frozen and thaw the user', () => {
-    const mon = makePokemon({ statusCondition: 'freeze' });
-    const move = { data: { name: 'scald' } } as BattleMove;
-    const messages: string[] = [];
-    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
-    assert.equal(checkFreezeSkip(mon, move, messages), false);
-    assert.equal(mon.statusCondition, null);
-    assert.ok(messages.some((m) => m.includes('녹았다')));
+    for (const moveName of ['scald', 'pyro-ball', 'matcha-gotcha']) {
+      const mon = makePokemon({ statusCondition: 'freeze' });
+      const move = { data: { name: moveName } } as BattleMove;
+      const messages: string[] = [];
+      assert.ok(FROZEN_EXCEPTION_MOVES.has(moveName));
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    }
   });
 });

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -734,30 +734,38 @@ describe('resolveTurn with status effects', () => {
   });
 
   it('freeze exception moves act normally and thaw the user', () => {
-    const player = makeTestPokemon({
-      displayName: 'Frozen',
-      speed: 999,
-      statusCondition: 'freeze' as StatusCondition,
-      moves: [{
-        data: makeMoveData({
-          name: 'scald',
-          nameKo: '열탕',
-          type: 'water',
-          category: 'special',
-          power: 80,
-          accuracy: 100,
-          pp: 15,
-        }),
-        currentPp: 15,
-      }],
-    });
-    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
-    const state = createBattleState([player], [opp]);
+    const thawMoves = [
+      { name: 'scald', nameKo: '열탕', type: 'water', category: 'special' as const, power: 80, pp: 15 },
+      { name: 'pyro-ball', nameKo: '화염볼', type: 'fire', category: 'physical' as const, power: 120, pp: 5 },
+      { name: 'matcha-gotcha', nameKo: '말차고차', type: 'grass', category: 'special' as const, power: 80, pp: 15 },
+    ];
 
-    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+    for (const thawMove of thawMoves) {
+      const player = makeTestPokemon({
+        displayName: 'Frozen',
+        speed: 999,
+        statusCondition: 'freeze' as StatusCondition,
+        moves: [{
+          data: makeMoveData({
+            name: thawMove.name,
+            nameKo: thawMove.nameKo,
+            type: thawMove.type,
+            category: thawMove.category,
+            power: thawMove.power,
+            accuracy: 100,
+            pp: thawMove.pp,
+          }),
+          currentPp: thawMove.pp,
+        }],
+      });
+      const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+      const state = createBattleState([player], [opp]);
 
-    assert.equal(player.statusCondition, null);
-    assert.equal(player.moves[0].currentPp, 14);
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+      assert.equal(player.statusCondition, null, `${thawMove.name} should thaw the user`);
+      assert.equal(player.moves[0].currentPp, thawMove.pp - 1, `${thawMove.name} should consume PP`);
+    }
   });
 
   it('fire-type attacks thaw frozen defenders before damage', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -82,6 +82,7 @@ function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon 
     fainted: false,
     statusCondition: null,
     toxicCounter: 0,
+    sleepCounter: 0,
     ...overrides,
   };
 }
@@ -149,6 +150,23 @@ describe('createBattlePokemon', () => {
     );
     assert.equal(bp.spAttack, calculateStat(80, 50));
     assert.equal(bp.spDefense, calculateStat(70, 50));
+  });
+
+  it('initializes status counters to zero', () => {
+    const bp = createBattlePokemon(
+      {
+        id: 4,
+        types: ['fire'],
+        level: 50,
+        baseStats: { hp: 39, attack: 52, defense: 43, speed: 65 },
+        displayName: 'Charmander',
+      },
+      [makeMoveData()],
+    );
+
+    assert.equal(bp.statusCondition, null);
+    assert.equal(bp.toxicCounter, 0);
+    assert.equal(bp.sleepCounter, 0);
   });
 });
 
@@ -657,6 +675,130 @@ describe('resolveTurn with status effects', () => {
     } finally {
       Math.random = origRandom;
     }
+  });
+
+  it('sleep skips the turn without consuming PP', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 2,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.equal(player.sleepCounter, 1);
+  });
+
+  it('wake-up turn still skips the move', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 1,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.ok(result.messages.some((m) => m.includes('깨어났다')));
+  });
+
+  it('freeze skips the turn without consuming PP when thaw roll fails', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.moves[0].currentPp, 10);
+      assert.equal(player.statusCondition, 'freeze');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('freeze exception moves act normally and thaw the user', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{
+        data: makeMoveData({
+          name: 'scald',
+          nameKo: '열탕',
+          type: 'water',
+          category: 'special',
+          power: 80,
+          accuracy: 100,
+          pp: 15,
+        }),
+        currentPp: 15,
+      }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 14);
+  });
+
+  it('fire-type attacks thaw frozen defenders before damage', () => {
+    const player = makeTestPokemon({
+      displayName: 'Fire',
+      speed: 999,
+      moves: [{ data: makeFireMove({ power: 60 }), currentPp: 25 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Frozen Target',
+      types: ['grass'],
+      statusCondition: 'freeze' as StatusCondition,
+      currentHp: 100,
+    });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+    assert.ok(opp.currentHp < 100, 'Damage should still apply after thaw');
+    assert.ok(result.messages.some((m) => m.includes('녹았다')));
+  });
+
+  it('ice-type targets remain immune to freeze secondary effects', () => {
+    const effectMove = makeMoveData({ type: 'ice', category: 'special', power: 90 });
+    (effectMove as any).effect = { type: 'freeze', chance: 100 };
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      moves: [{ data: effectMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Ice Target',
+      types: ['ice'],
+      statusCondition: null,
+    });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
   });
 
   it('simultaneous end-of-turn double KO results in opponent win (player loses)', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -858,4 +858,114 @@ describe('resolveTurn with status effects', () => {
     assert.equal(player.fainted, false, 'Player should not faint from post-turn burn tick after battle decided');
     assert.equal(state.phase, 'battle_end');
   });
+
+  it('sleep blocks Struggle turn (no-PP asleep pokemon cannot act)', () => {
+    // Sleep must consume the turn even when the attacker has no PP and would
+    // otherwise be forced into Struggle. Assertion: opponent took no damage
+    // from the sleeper, proving the sleeper never acted.
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      toxicCounter: 0,
+      sleepCounter: 3,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    // Opponent has no usable moves either — guarantees opp does NOT attack
+    // the sleeper, so sleeper's HP should remain at maxHp (no opp damage, no
+    // struggle recoil on the sleeper side because sleeper never acted).
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      speed: 1,
+      statusCondition: 'sleep' as StatusCondition,
+      toxicCounter: 0,
+      sleepCounter: 3,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+    // Neither mon should take damage — both were asleep and blocked from acting.
+    assert.equal(player.currentHp, player.maxHp, 'Sleeper should not take struggle recoil');
+    assert.equal(opp.currentHp, opp.maxHp, 'Neither mon should have dealt damage');
+    assert.ok(
+      result.messages.some((m) => m.includes('잠') || m.toLowerCase().includes('sleep')),
+      `Expected sleep message, got: ${JSON.stringify(result.messages)}`,
+    );
+  });
+
+  it('freeze blocks Struggle turn (no-PP frozen pokemon cannot act)', () => {
+    // Freeze must consume the turn even when Struggle would be forced.
+    // Pin Math.random to 0.9 so thaw roll (<0.2) never fires.
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    // Opponent also frozen with no PP — so neither side should act
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      speed: 1,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.currentHp, player.maxHp, 'Neither mon should have taken damage');
+      assert.equal(opp.currentHp, opp.maxHp, 'Neither mon should have dealt damage');
+      assert.equal(player.statusCondition, 'freeze', 'Player should still be frozen');
+      assert.equal(opp.statusCondition, 'freeze', 'Opponent should still be frozen');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('will-o-wisp does not thaw a frozen defender (non-damaging fire status)', () => {
+    // Regression: a non-damaging fire move must not thaw a frozen target and
+    // then apply a new burn in the same action. Pin Math.random to 0.5 so
+    // the defender's own thaw roll (<0.2) does not fire.
+    const wow = makeMoveData({ type: 'fire', category: 'physical', power: 0, accuracy: 85 });
+    (wow as any).effect = { type: 'burn', chance: 100 };
+    const player = makeTestPokemon({ displayName: 'P', speed: 999, statusCondition: null, toxicCounter: 0, moves: [{ data: wow, currentPp: 10 }] });
+    // Opponent is frozen, has no PP (so they would Struggle but sleep/freeze
+    // check fires first). Types set to water so fire is not immune.
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      types: ['water'],
+      speed: 1,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.5;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(opp.statusCondition, 'freeze', 'Freeze should not be cleared by non-damaging fire move');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('damaging fire move (flamethrower) still thaws a frozen defender', () => {
+    const flamethrower = makeMoveData({ type: 'fire', category: 'special', power: 90 });
+    const player = makeTestPokemon({ displayName: 'P', speed: 999, statusCondition: null, toxicCounter: 0, moves: [{ data: flamethrower, currentPp: 10 }] });
+    const opp = makeTestPokemon({ displayName: 'O', types: ['water'], statusCondition: 'freeze' as StatusCondition, toxicCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(opp.statusCondition, null, 'Frozen defender should be thawed by damaging fire move');
+      assert.ok(opp.currentHp < opp.maxHp, 'Damage should still apply');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- v2의 non-volatile 상태이상 시스템을 **수면(Sleep)**과 **얼음(Freeze)**으로 확장
- 본가 충실 메카닉 + 예외 기술(flame-wheel, sacred-fire, scald, flare-blitz, steam-eruption, burn-up)
- 5개 신규 수면 기술 + 5개 기존 얼음 기술에 부가효과
- 레거시 save migration + 3 rounds adversarial review 통과
- 3 commits / 967 tests / 0 tsc errors

## Mechanics

### Sleep (수면)
- `sleepCounter` 1~3 랜덤 초기화
- 매 턴 decrement, 0이 되면 깨어남
- 타입 면역 없음

### Freeze (얼음)
- 20% 매턴 해제 확률
- **Damaging fire 공격 적중 시** 해제 후 데미지 (non-damaging 불꽃 기술은 해제 안 함)
- Ice 타입 면역
- 예외 기술 6종은 얼음 상태에서도 사용 가능 (flame-wheel, sacred-fire, scald, flare-blitz, steam-eruption, burn-up)

## Implementation
- **Types**: StatusCondition에 'sleep'|'freeze' 추가, BattlePokemon에 sleepCounter 필드
- **Status module**: checkSleepSkip, checkFreezeSkip, FROZEN_EXCEPTION_MOVES Set
- **Move data**: hypnosis/sing/spore/sleep-powder/lovely-kiss 신규 + ice-beam/blizzard/ice-punch/powder-snow/freeze-dry에 freeze 10% 부가효과
- **Engine**: executeMove에 sleep/freeze skip check, 불꽃 damage thaw 로직
- **Migration**: normalizeBattlePokemon이 sleepCounter 백필 (undefined/NaN → 0)
- **UI**: [SLP] (yellow) / [FRZ] (cyan) 라벨 TUI + status bar
- **i18n**: en/ko 상태 메시지

## Adversarial review fixes (3 rounds)
- **R1**:
  - Sleep/freeze가 Struggle 턴도 스킵하도록 수정 (이전엔 no-PP 시 Struggle 우회)
  - 불꽃 해제 로직을 damaging 기술에만 적용 (will-o-wisp가 얼음 해제 후 화상 거는 중복 효과 버그 수정)
- **R2**: 레거시 battle-state.json에 sleepCounter 필드 없어서 NaN으로 인한 영구 수면 soft-lock 버그 수정
- **R3**: Codex **APPROVE** — no material findings

## Test plan
- [x] 967 tests passing (v2 대비 +24 신규)
- [x] TypeScript clean (\`tsc --noEmit\`)
- [x] Codex adversarial review approved (3 rounds)
- [ ] Manual smoke: 체육관 배틀에서 수면/얼음 확인
- [ ] Manual smoke: Flamethrower vs 얼음 해제 확인
- [ ] Manual smoke: Will-o-wisp vs 얼음 defender (해제 안 되어야 함)