### PR TITLE
fix: round PP bar percentages to whole numbers

### DIFF
--- a/src/core/pp.ts
+++ b/src/core/pp.ts
@@ -6,6 +6,7 @@ export function ppBar(stdinData: StdinData, blocks: number = 6): string | null {
   if (!fiveHour || !Number.isFinite(fiveHour.used_percentage)) return null;
 
   const remaining = Math.max(0, Math.min(100, 100 - fiveHour.used_percentage));
+  const displayRemaining = Math.round(remaining);
   const filled = Math.min(blocks, Math.round(remaining / 100 * blocks));
   const empty = blocks - filled;
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(empty);
@@ -28,5 +29,5 @@ export function ppBar(stdinData: StdinData, blocks: number = 6): string | null {
   }
 
   const label = t('statusline.pp_label');
-  return `${label}[${bar}] ${remaining}%${timeStr}`;
+  return `${label}[${bar}] ${displayRemaining}%${timeStr}`;
 }

--- a/test/pp-bar.test.ts
+++ b/test/pp-bar.test.ts
@@ -143,4 +143,29 @@ describe('ppBar', () => {
     assert.ok(result.includes('(~2h)'));
     assert.ok(!result.includes('2h0m'));
   });
+
+  it('rounds displayed percentage to a whole number for fractional remaining values', () => {
+    const data: StdinData = {
+      rate_limits: {
+        five_hour: { used_percentage: 12.34567, resets_at: 0 },
+      },
+    };
+    const result = ppBar(data);
+    assert.ok(result);
+    assert.ok(result.includes('88%'));
+    assert.ok(!result.includes('87.65433%'));
+    assert.ok(!/\d+\.\d+%/.test(result));
+  });
+
+  it('never emits scientific notation for near-zero remaining percentages', () => {
+    const data: StdinData = {
+      rate_limits: {
+        five_hour: { used_percentage: 99.999999, resets_at: 0 },
+      },
+    };
+    const result = ppBar(data);
+    assert.ok(result);
+    assert.ok(result.includes('0%'));
+    assert.ok(!/[eE][+-]?\d+%/.test(result));
+  });
 });


### PR DESCRIPTION
## Summary
- round the displayed PP bar percentage to a whole number
- preserve the existing bar-fill math so only the text output changes
- add regression tests for decimal and scientific-notation edge cases

## Testing
- node --import tsx --test test/pp-bar.test.ts
- npm run typecheck
- npm run build
- npm test