### PR TITLE
feat(battle): 상태이상 v3b — 능력변화 시스템

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -67,7 +67,11 @@
     "category": "physical",
     "power": 75,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "9": {
     "id": 9,
@@ -385,6 +389,21 @@
     "accuracy": 100,
     "pp": 25
   },
+  "47": {
+    "id": 47,
+    "name": "sing",
+    "nameKo": "노래하기",
+    "nameEn": "Sing",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 55,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "51": {
     "id": 51,
     "name": "acid",
@@ -468,7 +487,11 @@
     "category": "special",
     "power": 90,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "59": {
     "id": 59,
@@ -479,7 +502,11 @@
     "category": "special",
     "power": 110,
     "accuracy": 70,
-    "pp": 5
+    "pp": 5,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "60": {
     "id": 60,
@@ -654,6 +681,21 @@
       "chance": 100
     }
   },
+  "79": {
+    "id": 79,
+    "name": "sleep-powder",
+    "nameKo": "수면가루",
+    "nameEn": "Sleep Powder",
+    "type": "grass",
+    "category": "status",
+    "power": 0,
+    "accuracy": 75,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "80": {
     "id": 80,
     "name": "petal-dance",
@@ -790,6 +832,21 @@
     "power": 90,
     "accuracy": 100,
     "pp": 10
+  },
+  "95": {
+    "id": 95,
+    "name": "hypnosis",
+    "nameKo": "최면술",
+    "nameEn": "Hypnosis",
+    "type": "psychic",
+    "category": "status",
+    "power": 0,
+    "accuracy": 60,
+    "pp": 20,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
   },
   "98": {
     "id": 98,
@@ -1004,6 +1061,21 @@
     "accuracy": 100,
     "pp": 10
   },
+  "142": {
+    "id": 142,
+    "name": "lovely-kiss",
+    "nameKo": "악마의키스",
+    "nameEn": "Lovely Kiss",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 75,
+    "pp": 10,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
+  },
   "143": {
     "id": 143,
     "name": "sky-attack",
@@ -1047,6 +1119,21 @@
     "power": 70,
     "accuracy": 100,
     "pp": 10
+  },
+  "147": {
+    "id": 147,
+    "name": "spore",
+    "nameKo": "버섯포자",
+    "nameEn": "Spore",
+    "type": "grass",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 15,
+    "effect": {
+      "type": "sleep",
+      "chance": 100
+    }
   },
   "150": {
     "id": 150,
@@ -1211,7 +1298,11 @@
     "category": "special",
     "power": 40,
     "accuracy": 100,
-    "pp": 25
+    "pp": 25,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "182": {
     "id": 182,
@@ -3476,7 +3567,11 @@
     "category": "special",
     "power": 70,
     "accuracy": 100,
-    "pp": 20
+    "pp": 20,
+    "effect": {
+      "type": "freeze",
+      "chance": 10
+    }
   },
   "574": {
     "id": 574,

--- a/data/moves.json
+++ b/data/moves.json
@@ -121,6 +121,20 @@
     "accuracy": 100,
     "pp": 10
   },
+  "14": {
+    "id": 14,
+    "name": "swords-dance",
+    "nameKo": "칼춤",
+    "nameEn": "Swords Dance",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 20,
+    "statChanges": [
+      { "target": "self", "stat": "attack", "stages": 2, "chance": 100 }
+    ]
+  },
   "16": {
     "id": 16,
     "name": "gust",
@@ -345,6 +359,20 @@
     "accuracy": 100,
     "pp": 15
   },
+  "39": {
+    "id": 39,
+    "name": "tail-whip",
+    "nameKo": "꼬리흔들기",
+    "nameEn": "Tail Whip",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 30,
+    "statChanges": [
+      { "target": "opponent", "stat": "defense", "stages": -1, "chance": 100 }
+    ]
+  },
   "40": {
     "id": 40,
     "name": "poison-sting",
@@ -378,6 +406,20 @@
     "accuracy": 95,
     "pp": 20
   },
+  "43": {
+    "id": 43,
+    "name": "leer",
+    "nameKo": "째려보기",
+    "nameEn": "Leer",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 30,
+    "statChanges": [
+      { "target": "opponent", "stat": "defense", "stages": -1, "chance": 100 }
+    ]
+  },
   "44": {
     "id": 44,
     "name": "bite",
@@ -388,6 +430,20 @@
     "power": 60,
     "accuracy": 100,
     "pp": 25
+  },
+  "45": {
+    "id": 45,
+    "name": "growl",
+    "nameKo": "울음소리",
+    "nameEn": "Growl",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 40,
+    "statChanges": [
+      { "target": "opponent", "stat": "attack", "stages": -1, "chance": 100 }
+    ]
   },
   "47": {
     "id": 47,
@@ -539,7 +595,10 @@
     "category": "special",
     "power": 65,
     "accuracy": 100,
-    "pp": 20
+    "pp": 20,
+    "statChanges": [
+      { "target": "opponent", "stat": "attack", "stages": -1, "chance": 10 }
+    ]
   },
   "63": {
     "id": 63,
@@ -707,6 +766,20 @@
     "accuracy": 100,
     "pp": 10
   },
+  "81": {
+    "id": 81,
+    "name": "string-shot",
+    "nameKo": "실뿜기",
+    "nameEn": "String Shot",
+    "type": "bug",
+    "category": "status",
+    "power": 0,
+    "accuracy": 95,
+    "pp": 40,
+    "statChanges": [
+      { "target": "opponent", "stat": "speed", "stages": -1, "chance": 100 }
+    ]
+  },
   "84": {
     "id": 84,
     "name": "thunder-shock",
@@ -831,7 +904,10 @@
     "category": "special",
     "power": 90,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "statChanges": [
+      { "target": "opponent", "stat": "spDefense", "stages": -1, "chance": 10 }
+    ]
   },
   "95": {
     "id": 95,
@@ -847,6 +923,20 @@
       "type": "sleep",
       "chance": 100
     }
+  },
+  "97": {
+    "id": 97,
+    "name": "agility",
+    "nameKo": "고속이동",
+    "nameEn": "Agility",
+    "type": "psychic",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 30,
+    "statChanges": [
+      { "target": "self", "stat": "speed", "stages": 2, "chance": 100 }
+    ]
   },
   "98": {
     "id": 98,
@@ -869,6 +959,20 @@
     "power": 0,
     "accuracy": null,
     "pp": 20
+  },
+  "103": {
+    "id": 103,
+    "name": "screech",
+    "nameKo": "싫은소리",
+    "nameEn": "Screech",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 85,
+    "pp": 40,
+    "statChanges": [
+      { "target": "opponent", "stat": "defense", "stages": -2, "chance": 100 }
+    ]
   },
   "105": {
     "id": 105,
@@ -1326,6 +1430,20 @@
     "accuracy": 100,
     "pp": 30
   },
+  "184": {
+    "id": 184,
+    "name": "scary-face",
+    "nameKo": "무서운얼굴",
+    "nameEn": "Scary Face",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 10,
+    "statChanges": [
+      { "target": "opponent", "stat": "speed", "stages": -2, "chance": 100 }
+    ]
+  },
   "185": {
     "id": 185,
     "name": "feint-attack",
@@ -1405,7 +1523,10 @@
     "category": "special",
     "power": 55,
     "accuracy": 95,
-    "pp": 15
+    "pp": 15,
+    "statChanges": [
+      { "target": "opponent", "stat": "speed", "stages": -1, "chance": 100 }
+    ]
   },
   "198": {
     "id": 198,
@@ -1439,6 +1560,20 @@
     "power": 75,
     "accuracy": 100,
     "pp": 10
+  },
+  "204": {
+    "id": 204,
+    "name": "charm",
+    "nameKo": "애교부리기",
+    "nameEn": "Charm",
+    "type": "fairy",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 20,
+    "statChanges": [
+      { "target": "opponent", "stat": "attack", "stages": -2, "chance": 100 }
+    ]
   },
   "205": {
     "id": 205,
@@ -1554,6 +1689,20 @@
     "accuracy": 100,
     "pp": 40
   },
+  "230": {
+    "id": 230,
+    "name": "sweet-scent",
+    "nameKo": "달콤한향기",
+    "nameEn": "Sweet Scent",
+    "type": "normal",
+    "category": "status",
+    "power": 0,
+    "accuracy": 100,
+    "pp": 20,
+    "statChanges": [
+      { "target": "opponent", "stat": "evasion", "stages": -2, "chance": 100 }
+    ]
+  },
   "231": {
     "id": 231,
     "name": "iron-tail",
@@ -1629,7 +1778,10 @@
     "category": "physical",
     "power": 80,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "statChanges": [
+      { "target": "opponent", "stat": "defense", "stages": -1, "chance": 20 }
+    ]
   },
   "245": {
     "id": 245,
@@ -1662,7 +1814,10 @@
     "category": "special",
     "power": 80,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "statChanges": [
+      { "target": "opponent", "stat": "spDefense", "stages": -1, "chance": 20 }
+    ]
   },
   "248": {
     "id": 248,
@@ -1684,7 +1839,10 @@
     "category": "physical",
     "power": 40,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "statChanges": [
+      { "target": "opponent", "stat": "defense", "stages": -1, "chance": 50 }
+    ]
   },
   "250": {
     "id": 250,
@@ -2108,6 +2266,20 @@
     "accuracy": null,
     "pp": 20
   },
+  "334": {
+    "id": 334,
+    "name": "iron-defense",
+    "nameKo": "철벽",
+    "nameEn": "Iron Defense",
+    "type": "steel",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 15,
+    "statChanges": [
+      { "target": "self", "stat": "defense", "stages": 2, "chance": 100 }
+    ]
+  },
   "337": {
     "id": 337,
     "name": "dragon-claw",
@@ -2163,6 +2335,21 @@
     "accuracy": null,
     "pp": 20
   },
+  "347": {
+    "id": 347,
+    "name": "calm-mind",
+    "nameKo": "명상",
+    "nameEn": "Calm Mind",
+    "type": "psychic",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 20,
+    "statChanges": [
+      { "target": "self", "stat": "spAttack", "stages": 1, "chance": 100 },
+      { "target": "self", "stat": "spDefense", "stages": 1, "chance": 100 }
+    ]
+  },
   "348": {
     "id": 348,
     "name": "leaf-blade",
@@ -2173,6 +2360,21 @@
     "power": 90,
     "accuracy": 100,
     "pp": 15
+  },
+  "349": {
+    "id": 349,
+    "name": "dragon-dance",
+    "nameKo": "용의춤",
+    "nameEn": "Dragon Dance",
+    "type": "dragon",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 20,
+    "statChanges": [
+      { "target": "self", "stat": "attack", "stages": 1, "chance": 100 },
+      { "target": "self", "stat": "speed", "stages": 1, "chance": 100 }
+    ]
   },
   "350": {
     "id": 350,
@@ -2429,7 +2631,8 @@
     "category": "physical",
     "power": 80,
     "accuracy": 100,
-    "pp": 15
+    "pp": 15,
+    "statChanges": []
   },
   "403": {
     "id": 403,
@@ -2462,7 +2665,10 @@
     "category": "special",
     "power": 90,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "statChanges": [
+      { "target": "opponent", "stat": "spDefense", "stages": -1, "chance": 10 }
+    ]
   },
   "406": {
     "id": 406,
@@ -2562,6 +2768,20 @@
     "power": 150,
     "accuracy": 90,
     "pp": 5
+  },
+  "417": {
+    "id": 417,
+    "name": "nasty-plot",
+    "nameKo": "나쁜음모",
+    "nameEn": "Nasty Plot",
+    "type": "dark",
+    "category": "status",
+    "power": 0,
+    "accuracy": null,
+    "pp": 20,
+    "statChanges": [
+      { "target": "self", "stat": "spAttack", "stages": 2, "chance": 100 }
+    ]
   },
   "418": {
     "id": 418,
@@ -2693,7 +2913,10 @@
     "category": "special",
     "power": 80,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "statChanges": [
+      { "target": "opponent", "stat": "spDefense", "stages": -1, "chance": 10 }
+    ]
   },
   "431": {
     "id": 431,
@@ -3068,7 +3291,10 @@
     "category": "special",
     "power": 40,
     "accuracy": 100,
-    "pp": 20
+    "pp": 20,
+    "statChanges": [
+      { "target": "opponent", "stat": "spDefense", "stages": -2, "chance": 100 }
+    ]
   },
   "492": {
     "id": 492,
@@ -3659,7 +3885,10 @@
     "category": "special",
     "power": 75,
     "accuracy": 100,
-    "pp": 10
+    "pp": 10,
+    "statChanges": [
+      { "target": "opponent", "stat": "spAttack", "stages": -1, "chance": 100 }
+    ]
   },
   "605": {
     "id": 605,

--- a/docs/superpowers/plans/2026-04-10-status-effects-v3a.md
+++ b/docs/superpowers/plans/2026-04-10-status-effects-v3a.md
@@ -1,0 +1,1044 @@
+# Status Effects v3a Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Sleep and Freeze to the existing v2 Tokenmon battle status system, including engine rules, move data, UI labels, i18n, and regression tests.
+
+**Architecture:** Extend the existing v2 non-volatile status pipeline instead of introducing a new subsystem. Sleep and freeze remain pure `statusCondition`-driven effects, with `sleepCounter` stored on `BattlePokemon`, pre-move skip helpers in `src/core/status-effects.ts`, and narrow battle-engine integration inside `executeMove()`.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, JSON move data, existing i18n JSON dictionaries, battle TUI renderer.
+
+---
+
+## File Map
+
+- `src/core/types.ts`: status union + `BattlePokemon.sleepCounter`
+- `src/core/status-effects.ts`: sleep/freeze rules, immunities, exception moves, status application helpers
+- `src/core/turn-battle.ts`: pre-move sleep/freeze integration and fire-thaw battle flow
+- `src/core/gym-ai.ts`: confirm no heuristic change is needed
+- `src/i18n/en.json`: English messages and labels
+- `src/i18n/ko.json`: Korean messages and labels
+- `src/battle-tui/renderer.ts`: battle log status color rendering
+- `src/status-line.ts`: compact status badges
+- `data/moves.json`: new sleep moves + freeze secondary effects
+- `test/status-effects.test.ts`: unit coverage for sleep/freeze helpers
+- `test/turn-battle.test.ts`: battle-flow regressions
+
+### Task 1: Extend Types
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Extend `StatusCondition` in `src/core/types.ts`**
+
+```ts
+// src/core/types.ts
+export type StatusCondition =
+  | 'burn'
+  | 'poison'
+  | 'badly_poisoned'
+  | 'paralysis'
+  | 'sleep'
+  | 'freeze';
+```
+
+- [ ] **Step 2: Extend `BattlePokemon` with `sleepCounter`**
+
+```ts
+// src/core/types.ts
+export interface BattlePokemon {
+  id: number;
+  name: string;
+  displayName: string;
+  types: string[];
+  level: number;
+  maxHp: number;
+  currentHp: number;
+  attack: number;
+  defense: number;
+  spAttack: number;
+  spDefense: number;
+  speed: number;
+  moves: BattleMove[];
+  fainted: boolean;
+  statusCondition: StatusCondition | null;
+  toxicCounter: number;
+  sleepCounter: number;
+}
+```
+
+- [ ] **Step 3: Initialize `sleepCounter` in `createBattlePokemon()`**
+
+```ts
+// src/core/turn-battle.ts
+export function createBattlePokemon(
+  input: CreateBattlePokemonInput,
+  moves: MoveData[],
+): BattlePokemon {
+  const { id, types, level, baseStats } = input;
+  const maxHp = calculateHp(baseStats.hp, level);
+
+  const spAttackBase = baseStats.sp_attack ?? baseStats.attack;
+  const spDefenseBase = baseStats.sp_defense ?? baseStats.defense;
+
+  return {
+    id,
+    name: String(id),
+    displayName: input.displayName ?? String(id),
+    types,
+    level,
+    maxHp,
+    currentHp: maxHp,
+    attack: calculateStat(baseStats.attack, level),
+    defense: calculateStat(baseStats.defense, level),
+    spAttack: calculateStat(spAttackBase, level),
+    spDefense: calculateStat(spDefenseBase, level),
+    speed: calculateStat(baseStats.speed, level),
+    moves: moves.map((m) => ({ data: m, currentPp: m.pp })),
+    fainted: false,
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+  };
+}
+```
+
+- [ ] **Step 4: Update `makeTestPokemon()` to include `sleepCounter`**
+
+```ts
+// test/turn-battle.test.ts
+function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
+  return {
+    id: 1,
+    name: '1',
+    displayName: 'Attacker',
+    types: ['normal'],
+    level: 50,
+    maxHp: 120,
+    currentHp: 120,
+    attack: 60,
+    defense: 50,
+    spAttack: 55,
+    spDefense: 50,
+    speed: 70,
+    moves: [{ data: makeMoveData(), currentPp: 35 }],
+    fainted: false,
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Add type-level regression tests for the new default field**
+
+```ts
+// test/turn-battle.test.ts
+describe('createBattlePokemon', () => {
+  it('initializes status counters to zero', () => {
+    const bp = createBattlePokemon(
+      {
+        id: 4,
+        types: ['fire'],
+        level: 50,
+        baseStats: { hp: 39, attack: 52, defense: 43, speed: 65 },
+        displayName: 'Charmander',
+      },
+      [makeMoveData()],
+    );
+
+    assert.equal(bp.statusCondition, null);
+    assert.equal(bp.toxicCounter, 0);
+    assert.equal(bp.sleepCounter, 0);
+  });
+});
+```
+
+- [ ] **Step 6: Run the focused tests**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS after the remaining plan tasks are complete
+
+### Task 2: Status Effects Module Updates
+
+**Files:**
+- Modify: `src/core/status-effects.ts`
+- Modify: `test/status-effects.test.ts`
+
+- [ ] **Step 1: Replace `src/core/status-effects.ts` with the full updated implementation**
+
+```ts
+// src/core/status-effects.ts
+import { t } from '../i18n/index.js';
+import type { BattleMove, BattlePokemon, StatusCondition } from './types.js';
+
+const STATUS_IMMUNITIES: Record<StatusCondition, string[]> = {
+  poison: ['poison', 'steel'],
+  badly_poisoned: ['poison', 'steel'],
+  burn: ['fire'],
+  paralysis: ['electric'],
+  sleep: [],
+  freeze: ['ice'],
+};
+
+export const FROZEN_EXCEPTION_MOVES = new Set([
+  'flame-wheel',
+  'sacred-fire',
+  'scald',
+  'flare-blitz',
+  'steam-eruption',
+  'burn-up',
+]);
+
+export function isStatusImmune(pokemon: BattlePokemon, status: StatusCondition): boolean {
+  const immuneTypes = STATUS_IMMUNITIES[status];
+  return pokemon.types.some((type) => immuneTypes.includes(type));
+}
+
+export function tryApplyStatus(target: BattlePokemon, status: StatusCondition, messages: string[]): boolean {
+  if (target.fainted) return false;
+  if (target.statusCondition !== null) {
+    messages.push(t('status.already', { name: target.displayName }));
+    return false;
+  }
+  if (isStatusImmune(target, status)) {
+    messages.push(t('status.immune', { name: target.displayName }));
+    return false;
+  }
+
+  target.statusCondition = status;
+
+  if (status === 'badly_poisoned') {
+    target.toxicCounter = 1;
+  }
+
+  if (status === 'sleep') {
+    target.sleepCounter = Math.floor(Math.random() * 3) + 1;
+  } else {
+    target.sleepCounter = 0;
+  }
+
+  messages.push(t(`status.${status}.inflicted`, { name: target.displayName }));
+  return true;
+}
+
+export function getParalysisSpeedMultiplier(pokemon: BattlePokemon): number {
+  return pokemon.statusCondition === 'paralysis' ? 0.5 : 1.0;
+}
+
+export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
+  return pokemon.statusCondition === 'burn' ? 0.5 : 1.0;
+}
+
+export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'sleep') return false;
+
+  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+
+  if (pokemon.sleepCounter === 0) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.sleep.wake', { name: pokemon.displayName }));
+    return true;
+  }
+
+  messages.push(t('status.sleep.still_asleep', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkFreezeSkip(
+  pokemon: BattlePokemon,
+  move: BattleMove,
+  messages: string[],
+): boolean {
+  if (pokemon.statusCondition !== 'freeze') return false;
+
+  if (FROZEN_EXCEPTION_MOVES.has(move.data.name)) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  if (Math.random() < 0.2) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  messages.push(t('status.freeze.still_frozen', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkParalysisSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'paralysis') return false;
+  if (Math.random() < 0.25) {
+    messages.push(t('status.paralysis.immobile', { name: pokemon.displayName }));
+    return true;
+  }
+  return false;
+}
+
+export function applyEndOfTurnEffects(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.fainted || pokemon.statusCondition === null) return false;
+  let damage = 0;
+  switch (pokemon.statusCondition) {
+    case 'burn':
+      damage = Math.max(1, Math.floor(pokemon.maxHp / 16));
+      messages.push(t('status.burn.damage', { name: pokemon.displayName }));
+      break;
+    case 'poison':
+      damage = Math.max(1, Math.floor(pokemon.maxHp / 8));
+      messages.push(t('status.poison.damage', { name: pokemon.displayName }));
+      break;
+    case 'badly_poisoned':
+      damage = Math.max(1, Math.floor((pokemon.maxHp * pokemon.toxicCounter) / 16));
+      messages.push(t('status.poison.damage', { name: pokemon.displayName }));
+      pokemon.toxicCounter++;
+      break;
+    case 'paralysis':
+    case 'sleep':
+    case 'freeze':
+      return false;
+  }
+  if (damage > 0) {
+    pokemon.currentHp = Math.max(0, pokemon.currentHp - damage);
+    if (pokemon.currentHp <= 0) {
+      pokemon.fainted = true;
+      messages.push(t('status.fainted_by_status', { name: pokemon.displayName }));
+      return true;
+    }
+  }
+  return false;
+}
+
+export function rollMoveEffect(
+  move: { effect?: { type: StatusCondition; chance: number } },
+  target: BattlePokemon,
+  messages: string[],
+): void {
+  if (!move.effect) return;
+  if (Math.random() * 100 >= move.effect.chance) return;
+  tryApplyStatus(target, move.effect.type, messages);
+}
+```
+
+- [ ] **Step 2: Update the test helper in `test/status-effects.test.ts`**
+
+```ts
+// test/status-effects.test.ts
+function makePokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
+  return {
+    id: 1, name: '1', displayName: 'Test', types: ['normal'], level: 50,
+    maxHp: 160, currentHp: 160, attack: 60, defense: 50, spAttack: 55,
+    spDefense: 50, speed: 70, moves: [], fainted: false,
+    statusCondition: null, toxicCounter: 0, sleepCounter: 0, ...overrides,
+  };
+}
+```
+
+- [ ] **Step 3: Update imports and add full helper coverage in `test/status-effects.test.ts`**
+
+```ts
+// test/status-effects.test.ts
+import {
+  isStatusImmune,
+  tryApplyStatus,
+  checkParalysisSkip,
+  checkSleepSkip,
+  checkFreezeSkip,
+  FROZEN_EXCEPTION_MOVES,
+  getBurnAttackMultiplier,
+  getParalysisSpeedMultiplier,
+  applyEndOfTurnEffects,
+} from '../src/core/status-effects.js';
+```
+
+```ts
+// test/status-effects.test.ts
+describe('isStatusImmune', () => {
+  it('ice type immune to freeze', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['ice'] }), 'freeze'), true);
+  });
+
+  it('normal type not immune to sleep', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'sleep'), false);
+  });
+});
+
+describe('tryApplyStatus', () => {
+  it('inits sleepCounter for sleep in the 1..3 range', () => {
+    const mon = makePokemon();
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.6; // floor(1.8) + 1 = 2
+      assert.equal(tryApplyStatus(mon, 'sleep', []), true);
+      assert.equal(mon.statusCondition, 'sleep');
+      assert.equal(mon.sleepCounter, 2);
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('blocks freeze on ice types', () => {
+    const mon = makePokemon({ types: ['ice'] });
+    assert.equal(tryApplyStatus(mon, 'freeze', []), false);
+    assert.equal(mon.statusCondition, null);
+  });
+});
+
+describe('checkSleepSkip', () => {
+  it('sleeping pokemon stays asleep when counter remains above zero', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 3 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, 'sleep');
+    assert.equal(mon.sleepCounter, 2);
+    assert.ok(messages.some((m) => m.includes('잠들어')));
+  });
+
+  it('sleeping pokemon wakes when counter reaches zero but still skips turn', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 1 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, null);
+    assert.equal(mon.sleepCounter, 0);
+    assert.ok(messages.some((m) => m.includes('깨어났다')));
+  });
+});
+
+describe('checkFreezeSkip', () => {
+  it('frozen pokemon skips when thaw roll fails', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as any;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      assert.equal(checkFreezeSkip(mon, move, messages), true);
+      assert.equal(mon.statusCondition, 'freeze');
+      assert.ok(messages.some((m) => m.includes('얼어붙어')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('frozen pokemon thaws on successful thaw roll', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as any;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.1;
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('exception moves can be used while frozen and thaw the user', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'scald' } } as any;
+    const messages: string[] = [];
+    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
+    assert.equal(checkFreezeSkip(mon, move, messages), false);
+    assert.equal(mon.statusCondition, null);
+    assert.ok(messages.some((m) => m.includes('녹았다')));
+  });
+});
+```
+
+- [ ] **Step 4: Run the focused unit suite**
+
+Run: `node --import tsx --test test/status-effects.test.ts`  
+Expected: PASS after the corresponding i18n keys exist
+
+### Task 3: i18n Messages
+
+**Files:**
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/ko.json`
+
+- [ ] **Step 1: Add English sleep/freeze keys**
+
+```json
+"status.sleep.inflicted": "{name} fell asleep!",
+"status.sleep.wake": "{name} woke up!",
+"status.sleep.still_asleep": "{name} is fast asleep!",
+"status.freeze.inflicted": "{name} was frozen solid!",
+"status.freeze.thawed": "{name} thawed out!",
+"status.freeze.still_frozen": "{name} is frozen solid!",
+"status.label.sleep": "SLP",
+"status.label.freeze": "FRZ",
+"status.name.sleep": "sleep",
+"status.name.freeze": "freeze"
+```
+
+- [ ] **Step 2: Add Korean sleep/freeze keys**
+
+```json
+"status.sleep.inflicted": "{name:은/는} 잠들었다!",
+"status.sleep.wake": "{name:은/는} 잠에서 깨어났다!",
+"status.sleep.still_asleep": "{name:은/는} 곤히 잠들어 있다!",
+"status.freeze.inflicted": "{name:은/는} 얼어붙었다!",
+"status.freeze.thawed": "{name:은/는} 얼음이 녹았다!",
+"status.freeze.still_frozen": "{name:은/는} 얼어붙어 움직일 수 없다!",
+"status.label.sleep": "수면",
+"status.label.freeze": "빙결",
+"status.name.sleep": "수면",
+"status.name.freeze": "빙결"
+```
+
+- [ ] **Step 3: Place the keys into the existing status section**
+
+Use the existing ordering style around:
+
+```json
+"status.paralysis.inflicted": "...",
+"status.burn.inflicted": "...",
+"status.poison.inflicted": "...",
+"status.badly_poisoned.inflicted": "...",
+"status.already": "...",
+"status.immune": "...",
+"status.fainted_by_status": "...",
+"status.name.burn": "...",
+"status.name.poison": "...",
+"status.name.paralysis": "...",
+"status.label.burn": "...",
+"status.label.poison": "...",
+"status.label.badly_poisoned": "...",
+"status.label.paralysis": "..."
+```
+
+- [ ] **Step 4: Validate JSON formatting**
+
+Run: `node -e "JSON.parse(require('node:fs').readFileSync('src/i18n/en.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/ko.json','utf8'))"`  
+Expected: no output, exit code 0
+
+### Task 4: Move Data
+
+**Files:**
+- Modify: `data/moves.json`
+
+- [ ] **Step 1: Add the missing sleep-inducing status moves**
+
+```json
+"47": {
+  "id": 47,
+  "name": "sing",
+  "nameKo": "노래하기",
+  "nameEn": "Sing",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 55,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"79": {
+  "id": 79,
+  "name": "sleep-powder",
+  "nameKo": "수면가루",
+  "nameEn": "Sleep Powder",
+  "type": "grass",
+  "category": "status",
+  "power": 0,
+  "accuracy": 75,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"95": {
+  "id": 95,
+  "name": "hypnosis",
+  "nameKo": "최면술",
+  "nameEn": "Hypnosis",
+  "type": "psychic",
+  "category": "status",
+  "power": 0,
+  "accuracy": 60,
+  "pp": 20,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"142": {
+  "id": 142,
+  "name": "lovely-kiss",
+  "nameKo": "악마의키스",
+  "nameEn": "Lovely Kiss",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 75,
+  "pp": 10,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+},
+"147": {
+  "id": 147,
+  "name": "spore",
+  "nameKo": "버섯포자",
+  "nameEn": "Spore",
+  "type": "grass",
+  "category": "status",
+  "power": 0,
+  "accuracy": 100,
+  "pp": 15,
+  "effect": {
+    "type": "sleep",
+    "chance": 100
+  }
+}
+```
+
+- [ ] **Step 2: Add freeze secondary effects to the existing ice attacks**
+
+```json
+"8": {
+  "id": 8,
+  "name": "ice-punch",
+  "nameKo": "냉동펀치",
+  "nameEn": "Ice Punch",
+  "type": "ice",
+  "category": "physical",
+  "power": 75,
+  "accuracy": 100,
+  "pp": 15,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"58": {
+  "id": 58,
+  "name": "ice-beam",
+  "nameKo": "냉동빔",
+  "nameEn": "Ice Beam",
+  "type": "ice",
+  "category": "special",
+  "power": 90,
+  "accuracy": 100,
+  "pp": 10,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"59": {
+  "id": 59,
+  "name": "blizzard",
+  "nameKo": "눈보라",
+  "nameEn": "Blizzard",
+  "type": "ice",
+  "category": "special",
+  "power": 110,
+  "accuracy": 70,
+  "pp": 5,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"181": {
+  "id": 181,
+  "name": "powder-snow",
+  "nameKo": "눈싸라기",
+  "nameEn": "Powder Snow",
+  "type": "ice",
+  "category": "special",
+  "power": 40,
+  "accuracy": 100,
+  "pp": 25,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+```json
+"573": {
+  "id": 573,
+  "name": "freeze-dry",
+  "nameKo": "프리즈드라이",
+  "nameEn": "Freeze-Dry",
+  "type": "ice",
+  "category": "special",
+  "power": 70,
+  "accuracy": 100,
+  "pp": 20,
+  "effect": {
+    "type": "freeze",
+    "chance": 10
+  }
+}
+```
+
+- [ ] **Step 3: Do not add `yawn` in v3a**
+
+Keep `yawn` out of this file change. Delayed sleep belongs to a later version.
+
+- [ ] **Step 4: Validate the move JSON**
+
+Run: `node -e "JSON.parse(require('node:fs').readFileSync('data/moves.json','utf8'))"`  
+Expected: no output, exit code 0
+
+### Task 5: Battle Engine Integration
+
+**Files:**
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Update status helper imports in `src/core/turn-battle.ts`**
+
+```ts
+// src/core/turn-battle.ts
+import {
+  getParalysisSpeedMultiplier,
+  getBurnAttackMultiplier,
+  checkSleepSkip,
+  checkFreezeSkip,
+  checkParalysisSkip,
+  applyEndOfTurnEffects,
+  rollMoveEffect,
+} from './status-effects.js';
+```
+
+- [ ] **Step 2: Insert sleep/freeze checks before paralysis**
+
+```ts
+// src/core/turn-battle.ts — inside executeMove()
+  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkParalysisSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+```
+
+- [ ] **Step 3: Thaw frozen defenders before fire damage**
+
+```ts
+// src/core/turn-battle.ts — after moveTypeImmune is computed, before damage
+  if (
+    defender.statusCondition === 'freeze' &&
+    move.data.type === 'fire' &&
+    !moveTypeImmune
+  ) {
+    defender.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: defender.displayName }));
+  }
+
+  const damage = calculateDamage(attacker, defender, move);
+  defender.currentHp = Math.max(0, defender.currentHp - damage);
+```
+
+- [ ] **Step 4: Import `t` if it is not already available in this module**
+
+```ts
+// src/core/turn-battle.ts
+import { t } from '../i18n/index.js';
+```
+
+- [ ] **Step 5: Extend `makeTestPokemon()` and add targeted regression tests**
+
+```ts
+// test/turn-battle.test.ts
+describe('resolveTurn with status effects', () => {
+  it('sleep skips the turn without consuming PP', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 2,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.equal(player.sleepCounter, 1);
+  });
+
+  it('wake-up turn still skips the move', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 1,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.ok(result.messages.some((m) => m.includes('깨어났다')));
+  });
+
+  it('freeze skips the turn without consuming PP when thaw roll fails', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.moves[0].currentPp, 10);
+      assert.equal(player.statusCondition, 'freeze');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('freeze exception moves act normally and thaw the user', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{
+        data: makeMoveData({
+          name: 'scald',
+          nameKo: '열탕',
+          type: 'water',
+          category: 'special',
+          power: 80,
+          accuracy: 100,
+          pp: 15,
+        }),
+        currentPp: 15,
+      }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 14);
+  });
+
+  it('fire-type attacks thaw frozen defenders before damage', () => {
+    const player = makeTestPokemon({
+      displayName: 'Fire',
+      speed: 999,
+      moves: [{ data: makeFireMove({ power: 60 }), currentPp: 25 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Frozen Target',
+      types: ['grass'],
+      statusCondition: 'freeze' as StatusCondition,
+      currentHp: 100,
+    });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+    assert.ok(opp.currentHp < 100, 'Damage should still apply after thaw');
+    assert.ok(result.messages.some((m) => m.includes('녹았다')));
+  });
+
+  it('ice-type targets remain immune to freeze secondary effects', () => {
+    const effectMove = makeMoveData({ type: 'ice', category: 'special', power: 90 });
+    (effectMove as any).effect = { type: 'freeze', chance: 100 };
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      moves: [{ data: effectMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Ice Target',
+      types: ['ice'],
+      statusCondition: null,
+    });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+  });
+});
+```
+
+- [ ] **Step 6: Run the battle regression suite**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS after all i18n and status helper changes are in place
+
+### Task 6: Battle UI Update
+
+**Files:**
+- Modify: `src/battle-tui/renderer.ts`
+- Modify: `src/status-line.ts`
+
+- [ ] **Step 1: Extend the renderer color map**
+
+```ts
+// src/battle-tui/renderer.ts
+function statusLabel(mon: BattlePokemon): string {
+  if (!mon.statusCondition) return '';
+  const colors: Record<string, string> = {
+    burn: '\x1b[31m',
+    poison: '\x1b[35m',
+    badly_poisoned: '\x1b[35m',
+    paralysis: '\x1b[33m',
+    sleep: '\x1b[33m',
+    freeze: '\x1b[36m',
+  };
+  const color = colors[mon.statusCondition] || '';
+  const label = t(`status.label.${mon.statusCondition}`);
+  return `${color}[${label}]\x1b[0m`;
+}
+```
+
+- [ ] **Step 2: Extend the compact status badge map**
+
+```ts
+// src/status-line.ts
+const statusLabels: Record<string, string> = {
+  burn: '\x1b[31m[BRN]\x1b[0m',
+  poison: '\x1b[35m[PSN]\x1b[0m',
+  badly_poisoned: '\x1b[35m[TOX]\x1b[0m',
+  paralysis: '\x1b[33m[PRZ]\x1b[0m',
+  sleep: '\x1b[33m[SLP]\x1b[0m',
+  freeze: '\x1b[36m[FRZ]\x1b[0m',
+};
+```
+
+- [ ] **Step 3: Verify labels align with i18n**
+
+`renderer.ts` uses localized `status.label.*`; `status-line.ts` keeps the fixed compact battle abbreviations. Confirm both surfaces are intentional and unchanged for existing statuses.
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify: `src/core/types.ts`
+- Verify: `src/core/status-effects.ts`
+- Verify: `src/core/turn-battle.ts`
+- Verify: `src/i18n/en.json`
+- Verify: `src/i18n/ko.json`
+- Verify: `src/battle-tui/renderer.ts`
+- Verify: `src/status-line.ts`
+- Verify: `data/moves.json`
+- Verify: `test/status-effects.test.ts`
+- Verify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Run the status unit tests**
+
+Run: `node --import tsx --test test/status-effects.test.ts`  
+Expected: PASS
+
+- [ ] **Step 2: Run the battle engine regression tests**
+
+Run: `node --import tsx --test test/turn-battle.test.ts`  
+Expected: PASS
+
+- [ ] **Step 3: Run the TypeScript checker**
+
+Run: `npx tsc --noEmit`  
+Expected: PASS
+
+- [ ] **Step 4: Re-validate JSON files**
+
+Run:
+
+```bash
+node -e "JSON.parse(require('node:fs').readFileSync('data/moves.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/en.json','utf8')); JSON.parse(require('node:fs').readFileSync('src/i18n/ko.json','utf8'))"
+```
+
+Expected: no output, exit code 0
+
+- [ ] **Step 5: Spot-check move data and exception behavior**
+
+Run:
+
+```bash
+rg -n '"name": "(ice-beam|blizzard|ice-punch|powder-snow|freeze-dry|hypnosis|sing|spore|sleep-powder|lovely-kiss)"' data/moves.json
+```
+
+Expected: all ten move blocks present
+
+- [ ] **Step 6: Verify acceptance criteria explicitly**
+
+Checklist:
+
+- Sleep and freeze are in `StatusCondition`
+- `sleepCounter` exists everywhere a `BattlePokemon` is built
+- sleep applies with a `1..3` counter
+- wake turn still skips the move
+- freeze has 20% thaw
+- frozen exception moves thaw and act
+- fire hits thaw frozen defenders before damage
+- ice types are immune to freeze
+- five sleep moves exist in `moves.json`
+- five ice attacks have 10% freeze effects
+- UI labels exist for sleep and freeze
+- English and Korean i18n keys exist
+
+- [ ] **Step 7: Commit with a Lore-format message**
+
+```bash
+git add src/core/types.ts src/core/status-effects.ts src/core/turn-battle.ts src/i18n/en.json src/i18n/ko.json src/battle-tui/renderer.ts src/status-line.ts data/moves.json test/status-effects.test.ts test/turn-battle.test.ts
+git commit -m "Add sleep and freeze to complete the v2 non-volatile status set
+
+The battle engine already has a stable status-application and pre-move skip
+pipeline, so this change extends that path with sleep counters, freeze thaw
+rules, and the small set of frozen exception moves instead of adding a second
+status subsystem.
+
+Constraint: Must preserve the existing one-non-volatile-status invariant
+Constraint: Must not extend MoveData just to support frozen exception moves
+Rejected: Wake-and-act-on-zero sleep convention | introduces a free-action edge case into the current PP-skip invariant
+Confidence: high
+Scope-risk: moderate
+Directive: Keep sleep/freeze checks before PP consumption for chosen moves
+Tested: node --import tsx --test test/status-effects.test.ts
+Tested: node --import tsx --test test/turn-battle.test.ts
+Tested: npx tsc --noEmit
+Not-tested: interactive TUI rendering in a live gym battle"
+```
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-10-status-effects-v3a.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-04-10-status-effects-v3b.md
+++ b/docs/superpowers/plans/2026-04-10-status-effects-v3b.md
@@ -1,0 +1,910 @@
+# Status Effects v3b Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add stat stages to the Tokenmon battle engine: a 7-stat `-6..+6` stage system on `BattlePokemon`, move-data driven buffs/debuffs, damage-move secondary stat drops, battle-engine integration for damage/accuracy/speed, and a gym AI heuristic that uses stat moves strategically.
+
+**Architecture:** Extend the existing battle state directly instead of adding a separate volatile-effect engine. `BattlePokemon` stores `statStages`, a dedicated `src/core/stat-stages.ts` module owns formulas and message emission, `MoveData.statChanges` describes self/opponent stage effects, and `src/core/turn-battle.ts` remains the single integration point for damage, accuracy, turn order, switching, and post-hit stat changes.
+
+**Tech Stack:** TypeScript, Node.js built-in test runner, JSON move data, existing i18n JSON dictionaries, current gym AI scorer.
+
+---
+
+## File Map
+
+- `src/core/types.ts`: `StatStages`, `StatChange`, `BattlePokemon.statStages`, `MoveData.statChanges`
+- `src/core/turn-battle.ts`: initialize stat stages, integrate damage/accuracy/speed, apply stat changes, reset on switch
+- `src/core/stat-stages.ts`: new formulas + stage application helpers
+- `src/core/gym-ai.ts`: stat-move heuristic
+- `src/core/battle-state-io.ts`: normalize legacy saves missing `statStages`
+- `src/i18n/en.json`: English stat-stage messages and names
+- `src/i18n/ko.json`: Korean stat-stage messages and names
+- `data/moves.json`: stat-buff/debuff moves and secondary stat-drop effects
+- `test/status-effects.test.ts`: stat-stage helper tests
+- `test/turn-battle.test.ts`: battle-flow integration tests
+- `test/battle-state-migration.test.ts`: persisted battle-state migration coverage
+
+### Task 1: Types
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/core/turn-battle.ts`
+- Modify: `src/core/battle-state-io.ts`
+- Modify: `test/turn-battle.test.ts`
+- Modify: `test/battle-state-migration.test.ts`
+
+- [ ] **Step 1: Add `StatStages` and `StatChange` to `src/core/types.ts`**
+
+```ts
+// src/core/types.ts
+export interface StatStages {
+  attack: number;
+  defense: number;
+  spAttack: number;
+  spDefense: number;
+  speed: number;
+  accuracy: number;
+  evasion: number;
+}
+
+export interface StatChange {
+  target: 'self' | 'opponent';
+  stat: keyof StatStages;
+  stages: number;
+  chance: number;
+}
+```
+
+- [ ] **Step 2: Extend `MoveData` and `BattlePokemon`**
+
+```ts
+// src/core/types.ts
+export interface MoveData {
+  id: number;
+  name: string;
+  nameKo?: string;
+  nameEn?: string;
+  type: string;
+  category: 'physical' | 'special' | 'status';
+  power: number;
+  accuracy: number | null;
+  pp: number;
+  effect?: { type: StatusCondition; chance: number };
+  statChanges?: StatChange[];
+}
+
+export interface BattlePokemon {
+  id: number;
+  name: string;
+  displayName: string;
+  types: string[];
+  level: number;
+  maxHp: number;
+  currentHp: number;
+  attack: number;
+  defense: number;
+  spAttack: number;
+  spDefense: number;
+  speed: number;
+  moves: BattleMove[];
+  fainted: boolean;
+  statusCondition: StatusCondition | null;
+  toxicCounter: number;
+  sleepCounter: number;
+  statStages: StatStages;
+}
+```
+
+- [ ] **Step 3: Initialize `statStages` when constructing battle Pokemon**
+
+```ts
+// src/core/turn-battle.ts
+import { createStatStages } from './stat-stages.js';
+
+export function createBattlePokemon(
+  input: CreateBattlePokemonInput,
+  moves: MoveData[],
+): BattlePokemon {
+  // ...existing setup...
+  return {
+    // ...existing fields...
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+    statStages: createStatStages(),
+  };
+}
+```
+
+- [ ] **Step 4: Normalize legacy battle-state saves missing `statStages`**
+
+```ts
+// src/core/battle-state-io.ts
+import { createStatStages } from './stat-stages.js';
+
+export function normalizeBattlePokemon(mon: BattlePokemon): void {
+  if (mon.statusCondition === undefined) mon.statusCondition = null;
+  if (mon.toxicCounter === undefined) mon.toxicCounter = 0;
+  if (mon.sleepCounter === undefined || !Number.isFinite(mon.sleepCounter)) {
+    mon.sleepCounter = 0;
+  }
+  if (mon.statStages === undefined) {
+    mon.statStages = createStatStages();
+  } else {
+    mon.statStages.attack = Number.isFinite(mon.statStages.attack) ? mon.statStages.attack : 0;
+    mon.statStages.defense = Number.isFinite(mon.statStages.defense) ? mon.statStages.defense : 0;
+    mon.statStages.spAttack = Number.isFinite(mon.statStages.spAttack) ? mon.statStages.spAttack : 0;
+    mon.statStages.spDefense = Number.isFinite(mon.statStages.spDefense) ? mon.statStages.spDefense : 0;
+    mon.statStages.speed = Number.isFinite(mon.statStages.speed) ? mon.statStages.speed : 0;
+    mon.statStages.accuracy = Number.isFinite(mon.statStages.accuracy) ? mon.statStages.accuracy : 0;
+    mon.statStages.evasion = Number.isFinite(mon.statStages.evasion) ? mon.statStages.evasion : 0;
+  }
+}
+```
+
+- [ ] **Step 5: Update test helpers so every test Pokemon has stage storage**
+
+```ts
+// test/turn-battle.test.ts
+import { createStatStages } from '../src/core/stat-stages.js';
+
+function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
+  return {
+    id: 1,
+    name: '1',
+    displayName: 'Attacker',
+    types: ['normal'],
+    level: 50,
+    maxHp: 120,
+    currentHp: 120,
+    attack: 60,
+    defense: 50,
+    spAttack: 55,
+    spDefense: 50,
+    speed: 70,
+    moves: [{ data: makeMoveData(), currentPp: 35 }],
+    fainted: false,
+    statusCondition: null,
+    toxicCounter: 0,
+    sleepCounter: 0,
+    statStages: createStatStages(),
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 6: Extend migration tests for the new persisted field**
+
+```ts
+// test/battle-state-migration.test.ts
+it('normalizeBattlePokemon backfills missing statStages to zeroes (v3b)', () => {
+  const mon = makeLegacyPokemon();
+  assert.equal((mon as any).statStages, undefined);
+  normalizeBattlePokemon(mon);
+  assert.deepEqual(mon.statStages, {
+    attack: 0,
+    defense: 0,
+    spAttack: 0,
+    spDefense: 0,
+    speed: 0,
+    accuracy: 0,
+    evasion: 0,
+  });
+});
+```
+
+- [ ] **Step 7: Run the focused schema tests**
+
+Run: `node --import tsx --test test/battle-state-migration.test.ts test/turn-battle.test.ts`  
+Expected: PASS after later tasks complete
+
+### Task 2: Stat Stages Module
+
+**Files:**
+- Add: `src/core/stat-stages.ts`
+- Modify: `test/status-effects.test.ts`
+
+- [ ] **Step 1: Create the stage factory and multiplier helpers**
+
+```ts
+// src/core/stat-stages.ts
+import { t } from '../i18n/index.js';
+import type { BattlePokemon, StatStages } from './types.js';
+
+const MIN_STAGE = -6;
+const MAX_STAGE = 6;
+
+export function createStatStages(): StatStages {
+  return {
+    attack: 0,
+    defense: 0,
+    spAttack: 0,
+    spDefense: 0,
+    speed: 0,
+    accuracy: 0,
+    evasion: 0,
+  };
+}
+
+export function getStatMultiplier(stage: number): number {
+  return Math.max(2, 2 + stage) / Math.max(2, 2 - stage);
+}
+
+export function getAccEvaMultiplier(stage: number): number {
+  return Math.max(3, 3 + stage) / Math.max(3, 3 - stage);
+}
+```
+
+- [ ] **Step 2: Implement stat-name mapping and `applyStatChange()`**
+
+```ts
+// src/core/stat-stages.ts
+const STAT_LABEL_KEYS: Record<keyof StatStages, string> = {
+  attack: 'stat.name.attack',
+  defense: 'stat.name.defense',
+  spAttack: 'stat.name.sp_attack',
+  spDefense: 'stat.name.sp_defense',
+  speed: 'stat.name.speed',
+  accuracy: 'stat.name.accuracy',
+  evasion: 'stat.name.evasion',
+};
+
+export function applyStatChange(
+  target: BattlePokemon,
+  stat: keyof StatStages,
+  delta: number,
+  messages: string[],
+): boolean {
+  const current = target.statStages[stat];
+  const next = Math.max(MIN_STAGE, Math.min(MAX_STAGE, current + delta));
+  const statName = t(STAT_LABEL_KEYS[stat]);
+
+  if (next === current) {
+    messages.push(
+      t(delta > 0 ? 'stat.cannot_rise' : 'stat.cannot_fall', {
+        name: target.displayName,
+        stat: statName,
+      }),
+    );
+    return false;
+  }
+
+  target.statStages[stat] = next;
+  const key =
+    delta > 0
+      ? (Math.abs(delta) >= 2 ? 'stat.rose_sharply' : 'stat.rose')
+      : (Math.abs(delta) >= 2 ? 'stat.fell_harshly' : 'stat.fell');
+  messages.push(t(key, { name: target.displayName, stat: statName }));
+  return true;
+}
+```
+
+- [ ] **Step 3: Implement reset helper**
+
+```ts
+// src/core/stat-stages.ts
+export function resetStatStages(pokemon: BattlePokemon): void {
+  pokemon.statStages = createStatStages();
+}
+```
+
+- [ ] **Step 4: Add unit coverage for formulas, caps, and messages**
+
+```ts
+// test/status-effects.test.ts
+import {
+  applyStatChange,
+  createStatStages,
+  getAccEvaMultiplier,
+  getStatMultiplier,
+  resetStatStages,
+} from '../src/core/stat-stages.js';
+
+it('getStatMultiplier matches the battle-stage formula at +2 and -6', () => {
+  assert.equal(getStatMultiplier(2), 2);
+  assert.equal(getStatMultiplier(-6), 0.25);
+});
+
+it('getAccEvaMultiplier matches the accuracy/evasion formula at +1 and +6', () => {
+  assert.equal(getAccEvaMultiplier(1), 4 / 3);
+  assert.equal(getAccEvaMultiplier(6), 3);
+});
+
+it('applyStatChange clamps at +6 and emits cap messaging', () => {
+  const mon = makePokemon({ statStages: { ...createStatStages(), attack: 6 } });
+  const msgs: string[] = [];
+  const changed = applyStatChange(mon, 'attack', 2, msgs);
+  assert.equal(changed, false);
+  assert.equal(mon.statStages.attack, 6);
+  assert.match(msgs[0], /higher/i);
+});
+```
+
+- [ ] **Step 5: Run the stat-stage helper tests**
+
+Run: `node --import tsx --test test/status-effects.test.ts`  
+Expected: PASS after i18n keys exist
+
+### Task 3: i18n Messages
+
+**Files:**
+- Modify: `src/i18n/en.json`
+- Modify: `src/i18n/ko.json`
+
+- [ ] **Step 1: Add English stat-stage messages**
+
+```json
+"stat.rose": "{name}'s {stat} rose!",
+"stat.rose_sharply": "{name}'s {stat} rose sharply!",
+"stat.fell": "{name}'s {stat} fell!",
+"stat.fell_harshly": "{name}'s {stat} fell harshly!",
+"stat.cannot_rise": "{name}'s {stat} won't go any higher!",
+"stat.cannot_fall": "{name}'s {stat} won't go any lower!",
+"stat.name.attack": "Attack",
+"stat.name.defense": "Defense",
+"stat.name.sp_attack": "Sp. Atk",
+"stat.name.sp_defense": "Sp. Def",
+"stat.name.speed": "Speed",
+"stat.name.accuracy": "Accuracy",
+"stat.name.evasion": "Evasion"
+```
+
+- [ ] **Step 2: Add Korean stat-stage messages**
+
+```json
+"stat.rose": "{name}의 {stat}이(가) 올라갔다!",
+"stat.rose_sharply": "{name}의 {stat}이(가) 크게 올라갔다!",
+"stat.fell": "{name}의 {stat}이(가) 내려갔다!",
+"stat.fell_harshly": "{name}의 {stat}이(가) 크게 내려갔다!",
+"stat.cannot_rise": "{name}의 {stat}은(는) 더이상 올라가지 않는다!",
+"stat.cannot_fall": "{name}의 {stat}은(는) 더이상 내려가지 않는다!",
+"stat.name.attack": "공격",
+"stat.name.defense": "방어",
+"stat.name.sp_attack": "특수공격",
+"stat.name.sp_defense": "특수방어",
+"stat.name.speed": "스피드",
+"stat.name.accuracy": "명중률",
+"stat.name.evasion": "회피율"
+```
+
+- [ ] **Step 3: Verify the dictionaries still parse**
+
+Run: `node --import tsx -e "import en from './src/i18n/en.json' with { type: 'json' }; import ko from './src/i18n/ko.json' with { type: 'json' }; console.log(Object.keys(en).length, Object.keys(ko).length)"`  
+Expected: two counts printed, no JSON parse error
+
+### Task 4: Move Data
+
+**Files:**
+- Modify: `data/moves.json`
+
+- [ ] **Step 1: Add `statChanges` to existing debuff and damaging moves**
+
+```json
+"94": {
+  "id": 94,
+  "name": "psychic",
+  "nameKo": "사이코키네시스",
+  "nameEn": "Psychic",
+  "type": "psychic",
+  "category": "special",
+  "power": 90,
+  "accuracy": 100,
+  "pp": 10,
+  "statChanges": [
+    { "target": "opponent", "stat": "spDefense", "stages": -1, "chance": 10 }
+  ]
+}
+```
+
+```json
+"196": {
+  "id": 196,
+  "name": "icy-wind",
+  "nameKo": "얼다바람",
+  "nameEn": "Icy Wind",
+  "type": "ice",
+  "category": "special",
+  "power": 55,
+  "accuracy": 95,
+  "pp": 15,
+  "statChanges": [
+    { "target": "opponent", "stat": "speed", "stages": -1, "chance": 100 }
+  ]
+}
+```
+
+- [ ] **Step 2: Add self-buff status moves with explicit stage arrays**
+
+```json
+"14": {
+  "id": 14,
+  "name": "swords-dance",
+  "nameKo": "칼춤",
+  "nameEn": "Swords Dance",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": null,
+  "pp": 20,
+  "statChanges": [
+    { "target": "self", "stat": "attack", "stages": 2, "chance": 100 }
+  ]
+}
+```
+
+```json
+"349": {
+  "id": 349,
+  "name": "dragon-dance",
+  "nameKo": "용의춤",
+  "nameEn": "Dragon Dance",
+  "type": "dragon",
+  "category": "status",
+  "power": 0,
+  "accuracy": null,
+  "pp": 20,
+  "statChanges": [
+    { "target": "self", "stat": "attack", "stages": 1, "chance": 100 },
+    { "target": "self", "stat": "speed", "stages": 1, "chance": 100 }
+  ]
+}
+```
+
+- [ ] **Step 3: Add opponent-debuff status moves**
+
+```json
+"45": {
+  "id": 45,
+  "name": "growl",
+  "nameKo": "울음소리",
+  "nameEn": "Growl",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 100,
+  "pp": 40,
+  "statChanges": [
+    { "target": "opponent", "stat": "attack", "stages": -1, "chance": 100 }
+  ]
+}
+```
+
+```json
+"230": {
+  "id": 230,
+  "name": "sweet-scent",
+  "nameKo": "달콤한향기",
+  "nameEn": "Sweet Scent",
+  "type": "normal",
+  "category": "status",
+  "power": 0,
+  "accuracy": 100,
+  "pp": 20,
+  "statChanges": [
+    { "target": "opponent", "stat": "evasion", "stages": -2, "chance": 100 }
+  ]
+}
+```
+
+- [ ] **Step 4: Verify move-data integrity and schema shape**
+
+Run: `node --import tsx -e "import moves from './data/moves.json' with { type: 'json' }; for (const name of ['swords-dance','nasty-plot','dragon-dance','calm-mind','iron-defense','agility','growl','tail-whip','leer','string-shot','charm','screech','scary-face','sweet-scent','seed-bomb','crunch','icy-wind','rock-smash','psychic','flash-cannon','mystical-fire','acid-spray','bug-buzz','aurora-beam','shadow-ball']) { const move = Object.values(moves).find((m: any) => m.name === name); if (!move) throw new Error('missing ' + name); } console.log('move-data-ok')"`  
+Expected: `move-data-ok`
+
+### Task 5: Battle Engine Damage Integration
+
+**Files:**
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Apply stage multipliers inside `calculateDamage()`**
+
+```ts
+// src/core/turn-battle.ts
+import { getStatMultiplier } from './stat-stages.js';
+
+function calculateDamage(attacker: BattlePokemon, defender: BattlePokemon, move: MoveData): number {
+  const isPhysical = move.category === 'physical';
+  const attackStat = isPhysical ? attacker.attack : attacker.spAttack;
+  const defenseStat = isPhysical ? defender.defense : defender.spDefense;
+  const attackStage = isPhysical ? attacker.statStages.attack : attacker.statStages.spAttack;
+  const defenseStage = isPhysical ? defender.statStages.defense : defender.statStages.spDefense;
+
+  const effectiveAttack =
+    attackStat *
+    getStatMultiplier(attackStage) *
+    (isPhysical ? getBurnAttackMultiplier(attacker) : 1);
+  const effectiveDefense = defenseStat * getStatMultiplier(defenseStage);
+
+  // keep the existing STAB / type / random / base-damage math
+}
+```
+
+- [ ] **Step 2: Add damage regression coverage**
+
+```ts
+// test/turn-battle.test.ts
+it('damage increases with positive attack stages', () => {
+  const move = makeMoveData({ category: 'physical', power: 80 });
+  const neutral = calculateDamage(
+    makeTestPokemon({ statStages: createStatStages() }),
+    makeTestPokemon({ displayName: 'Defender', statStages: createStatStages() }),
+    move,
+  );
+  const boosted = calculateDamage(
+    makeTestPokemon({ statStages: { ...createStatStages(), attack: 2 } }),
+    makeTestPokemon({ displayName: 'Defender', statStages: createStatStages() }),
+    move,
+  );
+  assert.ok(boosted > neutral);
+});
+```
+
+- [ ] **Step 3: Verify defense drops matter as well**
+
+```ts
+// test/turn-battle.test.ts
+it('damage increases when the defender has negative defense stages', () => {
+  const move = makeMoveData({ category: 'special', power: 90 });
+  const neutral = calculateDamage(
+    makeTestPokemon({ statStages: createStatStages() }),
+    makeTestPokemon({ displayName: 'Defender', statStages: createStatStages() }),
+    move,
+  );
+  const dropped = calculateDamage(
+    makeTestPokemon({ statStages: createStatStages() }),
+    makeTestPokemon({
+      displayName: 'Defender',
+      statStages: { ...createStatStages(), spDefense: -2 },
+    }),
+    move,
+  );
+  assert.ok(dropped > neutral);
+});
+```
+
+- [ ] **Step 4: Run battle-engine damage tests**
+
+Run: `node --import tsx --test test/turn-battle.test.ts --test-name-pattern "damage|attack stages|defense stages|burn"`  
+Expected: PASS
+
+### Task 6: Battle Engine Accuracy + Speed Integration
+
+**Files:**
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Update `checkAccuracy()` to use attacker accuracy and defender evasion**
+
+```ts
+// src/core/turn-battle.ts
+import { getAccEvaMultiplier, getStatMultiplier } from './stat-stages.js';
+
+function checkAccuracy(attacker: BattlePokemon, defender: BattlePokemon, move: MoveData): boolean {
+  if (move.accuracy === null) return true;
+  const hitChance =
+    move.accuracy *
+    getAccEvaMultiplier(attacker.statStages.accuracy) /
+    getAccEvaMultiplier(defender.statStages.evasion);
+  return Math.random() * 100 < hitChance;
+}
+```
+
+- [ ] **Step 2: Thread the new `checkAccuracy(attacker, defender, move)` signature through `executeMove()`**
+
+```ts
+// src/core/turn-battle.ts
+if (!checkAccuracy(attacker, defender, move.data)) {
+  messages.push(t('battle.miss', { name: attacker.displayName }));
+  return;
+}
+```
+
+- [ ] **Step 3: Apply speed stages in turn-order resolution**
+
+```ts
+// src/core/turn-battle.ts
+const playerSpeed =
+  player.speed *
+  getStatMultiplier(player.statStages.speed) *
+  getParalysisSpeedMultiplier(player);
+const opponentSpeed =
+  opponent.speed *
+  getStatMultiplier(opponent.statStages.speed) *
+  getParalysisSpeedMultiplier(opponent);
+```
+
+- [ ] **Step 4: Add accuracy/evasion and speed tests**
+
+```ts
+// test/turn-battle.test.ts
+it('accuracy stages improve hit chance and evasion stages reduce it', () => {
+  const move = makeMoveData({ accuracy: 75 });
+  const attacker = makeTestPokemon({ statStages: { ...createStatStages(), accuracy: 2 } });
+  const defender = makeTestPokemon({
+    displayName: 'Defender',
+    statStages: { ...createStatStages(), evasion: 0 },
+  });
+  const hit = checkAccuracy(attacker, defender, move);
+  assert.equal(typeof hit, 'boolean');
+});
+
+it('speed stages can flip turn order', () => {
+  const slowButBoosted = makeTestPokemon({
+    speed: 50,
+    statStages: { ...createStatStages(), speed: 2 },
+  });
+  const fastButDropped = makeTestPokemon({
+    displayName: 'Faster',
+    speed: 90,
+    statStages: { ...createStatStages(), speed: -2 },
+  });
+  assert.ok(
+    50 * getStatMultiplier(2) > 90 * getStatMultiplier(-2),
+    'boosted slower mon should now move first',
+  );
+});
+```
+
+- [ ] **Step 5: Run the accuracy/speed test slice**
+
+Run: `node --import tsx --test test/turn-battle.test.ts --test-name-pattern "accuracy|evasion|speed|turn order"`  
+Expected: PASS
+
+### Task 7: Battle Engine Effect Application
+
+**Files:**
+- Modify: `src/core/turn-battle.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Add a helper that resolves `statChanges` after a successful hit or status move**
+
+```ts
+// src/core/turn-battle.ts
+import { applyStatChange, resetStatStages } from './stat-stages.js';
+
+function applyMoveStatChanges(
+  attacker: BattlePokemon,
+  defender: BattlePokemon,
+  move: MoveData,
+  messages: string[],
+): void {
+  for (const change of move.statChanges ?? []) {
+    if (Math.random() * 100 >= change.chance) continue;
+    const target = change.target === 'self' ? attacker : defender;
+    applyStatChange(target, change.stat, change.stages, messages);
+  }
+}
+```
+
+- [ ] **Step 2: Call the helper at the right point in `executeMove()`**
+
+```ts
+// src/core/turn-battle.ts
+if (move.data.power > 0 && damage > 0 && !defender.fainted) {
+  applyMoveStatChanges(attacker, defender, move.data, messages);
+}
+
+if (move.data.power === 0) {
+  applyMoveStatChanges(attacker, defender, move.data, messages);
+}
+```
+
+- [ ] **Step 3: Reset stages on the switching-in Pokemon**
+
+```ts
+// src/core/turn-battle.ts
+function executeSwitch(team: BattleTeam, nextIndex: number, messages: string[]): void {
+  team.activeIndex = nextIndex;
+  const active = team.pokemon[nextIndex];
+  active.toxicCounter = active.statusCondition === 'badly_poisoned' ? active.toxicCounter : 0;
+  resetStatStages(active);
+  messages.push(t('battle.switch', { name: active.displayName }));
+}
+```
+
+- [ ] **Step 4: Add integration tests for self-buffs, debuffs, secondaries, and switch reset**
+
+```ts
+// test/turn-battle.test.ts
+it('status buff moves apply to the user', () => {
+  const attacker = makeTestPokemon({
+    moves: [{
+      data: makeMoveData({
+        name: 'swords-dance',
+        category: 'status',
+        power: 0,
+        accuracy: null,
+        statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+      }),
+      currentPp: 20,
+    }],
+  });
+  const defender = makeTestPokemon({ displayName: 'Defender' });
+  executeMove(attacker, defender, 0, []);
+  assert.equal(attacker.statStages.attack, 2);
+});
+
+it('damaging moves can apply post-hit secondary stat drops', () => {
+  const attacker = makeTestPokemon({
+    moves: [{
+      data: makeMoveData({
+        name: 'icy-wind',
+        category: 'special',
+        power: 55,
+        statChanges: [{ target: 'opponent', stat: 'speed', stages: -1, chance: 100 }],
+      }),
+      currentPp: 15,
+    }],
+  });
+  const defender = makeTestPokemon({ displayName: 'Defender' });
+  executeMove(attacker, defender, 0, []);
+  assert.equal(defender.statStages.speed, -1);
+});
+```
+
+- [ ] **Step 5: Run the effect-application test slice**
+
+Run: `node --import tsx --test test/turn-battle.test.ts --test-name-pattern "buff|debuff|secondary|switch resets"`  
+Expected: PASS
+
+### Task 8: Gym AI Enhancement
+
+**Files:**
+- Modify: `src/core/gym-ai.ts`
+- Modify: `test/turn-battle.test.ts`
+
+- [ ] **Step 1: Add helpers that identify stat-only setup moves**
+
+```ts
+// src/core/gym-ai.ts
+function getHpRatio(pokemon: BattlePokemon): number {
+  return pokemon.maxHp > 0 ? pokemon.currentHp / pokemon.maxHp : 0;
+}
+
+function averageStages(mon: BattlePokemon, stats: Array<keyof BattlePokemon['statStages']>): number {
+  return stats.reduce((sum, stat) => sum + mon.statStages[stat], 0) / stats.length;
+}
+```
+
+- [ ] **Step 2: Score self-buffs and opponent-debuffs using the requested heuristic**
+
+```ts
+// src/core/gym-ai.ts
+function scoreStatChangeMove(attacker: BattlePokemon, defender: BattlePokemon, move: BattlePokemon['moves'][number]): number {
+  const changes = move.data.statChanges ?? [];
+  if (changes.length === 0) return 0;
+
+  const selfChanges = changes.filter((c) => c.target === 'self' && c.stages > 0);
+  if (selfChanges.length > 0) {
+    const stats = selfChanges.map((c) => c.stat);
+    if (stats.every((stat) => attacker.statStages[stat] >= 6)) return 0;
+    const currentStageAverage = averageStages(attacker, stats);
+    return Math.max(0, 50 * (1 - currentStageAverage / 6));
+  }
+
+  const opponentChanges = changes.filter((c) => c.target === 'opponent' && c.stages < 0);
+  if (opponentChanges.length > 0) {
+    if (getHpRatio(defender) <= 0.5) return 0;
+    const targetStat = opponentChanges[0].stat;
+    if (defender.statStages[targetStat] <= -6) return 0;
+    const normalized = Math.max(0, Math.min(1, defender.statStages[targetStat] / 6));
+    return 40 * (1 - normalized);
+  }
+
+  return 0;
+}
+```
+
+- [ ] **Step 3: Keep damage-with-secondary-drop moves on the normal damage path**
+
+```ts
+// src/core/gym-ai.ts
+if (move.data.power === 0 && move.data.statChanges?.length) {
+  return { index, score: scoreStatChangeMove(attacker, defender, move) };
+}
+
+const stab = attacker.types.includes(move.data.type) ? 1.5 : 1.0;
+const power = move.data.power || 0;
+return { index, score: power * stab * typeEff };
+```
+
+- [ ] **Step 4: Add AI regression tests**
+
+```ts
+// test/turn-battle.test.ts
+it('AI prefers self-buff setup when its own stages are low', async () => {
+  const { selectAiMove } = await import('../src/core/gym-ai.js');
+  const attacker = makeTestPokemon({
+    moves: [
+      {
+        data: makeMoveData({
+          name: 'swords-dance',
+          category: 'status',
+          power: 0,
+          accuracy: null,
+          statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+        }),
+        currentPp: 20,
+      },
+      { data: makeMoveData({ name: 'tackle', power: 40 }), currentPp: 35 },
+    ],
+  });
+  const defender = makeTestPokemon({ displayName: 'Defender', currentHp: 120 });
+  const choice = selectAiMove(attacker, defender);
+  assert.equal(choice, 0);
+});
+
+it('AI gives zero setup score when already capped', async () => {
+  const { selectAiMove } = await import('../src/core/gym-ai.js');
+  const attacker = makeTestPokemon({
+    statStages: { ...createStatStages(), attack: 6 },
+    moves: [
+      {
+        data: makeMoveData({
+          name: 'swords-dance',
+          category: 'status',
+          power: 0,
+          accuracy: null,
+          statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+        }),
+        currentPp: 20,
+      },
+      { data: makeMoveData({ name: 'slash', power: 70 }), currentPp: 20 },
+    ],
+  });
+  const choice = selectAiMove(attacker, makeTestPokemon({ displayName: 'Defender' }));
+  assert.equal(choice, 1);
+});
+```
+
+- [ ] **Step 5: Run AI coverage**
+
+Run: `node --import tsx --test test/turn-battle.test.ts --test-name-pattern "AI"`  
+Expected: PASS
+
+### Task 9: Final Verification
+
+**Files:**
+- Verify: `src/core/types.ts`
+- Verify: `src/core/stat-stages.ts`
+- Verify: `src/core/turn-battle.ts`
+- Verify: `src/core/gym-ai.ts`
+- Verify: `src/core/battle-state-io.ts`
+- Verify: `src/i18n/en.json`
+- Verify: `src/i18n/ko.json`
+- Verify: `data/moves.json`
+- Verify: `test/status-effects.test.ts`
+- Verify: `test/turn-battle.test.ts`
+- Verify: `test/battle-state-migration.test.ts`
+
+- [ ] **Step 1: Run the full targeted test suite**
+
+Run: `node --import tsx --test test/status-effects.test.ts test/turn-battle.test.ts test/battle-state-migration.test.ts`
+
+- [ ] **Step 2: Run TypeScript checking**
+
+Run: `npx tsc --noEmit`
+
+- [ ] **Step 3: Re-verify the move catalog for every v3b move**
+
+Run: `node --import tsx -e "import moves from './data/moves.json' with { type: 'json' }; const expected = ['swords-dance','nasty-plot','dragon-dance','calm-mind','iron-defense','agility','growl','tail-whip','leer','string-shot','charm','screech','scary-face','sweet-scent','seed-bomb','crunch','icy-wind','rock-smash','psychic','flash-cannon','mystical-fire','acid-spray','bug-buzz','aurora-beam','shadow-ball']; for (const name of expected) { const move = Object.values(moves).find((m: any) => m.name === name); if (!move) throw new Error('missing ' + name); if (!('statChanges' in (move as any))) throw new Error('missing statChanges for ' + name); } console.log('verified', expected.length)"`  
+Expected: `verified 25`
+
+- [ ] **Step 4: Acceptance checklist**
+
+- [ ] Stat stages clamp to `[-6, +6]`
+- [ ] Battle-stat multiplier formula is correct for `-6..+6`
+- [ ] Accuracy/evasion multiplier formula is correct
+- [ ] Damage uses attack/defense or special attack/special defense stages
+- [ ] Accuracy uses attacker accuracy and defender evasion stages
+- [ ] Turn order uses speed stages
+- [ ] Switching resets stat stages
+- [ ] Self-buff status moves apply to self
+- [ ] Opponent-debuff status moves apply to opponent
+- [ ] Damaging secondary stat drops resolve correctly
+- [ ] Cap messages appear at `+6` and `-6`
+- [ ] AI uses setup early when stages are low
+- [ ] AI avoids useless setup at cap
+- [ ] English and Korean messages exist for all stat-stage strings
+- [ ] Legacy battle-state migration backfills `statStages`

--- a/src/battle-tui/renderer.ts
+++ b/src/battle-tui/renderer.ts
@@ -25,6 +25,7 @@ function padRight(text: string, width: number): string {
 
 function statusLabel(mon: BattlePokemon): string {
   if (!mon.statusCondition) return '';
+  const label = t(`status.label.${mon.statusCondition}`);
   const colors: Record<string, string> = {
     burn: '\x1b[31m',
     poison: '\x1b[35m',
@@ -33,7 +34,6 @@ function statusLabel(mon: BattlePokemon): string {
     sleep: '\x1b[33m',
     freeze: '\x1b[36m',
   };
-  const label = t(`status.label.${mon.statusCondition}`);
   const color = colors[mon.statusCondition] || '';
   return ` ${color}[${label}]${RESET}`;
 }

--- a/src/battle-tui/renderer.ts
+++ b/src/battle-tui/renderer.ts
@@ -25,13 +25,15 @@ function padRight(text: string, width: number): string {
 
 function statusLabel(mon: BattlePokemon): string {
   if (!mon.statusCondition) return '';
-  const label = t(`status.label.${mon.statusCondition}`);
   const colors: Record<string, string> = {
     burn: '\x1b[31m',
     poison: '\x1b[35m',
     badly_poisoned: '\x1b[35m',
     paralysis: '\x1b[33m',
+    sleep: '\x1b[33m',
+    freeze: '\x1b[36m',
   };
+  const label = t(`status.label.${mon.statusCondition}`);
   const color = colors[mon.statusCondition] || '';
   return ` ${color}[${label}]${RESET}`;
 }

--- a/src/core/battle-state-io.ts
+++ b/src/core/battle-state-io.ts
@@ -38,9 +38,11 @@ export interface BattleStateFile {
 /**
  * Backfill status fields on a BattlePokemon parsed from an older save.
  * `statusCondition` and `toxicCounter` were added in status-effects-v2;
- * earlier battle-state.json files lack them. We normalize `undefined` to
- * the schema defaults so downstream checks (e.g. `statusCondition !== null`)
- * do not mistake a pre-status battle for "already has a status".
+ * `sleepCounter` was added in status-effects-v3a. Earlier battle-state.json
+ * files lack these. We normalize `undefined` to schema defaults so downstream
+ * checks (e.g. `statusCondition !== null`) do not mistake a pre-status battle
+ * for "already has a status", and so arithmetic on `sleepCounter` does not
+ * produce NaN (which would trap a sleeping mon in permanent sleep on resume).
  */
 export function normalizeBattlePokemon(mon: BattlePokemon): void {
   if (mon.statusCondition === undefined) {
@@ -48,6 +50,9 @@ export function normalizeBattlePokemon(mon: BattlePokemon): void {
   }
   if (mon.toxicCounter === undefined) {
     mon.toxicCounter = 0;
+  }
+  if (mon.sleepCounter === undefined || !Number.isFinite(mon.sleepCounter)) {
+    mon.sleepCounter = 0;
   }
 }
 

--- a/src/core/battle-state-io.ts
+++ b/src/core/battle-state-io.ts
@@ -3,6 +3,7 @@
  */
 import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdirSync, renameSync } from 'fs';
 import { join, dirname } from 'path';
+import { createStatStages } from './stat-stages.js';
 import type { BattlePokemon, BattleState, BattleTeam, GymData } from './types.js';
 
 // ── Constants ──
@@ -53,6 +54,17 @@ export function normalizeBattlePokemon(mon: BattlePokemon): void {
   }
   if (mon.sleepCounter === undefined || !Number.isFinite(mon.sleepCounter)) {
     mon.sleepCounter = 0;
+  }
+  if (mon.statStages === undefined) {
+    mon.statStages = createStatStages();
+  } else {
+    mon.statStages.attack = Number.isFinite(mon.statStages.attack) ? mon.statStages.attack : 0;
+    mon.statStages.defense = Number.isFinite(mon.statStages.defense) ? mon.statStages.defense : 0;
+    mon.statStages.spAttack = Number.isFinite(mon.statStages.spAttack) ? mon.statStages.spAttack : 0;
+    mon.statStages.spDefense = Number.isFinite(mon.statStages.spDefense) ? mon.statStages.spDefense : 0;
+    mon.statStages.speed = Number.isFinite(mon.statStages.speed) ? mon.statStages.speed : 0;
+    mon.statStages.accuracy = Number.isFinite(mon.statStages.accuracy) ? mon.statStages.accuracy : 0;
+    mon.statStages.evasion = Number.isFinite(mon.statStages.evasion) ? mon.statStages.evasion : 0;
   }
 }
 

--- a/src/core/gym-ai.ts
+++ b/src/core/gym-ai.ts
@@ -33,9 +33,14 @@ function scoreStatChangeMove(
   if (opponentChanges.length > 0) {
     if (getHpRatio(defender) <= 0.5) return 0;
     const targetStat = opponentChanges[0].stat;
-    if (defender.statStages[targetStat] <= -6) return 0;
-    const normalized = Math.max(0, Math.min(1, defender.statStages[targetStat] / 6));
-    return 40 * (1 - normalized);
+    const stage = defender.statStages[targetStat];
+    if (stage <= -6) return 0;
+    // Score by remaining debuff headroom toward -6.
+    // headroom = stage + 6 → ranges 0 (at -6) up to 12 (at +6).
+    // Normalize to [0, 1]; max score at +6 (urgent corrective drop),
+    // mid score at neutral, near 0 as we approach -6.
+    const headroomRatio = (stage + 6) / 12;
+    return 40 * headroomRatio;
   }
 
   return 0;

--- a/src/core/gym-ai.ts
+++ b/src/core/gym-ai.ts
@@ -5,6 +5,42 @@ import type { BattlePokemon, TurnAction } from './types.js';
 /** Base score for a status move (equivalent to a ~60-power move with neutral typing). */
 const STATUS_MOVE_BASE_SCORE = 60;
 
+function getHpRatio(pokemon: BattlePokemon): number {
+  return pokemon.maxHp > 0 ? pokemon.currentHp / pokemon.maxHp : 0;
+}
+
+function averageStages(mon: BattlePokemon, stats: Array<keyof BattlePokemon['statStages']>): number {
+  return stats.reduce((sum, stat) => sum + mon.statStages[stat], 0) / stats.length;
+}
+
+function scoreStatChangeMove(
+  attacker: BattlePokemon,
+  defender: BattlePokemon,
+  move: BattlePokemon['moves'][number],
+): number {
+  const changes = move.data.statChanges ?? [];
+  if (changes.length === 0) return 0;
+
+  const selfChanges = changes.filter((c) => c.target === 'self' && c.stages > 0);
+  if (selfChanges.length > 0) {
+    const stats = selfChanges.map((c) => c.stat);
+    if (stats.every((stat) => attacker.statStages[stat] >= 6)) return 0;
+    const currentStageAverage = averageStages(attacker, stats);
+    return Math.max(0, (STATUS_MOVE_BASE_SCORE + 10) * (1 - currentStageAverage / 6));
+  }
+
+  const opponentChanges = changes.filter((c) => c.target === 'opponent' && c.stages < 0);
+  if (opponentChanges.length > 0) {
+    if (getHpRatio(defender) <= 0.5) return 0;
+    const targetStat = opponentChanges[0].stat;
+    if (defender.statStages[targetStat] <= -6) return 0;
+    const normalized = Math.max(0, Math.min(1, defender.statStages[targetStat] / 6));
+    return 40 * (1 - normalized);
+  }
+
+  return 0;
+}
+
 /**
  * Select the best move index for the AI.
  *
@@ -25,6 +61,10 @@ export function selectAiMove(attacker: BattlePokemon, defender: BattlePokemon): 
     let typeEff = 1.0;
     for (const defType of defender.types) {
       typeEff *= getTypeEffectiveness(move.data.type, defType);
+    }
+
+    if (move.data.power === 0 && move.data.statChanges?.length) {
+      return { index, score: scoreStatChangeMove(attacker, defender, move) };
     }
 
     // Status move scoring

--- a/src/core/gym-ai.ts
+++ b/src/core/gym-ai.ts
@@ -17,6 +17,7 @@ function scoreStatChangeMove(
   attacker: BattlePokemon,
   defender: BattlePokemon,
   move: BattlePokemon['moves'][number],
+  typeEff: number,
 ): number {
   const changes = move.data.statChanges ?? [];
   if (changes.length === 0) return 0;
@@ -31,6 +32,10 @@ function scoreStatChangeMove(
 
   const opponentChanges = changes.filter((c) => c.target === 'opponent' && c.stages < 0);
   if (opponentChanges.length > 0) {
+    // Type-immune debuff moves cannot land on the defender (e.g., growl on
+    // Ghost type). Mirror the engine's gating so the AI does not waste a
+    // turn on a debuff that the battle resolver will silently drop.
+    if (typeEff === 0) return 0;
     if (getHpRatio(defender) <= 0.5) return 0;
     const targetStat = opponentChanges[0].stat;
     const stage = defender.statStages[targetStat];
@@ -69,7 +74,7 @@ export function selectAiMove(attacker: BattlePokemon, defender: BattlePokemon): 
     }
 
     if (move.data.power === 0 && move.data.statChanges?.length) {
-      return { index, score: scoreStatChangeMove(attacker, defender, move) };
+      return { index, score: scoreStatChangeMove(attacker, defender, move, typeEff) };
     }
 
     // Status move scoring

--- a/src/core/stat-stages.ts
+++ b/src/core/stat-stages.ts
@@ -1,0 +1,68 @@
+import { t } from '../i18n/index.js';
+import type { BattlePokemon, StatStages } from './types.js';
+
+const MIN_STAGE = -6;
+const MAX_STAGE = 6;
+
+const STAT_LABEL_KEYS: Record<keyof StatStages, string> = {
+  attack: 'stat.name.attack',
+  defense: 'stat.name.defense',
+  spAttack: 'stat.name.sp_attack',
+  spDefense: 'stat.name.sp_defense',
+  speed: 'stat.name.speed',
+  accuracy: 'stat.name.accuracy',
+  evasion: 'stat.name.evasion',
+};
+
+export function createStatStages(): StatStages {
+  return {
+    attack: 0,
+    defense: 0,
+    spAttack: 0,
+    spDefense: 0,
+    speed: 0,
+    accuracy: 0,
+    evasion: 0,
+  };
+}
+
+export function getStatMultiplier(stage: number): number {
+  return Math.max(2, 2 + stage) / Math.max(2, 2 - stage);
+}
+
+export function getAccEvaMultiplier(stage: number): number {
+  return Math.max(3, 3 + stage) / Math.max(3, 3 - stage);
+}
+
+export function applyStatChange(
+  target: BattlePokemon,
+  stat: keyof StatStages,
+  delta: number,
+  messages: string[],
+): boolean {
+  const current = target.statStages[stat];
+  const next = Math.max(MIN_STAGE, Math.min(MAX_STAGE, current + delta));
+  const statName = t(STAT_LABEL_KEYS[stat]);
+
+  if (next === current) {
+    messages.push(
+      t(delta > 0 ? 'stat.cannot_rise' : 'stat.cannot_fall', {
+        name: target.displayName,
+        stat: statName,
+      }),
+    );
+    return false;
+  }
+
+  target.statStages[stat] = next;
+  const key =
+    delta > 0
+      ? (Math.abs(delta) >= 2 ? 'stat.rose_sharply' : 'stat.rose')
+      : (Math.abs(delta) >= 2 ? 'stat.fell_harshly' : 'stat.fell');
+  messages.push(t(key, { name: target.displayName, stat: statName }));
+  return true;
+}
+
+export function resetStatStages(pokemon: BattlePokemon): void {
+  pokemon.statStages = createStatStages();
+}

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -62,7 +62,11 @@ export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
 export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
   if (pokemon.statusCondition !== 'sleep') return false;
 
-  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+  // Harden against corrupted/legacy saves where sleepCounter may be
+  // undefined/NaN — treat non-finite counters as "wake up now" rather than
+  // trapping the mon in permanent sleep.
+  const current = Number.isFinite(pokemon.sleepCounter) ? pokemon.sleepCounter : 0;
+  pokemon.sleepCounter = Math.max(0, current - 1);
 
   if (pokemon.sleepCounter === 0) {
     pokemon.statusCondition = null;

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -14,6 +14,8 @@ export const FROZEN_EXCEPTION_MOVES = new Set([
   'flame-wheel',
   'sacred-fire',
   'scald',
+  'pyro-ball',
+  'matcha-gotcha',
   'flare-blitz',
   'steam-eruption',
   'burn-up',

--- a/src/core/status-effects.ts
+++ b/src/core/status-effects.ts
@@ -1,12 +1,23 @@
 import { t } from '../i18n/index.js';
-import type { BattlePokemon, StatusCondition } from './types.js';
+import type { BattleMove, BattlePokemon, StatusCondition } from './types.js';
 
 const STATUS_IMMUNITIES: Record<StatusCondition, string[]> = {
   poison: ['poison', 'steel'],
   badly_poisoned: ['poison', 'steel'],
   burn: ['fire'],
   paralysis: ['electric'],
+  sleep: [],
+  freeze: ['ice'],
 };
+
+export const FROZEN_EXCEPTION_MOVES = new Set([
+  'flame-wheel',
+  'sacred-fire',
+  'scald',
+  'flare-blitz',
+  'steam-eruption',
+  'burn-up',
+]);
 
 export function isStatusImmune(pokemon: BattlePokemon, status: StatusCondition): boolean {
   const immuneTypes = STATUS_IMMUNITIES[status];
@@ -23,10 +34,19 @@ export function tryApplyStatus(target: BattlePokemon, status: StatusCondition, m
     messages.push(t('status.immune', { name: target.displayName }));
     return false;
   }
+
   target.statusCondition = status;
+
   if (status === 'badly_poisoned') {
     target.toxicCounter = 1;
   }
+
+  if (status === 'sleep') {
+    target.sleepCounter = Math.floor(Math.random() * 3) + 1;
+  } else {
+    target.sleepCounter = 0;
+  }
+
   messages.push(t(`status.${status}.inflicted`, { name: target.displayName }));
   return true;
 }
@@ -37,6 +57,44 @@ export function getParalysisSpeedMultiplier(pokemon: BattlePokemon): number {
 
 export function getBurnAttackMultiplier(pokemon: BattlePokemon): number {
   return pokemon.statusCondition === 'burn' ? 0.5 : 1.0;
+}
+
+export function checkSleepSkip(pokemon: BattlePokemon, messages: string[]): boolean {
+  if (pokemon.statusCondition !== 'sleep') return false;
+
+  pokemon.sleepCounter = Math.max(0, pokemon.sleepCounter - 1);
+
+  if (pokemon.sleepCounter === 0) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.sleep.wake', { name: pokemon.displayName }));
+    return true;
+  }
+
+  messages.push(t('status.sleep.still_asleep', { name: pokemon.displayName }));
+  return true;
+}
+
+export function checkFreezeSkip(
+  pokemon: BattlePokemon,
+  move: BattleMove,
+  messages: string[],
+): boolean {
+  if (pokemon.statusCondition !== 'freeze') return false;
+
+  if (FROZEN_EXCEPTION_MOVES.has(move.data.name)) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  if (Math.random() < 0.2) {
+    pokemon.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: pokemon.displayName }));
+    return false;
+  }
+
+  messages.push(t('status.freeze.still_frozen', { name: pokemon.displayName }));
+  return true;
 }
 
 export function checkParalysisSkip(pokemon: BattlePokemon, messages: string[]): boolean {
@@ -66,6 +124,8 @@ export function applyEndOfTurnEffects(pokemon: BattlePokemon, messages: string[]
       pokemon.toxicCounter++;
       break;
     case 'paralysis':
+    case 'sleep':
+    case 'freeze':
       return false;
   }
   if (damage > 0) {

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -243,11 +243,14 @@ function executeMove(
     }
   }
 
-  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+  // Sleep and freeze are full incapacitation in mainline — they stop the turn
+  // even when Struggle would otherwise be forced. Paralysis is only a partial
+  // skip, so it keeps the Struggle bypass to preserve the no-PP invariant.
+  if (checkSleepSkip(attacker, messages)) {
     return { defenderFainted: false };
   }
 
-  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+  if (checkFreezeSkip(attacker, move, messages)) {
     return { defenderFainted: false };
   }
 
@@ -272,9 +275,13 @@ function executeMove(
   const effMsg = getEffectivenessMessage(move.data.type, defender.types);
   const moveTypeImmune = effMsg === 'effect_immune';
 
+  // Fire-type thaw: only damaging fire hits thaw the defender. A non-damaging
+  // fire status move (e.g. will-o-wisp) must not thaw a frozen target, or it
+  // would then apply a new burn status in the same action.
   if (
     defender.statusCondition === 'freeze' &&
     move.data.type === 'fire' &&
+    move.data.power > 0 &&
     !moveTypeImmune
   ) {
     defender.statusCondition = null;

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -316,15 +316,35 @@ function executeMove(
     messages.push(`${attacker.displayName}의 ${move.data.nameKo}!`);
   }
 
+  // Move-type effectiveness — computed BEFORE accuracy so type-immune debuff
+  // moves report immunity instead of missing (e.g., Screech vs Ghost). The
+  // mainline order resolves immunity before the accuracy roll.
+  const effMsg = getEffectivenessMessage(move.data.type, defender.types);
+  const moveTypeImmune = effMsg === 'effect_immune';
+
+  // Early-return: a type-immune zero-power stat-change move with NO self-buff
+  // component (e.g., growl/screech/tail-whip into Ghost) cannot land at all.
+  // Skip the accuracy gate so the user-visible log says "no effect" instead
+  // of "miss". Moves that also include self-buff changes still need to run
+  // through applyMoveStatChanges, which gates opponent changes per-target.
+  const allChanges = move.data.statChanges ?? [];
+  const hasOpponentChange = allChanges.some((c) => c.target === 'opponent');
+  const hasSelfChange = allChanges.some((c) => c.target === 'self');
+  if (
+    moveTypeImmune &&
+    move.data.power === 0 &&
+    hasOpponentChange &&
+    !hasSelfChange
+  ) {
+    messages.push('효과가 없는 듯하다...');
+    return { defenderFainted: false };
+  }
+
   // Accuracy check
   if (!checkAccuracy(attacker, defender, move.data)) {
     messages.push(t('battle.miss', { name: attacker.displayName }));
     return { defenderFainted: false };
   }
-
-  // Move-type effectiveness (shared by damage, messages, and effect gating)
-  const effMsg = getEffectivenessMessage(move.data.type, defender.types);
-  const moveTypeImmune = effMsg === 'effect_immune';
 
   // Fire-type thaw: only damaging fire hits thaw the defender. A non-damaging
   // fire status move (e.g. will-o-wisp) must not thaw a frozen target, or it

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -192,8 +192,12 @@ function applyMoveStatChanges(
   defender: BattlePokemon,
   move: MoveData,
   messages: string[],
+  moveTypeImmuneToDefender: boolean,
 ): void {
   for (const change of move.statChanges ?? []) {
+    // Type-immune moves cannot debuff their immune target. Self-buff
+    // changes are unaffected (they always land on the attacker).
+    if (change.target === 'opponent' && moveTypeImmuneToDefender) continue;
     if (Math.random() * 100 >= change.chance) continue;
     const target = change.target === 'self' ? attacker : defender;
     applyStatChange(target, change.stat, change.stages, messages);
@@ -360,11 +364,11 @@ function executeMove(
   }
 
   if (move.data.power > 0 && damage > 0 && !defender.fainted) {
-    applyMoveStatChanges(attacker, defender, move.data, messages);
+    applyMoveStatChanges(attacker, defender, move.data, messages, moveTypeImmune);
   }
 
   if (move.data.power === 0) {
-    applyMoveStatChanges(attacker, defender, move.data, messages);
+    applyMoveStatChanges(attacker, defender, move.data, messages, moveTypeImmune);
   }
 
   // Roll secondary effect — blocked if the move type has no effect on the defender

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -1,3 +1,4 @@
+import { t } from '../i18n/index.js';
 import { getTypeEffectiveness } from './type-chart.js';
 import type {
   BaseStats,
@@ -12,6 +13,8 @@ import type {
 import {
   getParalysisSpeedMultiplier,
   getBurnAttackMultiplier,
+  checkSleepSkip,
+  checkFreezeSkip,
   checkParalysisSkip,
   applyEndOfTurnEffects,
   rollMoveEffect,
@@ -66,6 +69,7 @@ export function createBattlePokemon(
     fainted: false,
     statusCondition: null,
     toxicCounter: 0,
+    sleepCounter: 0,
   };
 }
 
@@ -239,9 +243,14 @@ function executeMove(
     }
   }
 
-  // Paralysis full-skip check — only applies to chosen moves, never to
-  // mandatory Struggle. This preserves the invariant that a no-PP turn always
-  // resolves through Struggle recoil.
+  if (!isStruggle && checkSleepSkip(attacker, messages)) {
+    return { defenderFainted: false };
+  }
+
+  if (!isStruggle && checkFreezeSkip(attacker, move, messages)) {
+    return { defenderFainted: false };
+  }
+
   if (!isStruggle && checkParalysisSkip(attacker, messages)) {
     return { defenderFainted: false };
   }
@@ -263,7 +272,15 @@ function executeMove(
   const effMsg = getEffectivenessMessage(move.data.type, defender.types);
   const moveTypeImmune = effMsg === 'effect_immune';
 
-  // Damage calculation
+  if (
+    defender.statusCondition === 'freeze' &&
+    move.data.type === 'fire' &&
+    !moveTypeImmune
+  ) {
+    defender.statusCondition = null;
+    messages.push(t('status.freeze.thawed', { name: defender.displayName }));
+  }
+
   const damage = calculateDamage(attacker, defender, move);
   defender.currentHp = Math.max(0, defender.currentHp - damage);
 

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -205,8 +205,15 @@ function executeSwitch(
   targetIndex: number,
   messages: string[],
 ): void {
-  // Reject invalid switch targets
-  if (targetIndex < 0 || targetIndex >= team.pokemon.length || team.pokemon[targetIndex].fainted) {
+  // Reject invalid switch targets — including no-op same-slot switches.
+  // A same-slot switch must not reach the reset path below, otherwise it would
+  // act as a free, priority cleanse for stat stages without leaving the field.
+  if (
+    targetIndex < 0 ||
+    targetIndex >= team.pokemon.length ||
+    team.pokemon[targetIndex].fainted ||
+    targetIndex === team.activeIndex
+  ) {
     return;
   }
   const old = getActivePokemon(team);

--- a/src/core/turn-battle.ts
+++ b/src/core/turn-battle.ts
@@ -1,5 +1,12 @@
 import { t } from '../i18n/index.js';
 import { getTypeEffectiveness } from './type-chart.js';
+import {
+  applyStatChange,
+  createStatStages,
+  getAccEvaMultiplier,
+  getStatMultiplier,
+  resetStatStages,
+} from './stat-stages.js';
 import type {
   BaseStats,
   MoveData,
@@ -70,6 +77,7 @@ export function createBattlePokemon(
     statusCondition: null,
     toxicCounter: 0,
     sleepCounter: 0,
+    statStages: createStatStages(),
   };
 }
 
@@ -83,10 +91,19 @@ export function calculateDamage(
   const power = move.data.power;
   if (!power || power <= 0) return 0;
 
-  const rawAtk = move.data.category === 'physical' ? attacker.attack : attacker.spAttack;
-  const burnMod = move.data.category === 'physical' ? getBurnAttackMultiplier(attacker) : 1.0;
-  const atk = Math.floor(rawAtk * burnMod);
-  const def = Math.max(1, move.data.category === 'physical' ? defender.defense : defender.spDefense);
+  const isPhysical = move.data.category === 'physical';
+  const attackStat = isPhysical ? attacker.attack : attacker.spAttack;
+  const defenseStat = isPhysical ? defender.defense : defender.spDefense;
+  const attackStage = isPhysical ? attacker.statStages.attack : attacker.statStages.spAttack;
+  const defenseStage = isPhysical ? defender.statStages.defense : defender.statStages.spDefense;
+
+  const effectiveAttack =
+    attackStat *
+    getStatMultiplier(attackStage) *
+    (isPhysical ? getBurnAttackMultiplier(attacker) : 1);
+  const effectiveDefense = defenseStat * getStatMultiplier(defenseStage);
+  const atk = Math.floor(effectiveAttack);
+  const def = Math.max(1, Math.floor(effectiveDefense));
 
   const base = Math.floor(
     ((2 * attacker.level / 5 + 2) * power * atk) / def / 50 + 2,
@@ -123,9 +140,17 @@ export function getEffectivenessMessage(
 
 // ── Accuracy Check ──
 
-export function checkAccuracy(move: BattleMove): boolean {
-  if (move.data.accuracy <= 0) return true; // always-hit moves
-  return Math.random() * 100 < move.data.accuracy;
+export function checkAccuracy(
+  attacker: BattlePokemon,
+  defender: BattlePokemon,
+  move: MoveData,
+): boolean {
+  if (move.accuracy === null) return true;
+  const hitChance =
+    move.accuracy *
+    getAccEvaMultiplier(attacker.statStages.accuracy) /
+    getAccEvaMultiplier(defender.statStages.evasion);
+  return Math.random() * 100 < hitChance;
 }
 
 // ── Battle State Factory ──
@@ -162,6 +187,19 @@ interface ActionEntry {
   pokemon: BattlePokemon;
 }
 
+function applyMoveStatChanges(
+  attacker: BattlePokemon,
+  defender: BattlePokemon,
+  move: MoveData,
+  messages: string[],
+): void {
+  for (const change of move.statChanges ?? []) {
+    if (Math.random() * 100 >= change.chance) continue;
+    const target = change.target === 'self' ? attacker : defender;
+    applyStatChange(target, change.stat, change.stages, messages);
+  }
+}
+
 function executeSwitch(
   team: BattleTeam,
   targetIndex: number,
@@ -177,8 +215,10 @@ function executeSwitch(
   if (old.statusCondition === 'badly_poisoned') {
     old.toxicCounter = 1;
   }
-  const next = getActivePokemon(team);
-  messages.push(`${old.displayName}에서 ${next.displayName}(으)로 교체!`);
+  const active = getActivePokemon(team);
+  active.toxicCounter = active.statusCondition === 'badly_poisoned' ? active.toxicCounter : 0;
+  resetStatStages(active);
+  messages.push(t('battle.switch', { name: active.displayName }));
 }
 
 const STRUGGLE_MOVE: BattleMove = {
@@ -266,8 +306,8 @@ function executeMove(
   }
 
   // Accuracy check
-  if (!checkAccuracy(move)) {
-    messages.push('공격이 빗나갔다!');
+  if (!checkAccuracy(attacker, defender, move.data)) {
+    messages.push(t('battle.miss', { name: attacker.displayName }));
     return { defenderFainted: false };
   }
 
@@ -310,6 +350,14 @@ function executeMove(
     defender.fainted = true;
     messages.push(`${defender.displayName}은(는) 쓰러졌다!`);
     return { defenderFainted: true };
+  }
+
+  if (move.data.power > 0 && damage > 0 && !defender.fainted) {
+    applyMoveStatChanges(attacker, defender, move.data, messages);
+  }
+
+  if (move.data.power === 0) {
+    applyMoveStatChanges(attacker, defender, move.data, messages);
   }
 
   // Roll secondary effect — blocked if the move type has no effect on the defender
@@ -358,8 +406,16 @@ export function resolveTurn(
     const bPriority = b.action.type === 'switch' ? 0 : 1;
     if (aPriority !== bPriority) return aPriority - bPriority;
     // Same priority → speed
-    const aSpeed = Math.floor(a.pokemon.speed * getParalysisSpeedMultiplier(a.pokemon));
-    const bSpeed = Math.floor(b.pokemon.speed * getParalysisSpeedMultiplier(b.pokemon));
+    const aSpeed = Math.floor(
+      a.pokemon.speed *
+      getStatMultiplier(a.pokemon.statStages.speed) *
+      getParalysisSpeedMultiplier(a.pokemon),
+    );
+    const bSpeed = Math.floor(
+      b.pokemon.speed *
+      getStatMultiplier(b.pokemon.statStages.speed) *
+      getParalysisSpeedMultiplier(b.pokemon),
+    );
     if (aSpeed !== bSpeed) return bSpeed - aSpeed;
     // Random tiebreak
     return Math.random() < 0.5 ? -1 : 1;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -467,7 +467,13 @@ export interface StdinData {
 
 export type MoveCategory = 'physical' | 'special' | 'status';
 
-export type StatusCondition = 'burn' | 'poison' | 'badly_poisoned' | 'paralysis';
+export type StatusCondition =
+  | 'burn'
+  | 'poison'
+  | 'badly_poisoned'
+  | 'paralysis'
+  | 'sleep'
+  | 'freeze';
 
 export interface MoveData {
   id: number;
@@ -511,6 +517,7 @@ export interface BattlePokemon {
   fainted: boolean;
   statusCondition: StatusCondition | null;
   toxicCounter: number;
+  sleepCounter: number;
 }
 
 export interface BattleTeam {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -475,6 +475,23 @@ export type StatusCondition =
   | 'sleep'
   | 'freeze';
 
+export interface StatStages {
+  attack: number;
+  defense: number;
+  spAttack: number;
+  spDefense: number;
+  speed: number;
+  accuracy: number;
+  evasion: number;
+}
+
+export interface StatChange {
+  target: 'self' | 'opponent';
+  stat: keyof StatStages;
+  stages: number;
+  chance: number;
+}
+
 export interface MoveData {
   id: number;
   name: string;
@@ -483,12 +500,13 @@ export interface MoveData {
   type: string;
   category: MoveCategory;
   power: number;
-  accuracy: number;
+  accuracy: number | null;
   pp: number;
   effect?: {
     type: StatusCondition;
     chance: number;
   };
+  statChanges?: StatChange[];
 }
 
 export interface PokemonMovePool {
@@ -518,6 +536,7 @@ export interface BattlePokemon {
   statusCondition: StatusCondition | null;
   toxicCounter: number;
   sleepCounter: number;
+  statStages: StatStages;
 }
 
 export interface BattleTeam {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -588,6 +588,12 @@
 
   "status.paralysis.inflicted": "{name} is paralyzed! It may be unable to move!",
   "status.paralysis.immobile": "{name} is paralyzed! It can't move!",
+  "status.sleep.inflicted": "{name} fell asleep!",
+  "status.sleep.wake": "{name} woke up!",
+  "status.sleep.still_asleep": "{name} is fast asleep!",
+  "status.freeze.inflicted": "{name} was frozen solid!",
+  "status.freeze.thawed": "{name} thawed out!",
+  "status.freeze.still_frozen": "{name} is frozen solid!",
   "status.burn.inflicted": "{name} was burned!",
   "status.burn.damage": "{name} is hurt by its burn!",
   "status.poison.inflicted": "{name} was poisoned!",
@@ -599,8 +605,12 @@
   "status.name.burn": "burn",
   "status.name.poison": "poison",
   "status.name.paralysis": "paralysis",
+  "status.name.sleep": "sleep",
+  "status.name.freeze": "freeze",
   "status.label.burn": "BRN",
   "status.label.poison": "PSN",
   "status.label.badly_poisoned": "TOX",
-  "status.label.paralysis": "PRZ"
+  "status.label.paralysis": "PRZ",
+  "status.label.sleep": "SLP",
+  "status.label.freeze": "FRZ"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -363,6 +363,8 @@
   "battle.gym_challenge": "{leader} wants to battle!",
   "battle.send_out": "{leader} sent out {pokemon}!",
   "battle.go": "Go, {pokemon}!",
+  "battle.switch": "Go! {name}!",
+  "battle.miss": "{name}'s attack missed!",
   "battle.victory": "You defeated {leader}!",
   "battle.defeat": "You lost to {leader}...",
   "battle.select_switch": "Choose a Pokémon to switch to:",
@@ -612,5 +614,18 @@
   "status.label.badly_poisoned": "TOX",
   "status.label.paralysis": "PRZ",
   "status.label.sleep": "SLP",
-  "status.label.freeze": "FRZ"
+  "status.label.freeze": "FRZ",
+  "stat.rose": "{name}'s {stat} rose!",
+  "stat.rose_sharply": "{name}'s {stat} rose sharply!",
+  "stat.fell": "{name}'s {stat} fell!",
+  "stat.fell_harshly": "{name}'s {stat} fell harshly!",
+  "stat.cannot_rise": "{name}'s {stat} won't go any higher!",
+  "stat.cannot_fall": "{name}'s {stat} won't go any lower!",
+  "stat.name.attack": "Attack",
+  "stat.name.defense": "Defense",
+  "stat.name.sp_attack": "Sp. Atk",
+  "stat.name.sp_defense": "Sp. Def",
+  "stat.name.speed": "Speed",
+  "stat.name.accuracy": "Accuracy",
+  "stat.name.evasion": "Evasion"
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -588,6 +588,12 @@
 
   "status.paralysis.inflicted": "{name:은/는} 마비되었다!",
   "status.paralysis.immobile": "{name:은/는} 몸이 저려 움직일 수 없다!",
+  "status.sleep.inflicted": "{name:은/는} 잠들었다!",
+  "status.sleep.wake": "{name:은/는} 잠에서 깨어났다!",
+  "status.sleep.still_asleep": "{name:은/는} 곤히 잠들어 있다!",
+  "status.freeze.inflicted": "{name:은/는} 얼어붙었다!",
+  "status.freeze.thawed": "{name:은/는} 얼음이 녹았다!",
+  "status.freeze.still_frozen": "{name:은/는} 얼어붙어 움직일 수 없다!",
   "status.burn.inflicted": "{name:은/는} 화상을 입었다!",
   "status.burn.damage": "{name:은/는} 화상 데미지를 입었다!",
   "status.poison.inflicted": "{name:은/는} 독에 걸렸다!",
@@ -599,8 +605,12 @@
   "status.name.burn": "화상",
   "status.name.poison": "독",
   "status.name.paralysis": "마비",
+  "status.name.sleep": "수면",
+  "status.name.freeze": "빙결",
   "status.label.burn": "화상",
   "status.label.poison": "독",
   "status.label.badly_poisoned": "맹독",
-  "status.label.paralysis": "마비"
+  "status.label.paralysis": "마비",
+  "status.label.sleep": "수면",
+  "status.label.freeze": "빙결"
 }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -363,6 +363,8 @@
   "battle.gym_challenge": "{leader:이/가} 승부를 걸어왔다!",
   "battle.send_out": "{leader:은/는} {pokemon:을/를} 내보냈다!",
   "battle.go": "가라, {pokemon}!",
+  "battle.switch": "{name}(으)로 교체!",
+  "battle.miss": "{name}의 공격이 빗나갔다!",
   "battle.victory": "{leader}에게 승리했다!",
   "battle.defeat": "{leader}에게 패배했다...",
   "battle.select_switch": "교체할 포켓몬을 선택하세요:",
@@ -612,5 +614,18 @@
   "status.label.badly_poisoned": "맹독",
   "status.label.paralysis": "마비",
   "status.label.sleep": "수면",
-  "status.label.freeze": "빙결"
+  "status.label.freeze": "빙결",
+  "stat.rose": "{name}의 {stat}이(가) 올라갔다!",
+  "stat.rose_sharply": "{name}의 {stat}이(가) 크게 올라갔다!",
+  "stat.fell": "{name}의 {stat}이(가) 내려갔다!",
+  "stat.fell_harshly": "{name}의 {stat}이(가) 크게 내려갔다!",
+  "stat.cannot_rise": "{name}의 {stat}은(는) 더이상 올라가지 않는다!",
+  "stat.cannot_fall": "{name}의 {stat}은(는) 더이상 내려가지 않는다!",
+  "stat.name.attack": "공격",
+  "stat.name.defense": "방어",
+  "stat.name.sp_attack": "특수공격",
+  "stat.name.sp_defense": "특수방어",
+  "stat.name.speed": "스피드",
+  "stat.name.accuracy": "명중률",
+  "stat.name.evasion": "회피율"
 }

--- a/src/status-line.ts
+++ b/src/status-line.ts
@@ -467,6 +467,8 @@ function renderBattleMode(battleData: {
     poison: '\x1b[35m[PSN]\x1b[0m',
     badly_poisoned: '\x1b[35m[TOX]\x1b[0m',
     paralysis: '\x1b[33m[PRZ]\x1b[0m',
+    sleep: '\x1b[33m[SLP]\x1b[0m',
+    freeze: '\x1b[36m[FRZ]\x1b[0m',
   };
   const oppStatusMark = oppMon.statusCondition ? ' ' + (statusLabels[oppMon.statusCondition] || '') : '';
   const playerStatusMark = playerMon.statusCondition ? ' ' + (statusLabels[playerMon.statusCondition] || '') : '';

--- a/test/battle-state-migration.test.ts
+++ b/test/battle-state-migration.test.ts
@@ -100,4 +100,44 @@ describe('battle state migration', () => {
     mon.statusCondition = 'burn';
     assert.equal(mon.statusCondition, 'burn');
   });
+
+  it('normalizeBattlePokemon backfills missing sleepCounter to 0 (v3a)', () => {
+    const mon = makeLegacyPokemon();
+    assert.equal((mon as any).sleepCounter, undefined);
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+  });
+
+  it('normalizeBattlePokemon coerces NaN/infinite sleepCounter to 0', () => {
+    const mon = makeLegacyPokemon();
+    mon.sleepCounter = NaN as unknown as number;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+
+    mon.sleepCounter = Infinity;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 0);
+  });
+
+  it('normalizeBattlePokemon preserves existing sleepCounter', () => {
+    const mon = makeLegacyPokemon();
+    mon.sleepCounter = 2;
+    normalizeBattlePokemon(mon);
+    assert.equal(mon.sleepCounter, 2);
+  });
+
+  it('resumed legacy sleeping mon can wake up without NaN soft-lock', async () => {
+    // Regression for v3a R2 finding: a legacy save with statusCondition='sleep'
+    // but sleepCounter=undefined would otherwise decrement to NaN and trap the
+    // mon in permanent sleep. After migration, the mon should wake up on the
+    // first checkSleepSkip call (counter 0 → wake).
+    const { checkSleepSkip } = await import('../src/core/status-effects.js');
+    const mon = makeLegacyPokemon();
+    mon.statusCondition = 'sleep';
+    normalizeBattlePokemon(mon);
+    const msgs: string[] = [];
+    const skipped = checkSleepSkip(mon, msgs);
+    assert.equal(skipped, true, 'Should skip this turn');
+    assert.equal(mon.statusCondition, null, 'Should wake up (not stuck in permanent sleep)');
+  });
 });

--- a/test/battle-state-migration.test.ts
+++ b/test/battle-state-migration.test.ts
@@ -126,6 +126,21 @@ describe('battle state migration', () => {
     assert.equal(mon.sleepCounter, 2);
   });
 
+  it('normalizeBattlePokemon backfills missing statStages to zeroes (v3b)', () => {
+    const mon = makeLegacyPokemon();
+    assert.equal((mon as any).statStages, undefined);
+    normalizeBattlePokemon(mon);
+    assert.deepEqual(mon.statStages, {
+      attack: 0,
+      defense: 0,
+      spAttack: 0,
+      spDefense: 0,
+      speed: 0,
+      accuracy: 0,
+      evasion: 0,
+    });
+  });
+
   it('resumed legacy sleeping mon can wake up without NaN soft-lock', async () => {
     // Regression for v3a R2 finding: a legacy save with statusCondition='sleep'
     // but sleepCounter=undefined would otherwise decrement to NaN and trap the

--- a/test/gym-ai.test.ts
+++ b/test/gym-ai.test.ts
@@ -160,3 +160,80 @@ describe('selectAiMove with status moves', () => {
     assert.equal(statusCount, 0, 'Should never pick Thunder Wave against Ground (move-type immune)');
   });
 });
+
+describe('selectAiMove with stat-change moves (debuff scoring)', () => {
+  // Regression for v3b R2: opponent debuff scoring was inverted, so the AI
+  // valued redundant drops on already-debuffed targets and ignored buffed
+  // ones. The fix uses headroom toward -6 instead of raw stage.
+
+  const weakTackle: MoveData = {
+    id: 33, name: 'tackle', nameKo: '몸통박치기', nameEn: 'Tackle',
+    type: 'normal', category: 'physical', power: 10, accuracy: 100, pp: 35,
+  };
+  const growl: MoveData = {
+    id: 45, name: 'growl', nameKo: '울음소리', nameEn: 'Growl',
+    type: 'normal', category: 'status' as any, power: 0, accuracy: 100, pp: 40,
+    statChanges: [{ target: 'opponent', stat: 'attack', stages: -1, chance: 100 }],
+  } as any;
+
+  function makeNormalDefender(): BattlePokemon {
+    return createBattlePokemon(
+      { id: 100, types: ['normal'], level: 30, baseStats: { hp: 80, attack: 60, defense: 50, speed: 50, sp_attack: 50, sp_defense: 50 } },
+      [tackle],
+    );
+  }
+
+  function makeAttackerWithDebuff(): BattlePokemon {
+    return createBattlePokemon(
+      { id: 25, types: ['normal'], level: 30, baseStats: { hp: 35, attack: 55, defense: 40, speed: 90, sp_attack: 50, sp_defense: 50 } },
+      [weakTackle, growl],
+    );
+  }
+
+  it('never uses debuff against a target already at -6 in the relevant stat', () => {
+    let debuffCount = 0;
+    for (let i = 0; i < 100; i++) {
+      const defender = makeNormalDefender();
+      defender.statStages.attack = -6;
+      if (selectAiMove(makeAttackerWithDebuff(), defender) === 1) debuffCount++;
+    }
+    assert.equal(debuffCount, 0, 'Should never pick growl when target attack is already at -6');
+  });
+
+  it('prioritizes debuff against a buffed target over a weak attack', () => {
+    // weakTackle scores ~10 (10 * 1 * 1). growl against +6 attack scores
+    // 40 * 12/12 = 40. So debuff should be picked the vast majority of the
+    // time (80% best + 20% random tiebreak).
+    let debuffCount = 0;
+    for (let i = 0; i < 200; i++) {
+      const defender = makeNormalDefender();
+      defender.statStages.attack = 6;
+      if (selectAiMove(makeAttackerWithDebuff(), defender) === 1) debuffCount++;
+    }
+    assert.ok(
+      debuffCount > 150,
+      `Expected debuff vs +6 attacker to be picked >150/200, got ${debuffCount}`,
+    );
+  });
+
+  it('debuff scoring decays as defender approaches -6 (monotonic with headroom)', () => {
+    // Compare selection rates at stages -3 vs +3 to verify the headroom-based
+    // scoring (not the inverted raw-stage one). +3 should yield more debuff
+    // selections than -3.
+    let countAtMinus3 = 0;
+    let countAtPlus3 = 0;
+    for (let i = 0; i < 200; i++) {
+      const defA = makeNormalDefender();
+      defA.statStages.attack = -3;
+      if (selectAiMove(makeAttackerWithDebuff(), defA) === 1) countAtMinus3++;
+
+      const defB = makeNormalDefender();
+      defB.statStages.attack = 3;
+      if (selectAiMove(makeAttackerWithDebuff(), defB) === 1) countAtPlus3++;
+    }
+    assert.ok(
+      countAtPlus3 > countAtMinus3,
+      `Buffed (+3) should be debuffed more often than already-debuffed (-3): +3=${countAtPlus3} vs -3=${countAtMinus3}`,
+    );
+  });
+});

--- a/test/gym-ai.test.ts
+++ b/test/gym-ai.test.ts
@@ -216,6 +216,20 @@ describe('selectAiMove with stat-change moves (debuff scoring)', () => {
     );
   });
 
+  it('never uses normal-type debuff against Ghost (move-type immune)', () => {
+    // Regression for v3b R3: AI was scoring growl normally against Ghost,
+    // even though normal-type moves cannot land on Ghost types.
+    let debuffCount = 0;
+    for (let i = 0; i < 100; i++) {
+      const ghostDefender = createBattlePokemon(
+        { id: 92, types: ['ghost'], level: 30, baseStats: { hp: 30, attack: 35, defense: 30, speed: 80, sp_attack: 100, sp_defense: 35 } },
+        [tackle],
+      );
+      if (selectAiMove(makeAttackerWithDebuff(), ghostDefender) === 1) debuffCount++;
+    }
+    assert.equal(debuffCount, 0, 'AI should never pick growl against Ghost-type');
+  });
+
   it('debuff scoring decays as defender approaches -6 (monotonic with headroom)', () => {
     // Compare selection rates at stages -3 vs +3 to verify the headroom-based
     // scoring (not the inverted raw-stage one). +3 should yield more debuff

--- a/test/status-effects.test.ts
+++ b/test/status-effects.test.ts
@@ -1,10 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { initLocale } from '../src/i18n/index.js';
-import type { BattlePokemon, StatusCondition } from '../src/core/types.js';
+import type { BattleMove, BattlePokemon } from '../src/core/types.js';
 import {
-  isStatusImmune, tryApplyStatus, checkParalysisSkip,
-  getBurnAttackMultiplier, getParalysisSpeedMultiplier,
+  isStatusImmune,
+  tryApplyStatus,
+  checkParalysisSkip,
+  checkSleepSkip,
+  checkFreezeSkip,
+  FROZEN_EXCEPTION_MOVES,
+  getBurnAttackMultiplier,
+  getParalysisSpeedMultiplier,
   applyEndOfTurnEffects,
 } from '../src/core/status-effects.js';
 
@@ -15,7 +21,7 @@ function makePokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
     id: 1, name: '1', displayName: 'Test', types: ['normal'], level: 50,
     maxHp: 160, currentHp: 160, attack: 60, defense: 50, spAttack: 55,
     spDefense: 50, speed: 70, moves: [], fainted: false,
-    statusCondition: null, toxicCounter: 0, ...overrides,
+    statusCondition: null, toxicCounter: 0, sleepCounter: 0, ...overrides,
   };
 }
 
@@ -27,10 +33,16 @@ describe('isStatusImmune', () => {
   it('steel type NOT immune to burn', () => { assert.equal(isStatusImmune(makePokemon({ types: ['steel'] }), 'burn'), false); });
   it('fire type immune to burn', () => { assert.equal(isStatusImmune(makePokemon({ types: ['fire'] }), 'burn'), true); });
   it('electric type immune to paralysis', () => { assert.equal(isStatusImmune(makePokemon({ types: ['electric'] }), 'paralysis'), true); });
+  it('ice type immune to freeze', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['ice'] }), 'freeze'), true);
+  });
   it('normal type not immune', () => {
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'burn'), false);
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'poison'), false);
     assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'paralysis'), false);
+  });
+  it('normal type not immune to sleep', () => {
+    assert.equal(isStatusImmune(makePokemon({ types: ['normal'] }), 'sleep'), false);
   });
   it('dual-type with immune type blocks', () => { assert.equal(isStatusImmune(makePokemon({ types: ['water', 'poison'] }), 'poison'), true); });
 });
@@ -57,6 +69,23 @@ describe('tryApplyStatus', () => {
     tryApplyStatus(mon, 'badly_poisoned', []);
     assert.equal(mon.statusCondition, 'badly_poisoned');
     assert.equal(mon.toxicCounter, 1);
+  });
+  it('inits sleepCounter for sleep in the 1..3 range', () => {
+    const mon = makePokemon();
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.6; // floor(1.8) + 1 = 2
+      assert.equal(tryApplyStatus(mon, 'sleep', []), true);
+      assert.equal(mon.statusCondition, 'sleep');
+      assert.equal(mon.sleepCounter, 2);
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+  it('blocks freeze on ice types', () => {
+    const mon = makePokemon({ types: ['ice'] });
+    assert.equal(tryApplyStatus(mon, 'freeze', []), false);
+    assert.equal(mon.statusCondition, null);
   });
   it('does not apply to fainted', () => {
     assert.equal(tryApplyStatus(makePokemon({ fainted: true }), 'burn', []), false);
@@ -118,5 +147,67 @@ describe('checkParalysisSkip', () => {
     let skips = 0;
     for (let i = 0; i < 1000; i++) if (checkParalysisSkip(mon, [])) skips++;
     assert.ok(skips > 150 && skips < 350, `Expected ~250 skips, got ${skips}`);
+  });
+});
+
+describe('checkSleepSkip', () => {
+  it('sleeping pokemon stays asleep when counter remains above zero', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 3 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, 'sleep');
+    assert.equal(mon.sleepCounter, 2);
+    assert.ok(messages.some((m) => m.includes('잠들어')));
+  });
+
+  it('sleeping pokemon wakes when counter reaches zero but still skips turn', () => {
+    const mon = makePokemon({ statusCondition: 'sleep', sleepCounter: 1 });
+    const messages: string[] = [];
+    assert.equal(checkSleepSkip(mon, messages), true);
+    assert.equal(mon.statusCondition, null);
+    assert.equal(mon.sleepCounter, 0);
+    assert.ok(messages.some((m) => m.includes('깨어났다')));
+  });
+});
+
+describe('checkFreezeSkip', () => {
+  it('frozen pokemon skips when thaw roll fails', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as BattleMove;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      assert.equal(checkFreezeSkip(mon, move, messages), true);
+      assert.equal(mon.statusCondition, 'freeze');
+      assert.ok(messages.some((m) => m.includes('얼어붙어')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('frozen pokemon thaws on successful thaw roll', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'tackle' } } as BattleMove;
+    const messages: string[] = [];
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.1;
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('exception moves can be used while frozen and thaw the user', () => {
+    const mon = makePokemon({ statusCondition: 'freeze' });
+    const move = { data: { name: 'scald' } } as BattleMove;
+    const messages: string[] = [];
+    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
+    assert.equal(checkFreezeSkip(mon, move, messages), false);
+    assert.equal(mon.statusCondition, null);
+    assert.ok(messages.some((m) => m.includes('녹았다')));
   });
 });

--- a/test/status-effects.test.ts
+++ b/test/status-effects.test.ts
@@ -202,12 +202,14 @@ describe('checkFreezeSkip', () => {
   });
 
   it('exception moves can be used while frozen and thaw the user', () => {
-    const mon = makePokemon({ statusCondition: 'freeze' });
-    const move = { data: { name: 'scald' } } as BattleMove;
-    const messages: string[] = [];
-    assert.ok(FROZEN_EXCEPTION_MOVES.has('scald'));
-    assert.equal(checkFreezeSkip(mon, move, messages), false);
-    assert.equal(mon.statusCondition, null);
-    assert.ok(messages.some((m) => m.includes('녹았다')));
+    for (const moveName of ['scald', 'pyro-ball', 'matcha-gotcha']) {
+      const mon = makePokemon({ statusCondition: 'freeze' });
+      const move = { data: { name: moveName } } as BattleMove;
+      const messages: string[] = [];
+      assert.ok(FROZEN_EXCEPTION_MOVES.has(moveName));
+      assert.equal(checkFreezeSkip(mon, move, messages), false);
+      assert.equal(mon.statusCondition, null);
+      assert.ok(messages.some((m) => m.includes('녹았다')));
+    }
   });
 });

--- a/test/status-effects.test.ts
+++ b/test/status-effects.test.ts
@@ -3,6 +3,13 @@ import assert from 'node:assert/strict';
 import { initLocale } from '../src/i18n/index.js';
 import type { BattleMove, BattlePokemon } from '../src/core/types.js';
 import {
+  applyStatChange,
+  createStatStages,
+  getAccEvaMultiplier,
+  getStatMultiplier,
+  resetStatStages,
+} from '../src/core/stat-stages.js';
+import {
   isStatusImmune,
   tryApplyStatus,
   checkParalysisSkip,
@@ -21,7 +28,8 @@ function makePokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon {
     id: 1, name: '1', displayName: 'Test', types: ['normal'], level: 50,
     maxHp: 160, currentHp: 160, attack: 60, defense: 50, spAttack: 55,
     spDefense: 50, speed: 70, moves: [], fainted: false,
-    statusCondition: null, toxicCounter: 0, sleepCounter: 0, ...overrides,
+    statusCondition: null, toxicCounter: 0, sleepCounter: 0,
+    statStages: createStatStages(), ...overrides,
   };
 }
 
@@ -100,6 +108,36 @@ describe('getBurnAttackMultiplier', () => {
 describe('getParalysisSpeedMultiplier', () => {
   it('0.5 for paralyzed', () => { assert.equal(getParalysisSpeedMultiplier(makePokemon({ statusCondition: 'paralysis' })), 0.5); });
   it('1.0 for normal', () => { assert.equal(getParalysisSpeedMultiplier(makePokemon()), 1.0); });
+});
+
+describe('stat stage helpers', () => {
+  it('getStatMultiplier matches the battle-stage formula at +2 and -6', () => {
+    assert.equal(getStatMultiplier(2), 2);
+    assert.equal(getStatMultiplier(-6), 0.25);
+  });
+
+  it('getAccEvaMultiplier matches the accuracy/evasion formula at +1 and +6', () => {
+    assert.equal(getAccEvaMultiplier(1), 4 / 3);
+    assert.equal(getAccEvaMultiplier(6), 3);
+  });
+
+  it('applyStatChange clamps at +6 and emits cap messaging', () => {
+    const mon = makePokemon({ statStages: { ...createStatStages(), attack: 6 } });
+    const msgs: string[] = [];
+    const changed = applyStatChange(mon, 'attack', 2, msgs);
+    assert.equal(changed, false);
+    assert.equal(mon.statStages.attack, 6);
+    assert.ok(msgs[0].includes('공격'));
+    assert.ok(msgs[0].includes('올라가지 않는다'));
+  });
+
+  it('resetStatStages zeroes out existing boosts and drops', () => {
+    const mon = makePokemon({
+      statStages: { ...createStatStages(), attack: 2, defense: -1, speed: 4 },
+    });
+    resetStatStages(mon);
+    assert.deepEqual(mon.statStages, createStatStages());
+  });
 });
 
 describe('applyEndOfTurnEffects', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -734,30 +734,38 @@ describe('resolveTurn with status effects', () => {
   });
 
   it('freeze exception moves act normally and thaw the user', () => {
-    const player = makeTestPokemon({
-      displayName: 'Frozen',
-      speed: 999,
-      statusCondition: 'freeze' as StatusCondition,
-      moves: [{
-        data: makeMoveData({
-          name: 'scald',
-          nameKo: '열탕',
-          type: 'water',
-          category: 'special',
-          power: 80,
-          accuracy: 100,
-          pp: 15,
-        }),
-        currentPp: 15,
-      }],
-    });
-    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
-    const state = createBattleState([player], [opp]);
+    const thawMoves = [
+      { name: 'scald', nameKo: '열탕', type: 'water', category: 'special' as const, power: 80, pp: 15 },
+      { name: 'pyro-ball', nameKo: '화염볼', type: 'fire', category: 'physical' as const, power: 120, pp: 5 },
+      { name: 'matcha-gotcha', nameKo: '말차고차', type: 'grass', category: 'special' as const, power: 80, pp: 15 },
+    ];
 
-    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+    for (const thawMove of thawMoves) {
+      const player = makeTestPokemon({
+        displayName: 'Frozen',
+        speed: 999,
+        statusCondition: 'freeze' as StatusCondition,
+        moves: [{
+          data: makeMoveData({
+            name: thawMove.name,
+            nameKo: thawMove.nameKo,
+            type: thawMove.type,
+            category: thawMove.category,
+            power: thawMove.power,
+            accuracy: 100,
+            pp: thawMove.pp,
+          }),
+          currentPp: thawMove.pp,
+        }],
+      });
+      const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+      const state = createBattleState([player], [opp]);
 
-    assert.equal(player.statusCondition, null);
-    assert.equal(player.moves[0].currentPp, 14);
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+      assert.equal(player.statusCondition, null, `${thawMove.name} should thaw the user`);
+      assert.equal(player.moves[0].currentPp, thawMove.pp - 1, `${thawMove.name} should consume PP`);
+    }
   });
 
   it('fire-type attacks thaw frozen defenders before damage', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -557,6 +557,51 @@ describe('resolveTurn', () => {
     );
   });
 
+  it('type-immune debuff with <100 accuracy reports immunity, not miss', () => {
+    // Regression for v3b R4: Screech (85 acc, normal-type, opponent debuff)
+    // into Ghost should report immunity even when the accuracy roll would
+    // have failed. Previously the accuracy gate ran first and emitted "miss".
+    const screechMove: BattleMove = {
+      data: {
+        ...makeMoveData({ type: 'normal', category: 'physical', power: 0, accuracy: 85 }),
+        statChanges: [{ target: 'opponent', stat: 'defense', stages: -2, chance: 100 }],
+      } as any,
+      currentPp: 40,
+    };
+    const player = makeTestPokemon({
+      displayName: 'Screecher',
+      speed: 999,
+      moves: [screechMove],
+    });
+    const ghostDefender = makeTestPokemon({
+      displayName: 'Ghost',
+      types: ['ghost'],
+      speed: 1,
+    });
+    const screechState = createBattleState([player], [ghostDefender]);
+    const origRandom = Math.random;
+    try {
+      // Force a "miss" roll: 0.9 * 100 = 90, 90 < 85 is false → miss
+      Math.random = () => 0.9;
+      const result = resolveTurn(
+        screechState,
+        { type: 'move', moveIndex: 0 },
+        { type: 'move', moveIndex: 0 },
+      );
+      assert.equal(ghostDefender.statStages.defense, 0, 'No debuff applied');
+      assert.ok(
+        result.messages.some((m) => m.includes('효과가 없') || m.toLowerCase().includes('no effect')),
+        `Should report immunity, not miss. Messages: ${JSON.stringify(result.messages)}`,
+      );
+      assert.ok(
+        !result.messages.some((m) => m.includes('빗나갔') || m.toLowerCase().includes('miss')),
+        `Should NOT report miss when target is type-immune`,
+      );
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
   it('type-immune debuff still applies self-buff component if present', () => {
     // Defensive: a hypothetical move that buffs self AND debuffs opponent.
     // The opponent debuff should be blocked by type immunity, but the

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -524,6 +524,73 @@ describe('resolveTurn', () => {
     assert.ok(Array.isArray(result.messages));
   });
 
+  it('type-immune debuff move does not apply stat changes to defender', () => {
+    // Regression for v3b R3 HIGH: growl into a Ghost target was logging
+    // immunity but still dropping the defender's attack stage.
+    const growlMove: BattleMove = {
+      data: {
+        ...makeMoveData({ type: 'normal', category: 'physical', power: 0, accuracy: 100 }),
+        statChanges: [{ target: 'opponent', stat: 'attack', stages: -1, chance: 100 }],
+      } as any,
+      currentPp: 40,
+    };
+    const player = makeTestPokemon({
+      displayName: 'Growler',
+      speed: 999,
+      moves: [growlMove],
+    });
+    const ghostDefender = makeTestPokemon({
+      displayName: 'Ghost',
+      types: ['ghost'],
+      speed: 1,
+    });
+    const ghostState = createBattleState([player], [ghostDefender]);
+    resolveTurn(
+      ghostState,
+      { type: 'move', moveIndex: 0 },
+      { type: 'move', moveIndex: 0 },
+    );
+    assert.equal(
+      ghostDefender.statStages.attack,
+      0,
+      'Ghost defender should not have attack stage dropped by Normal-type debuff',
+    );
+  });
+
+  it('type-immune debuff still applies self-buff component if present', () => {
+    // Defensive: a hypothetical move that buffs self AND debuffs opponent.
+    // The opponent debuff should be blocked by type immunity, but the
+    // self-buff should still land because immunity does not affect self.
+    const dualMove: BattleMove = {
+      data: {
+        ...makeMoveData({ type: 'normal', category: 'physical', power: 0, accuracy: 100 }),
+        statChanges: [
+          { target: 'self', stat: 'attack', stages: 1, chance: 100 },
+          { target: 'opponent', stat: 'defense', stages: -1, chance: 100 },
+        ],
+      } as any,
+      currentPp: 10,
+    };
+    const player = makeTestPokemon({
+      displayName: 'Dual',
+      speed: 999,
+      moves: [dualMove],
+    });
+    const ghostDefender = makeTestPokemon({
+      displayName: 'Ghost',
+      types: ['ghost'],
+      speed: 1,
+    });
+    const dualState = createBattleState([player], [ghostDefender]);
+    resolveTurn(
+      dualState,
+      { type: 'move', moveIndex: 0 },
+      { type: 'move', moveIndex: 0 },
+    );
+    assert.equal(player.statStages.attack, 1, 'Self-buff should still apply');
+    assert.equal(ghostDefender.statStages.defense, 0, 'Opponent debuff should be blocked');
+  });
+
   it('same-slot switch does NOT reset stat stages (no-op cleanse exploit)', () => {
     // Regression: a "switch" action targeting the already-active Pokemon must
     // not act as a free, priority cleanse for stat-stage debuffs. The bug

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -13,6 +13,8 @@ import {
   hasAlivePokemon,
   resolveTurn,
 } from '../src/core/turn-battle.js';
+import { selectAiMove } from '../src/core/gym-ai.js';
+import { createStatStages } from '../src/core/stat-stages.js';
 import type { BattlePokemon, BattleMove, MoveData, BattleState, StatusCondition } from '../src/core/types.js';
 
 initLocale('ko');
@@ -83,6 +85,7 @@ function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon 
     statusCondition: null,
     toxicCounter: 0,
     sleepCounter: 0,
+    statStages: createStatStages(),
     ...overrides,
   };
 }
@@ -167,6 +170,7 @@ describe('createBattlePokemon', () => {
     assert.equal(bp.statusCondition, null);
     assert.equal(bp.toxicCounter, 0);
     assert.equal(bp.sleepCounter, 0);
+    assert.deepEqual(bp.statStages, createStatStages());
   });
 });
 
@@ -252,18 +256,43 @@ describe('getEffectivenessMessage', () => {
 });
 
 describe('checkAccuracy', () => {
-  it('returns true for always-hit moves (accuracy <= 0)', () => {
-    const move: BattleMove = { data: makeMoveData({ accuracy: 0 }), currentPp: 10 };
+  it('returns true for always-hit moves (accuracy null)', () => {
+    const attacker = makeTestPokemon();
+    const defender = makeTestPokemon({ displayName: 'Defender' });
+    const move = makeMoveData({ accuracy: null });
     // Should always return true
     for (let i = 0; i < 50; i++) {
-      assert.equal(checkAccuracy(move), true);
+      assert.equal(checkAccuracy(attacker, defender, move), true);
     }
   });
 
   it('returns boolean for normal accuracy moves', () => {
-    const move: BattleMove = { data: makeMoveData({ accuracy: 50 }), currentPp: 10 };
-    const result = checkAccuracy(move);
+    const attacker = makeTestPokemon();
+    const defender = makeTestPokemon({ displayName: 'Defender' });
+    const move = makeMoveData({ accuracy: 50 });
+    const result = checkAccuracy(attacker, defender, move);
     assert.equal(typeof result, 'boolean');
+  });
+
+  it('accuracy stages improve hit chance and evasion stages reduce it', () => {
+    const attacker = makeTestPokemon();
+    const defender = makeTestPokemon({ displayName: 'Defender' });
+    const move = makeMoveData({ accuracy: 50 });
+    const originalRandom = Math.random;
+
+    try {
+      Math.random = () => 0.7;
+      assert.equal(checkAccuracy(attacker, defender, move), false);
+
+      attacker.statStages.accuracy = 2;
+      assert.equal(checkAccuracy(attacker, defender, move), true);
+
+      attacker.statStages.accuracy = 0;
+      defender.statStages.evasion = 2;
+      assert.equal(checkAccuracy(attacker, defender, move), false);
+    } finally {
+      Math.random = originalRandom;
+    }
   });
 });
 
@@ -359,7 +388,7 @@ describe('resolveTurn', () => {
       { type: 'move', moveIndex: 0 },
     );
     // Switch message should come before attack message
-    const switchIdx = result.messages.findIndex((m) => m.includes('교체'));
+    const switchIdx = result.messages.findIndex((m) => m.includes('이상해씨'));
     const attackIdx = result.messages.findIndex((m) => m.includes('파이리'));
     assert.ok(switchIdx >= 0, 'Should have switch message');
     assert.ok(attackIdx >= 0, 'Should have attack message');
@@ -513,6 +542,46 @@ describe('calculateDamage edge cases', () => {
     const dmg = calculateDamage(attacker, defender, move);
     assert.equal(dmg, 0, `Immune matchup should deal 0 damage, got ${dmg}`);
   });
+
+  it('damage increases with positive attack stages', () => {
+    const attacker = makeTestPokemon({ attack: 100 });
+    const defender = makeTestPokemon({ defense: 60, displayName: 'Defender' });
+    const move: BattleMove = { data: makeMoveData({ power: 60 }), currentPp: 10 };
+    const originalRandom = Math.random;
+
+    try {
+      Math.random = () => 0;
+      const neutralDamage = calculateDamage(attacker, defender, move);
+      attacker.statStages.attack = 2;
+      const boostedDamage = calculateDamage(attacker, defender, move);
+      assert.ok(
+        boostedDamage > neutralDamage,
+        `Expected +2 attack stages to increase damage (${neutralDamage} -> ${boostedDamage})`,
+      );
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
+
+  it('damage increases when the defender has negative defense stages', () => {
+    const attacker = makeTestPokemon({ attack: 100 });
+    const defender = makeTestPokemon({ defense: 80, displayName: 'Defender' });
+    const move: BattleMove = { data: makeMoveData({ power: 60 }), currentPp: 10 };
+    const originalRandom = Math.random;
+
+    try {
+      Math.random = () => 0;
+      const neutralDamage = calculateDamage(attacker, defender, move);
+      defender.statStages.defense = -2;
+      const droppedDefenseDamage = calculateDamage(attacker, defender, move);
+      assert.ok(
+        droppedDefenseDamage > neutralDamage,
+        `Expected -2 defense stages to increase damage (${neutralDamage} -> ${droppedDefenseDamage})`,
+      );
+    } finally {
+      Math.random = originalRandom;
+    }
+  });
 });
 
 describe('resolveTurn with status effects', () => {
@@ -523,6 +592,24 @@ describe('resolveTurn with status effects', () => {
     const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
     // Opponent effective speed = 200 * 0.5 = 100 < 110, player goes first
     assert.ok(result.messages[0].includes('Fast'), `Player should act first, got: ${result.messages[0]}`);
+  });
+
+  it('speed stages can flip turn order', () => {
+    const player = makeTestPokemon({ displayName: 'Boosted', speed: 80 });
+    player.statStages.speed = 2;
+    const opponent = makeTestPokemon({ displayName: 'Base', speed: 100 });
+    const state = createBattleState([player], [opponent]);
+
+    const result = resolveTurn(
+      state,
+      { type: 'move', moveIndex: 0 },
+      { type: 'move', moveIndex: 0 },
+    );
+
+    assert.ok(
+      result.messages[0].includes('Boosted'),
+      `Expected boosted speed stages to flip turn order, got ${result.messages[0]}`,
+    );
   });
 
   it('burn halves physical damage', () => {
@@ -569,6 +656,47 @@ describe('resolveTurn with status effects', () => {
     assert.equal(opp.statusCondition, 'burn');
   });
 
+  it('status buff moves apply to the user', () => {
+    const buffMove = makeMoveData({
+      name: 'swords-dance',
+      nameKo: '칼춤',
+      power: 0,
+      statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+    });
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      moves: [{ data: buffMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'O' });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statStages.attack, 2);
+  });
+
+  it('damaging moves can apply post-hit secondary stat drops', () => {
+    const debuffMove = makeMoveData({
+      name: 'crunch',
+      nameKo: '깨물어부수기',
+      power: 80,
+      statChanges: [{ target: 'opponent', stat: 'defense', stages: -1, chance: 100 }],
+    });
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      attack: 100,
+      moves: [{ data: debuffMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'O', defense: 60 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statStages.defense, -1);
+  });
+
   it('toxic counter resets on switch', () => {
     const p1 = makeTestPokemon({ displayName: 'Toxic', statusCondition: 'badly_poisoned' as StatusCondition, toxicCounter: 5 });
     const p2 = makeTestPokemon({ displayName: 'Fresh', statusCondition: null, toxicCounter: 0 });
@@ -576,6 +704,19 @@ describe('resolveTurn with status effects', () => {
     const state = createBattleState([p1, p2], [opp]);
     resolveTurn(state, { type: 'switch', pokemonIndex: 1 }, { type: 'move', moveIndex: 0 });
     assert.equal(p1.toxicCounter, 1);
+  });
+
+  it('switch resets stat stages on the incoming pokemon', () => {
+    const p1 = makeTestPokemon({ displayName: 'Lead' });
+    const p2 = makeTestPokemon({ displayName: 'Bench' });
+    p2.statStages.attack = 3;
+    p2.statStages.speed = -2;
+    const opp = makeTestPokemon({ displayName: 'O' });
+    const state = createBattleState([p1, p2], [opp]);
+
+    resolveTurn(state, { type: 'switch', pokemonIndex: 1 }, { type: 'move', moveIndex: 0 });
+
+    assert.deepEqual(p2.statStages, createStatStages());
   });
 
   it('move-type immune target does not receive status from secondary effect', () => {
@@ -975,5 +1116,53 @@ describe('resolveTurn with status effects', () => {
     } finally {
       Math.random = origRandom;
     }
+  });
+
+  it('AI prefers self-buff setup when its own stages are low', () => {
+    const attacker = makeTestPokemon({
+      moves: [
+        {
+          data: makeMoveData({
+            name: 'swords-dance',
+            category: 'status',
+            power: 0,
+            accuracy: null,
+            statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+          }),
+          currentPp: 20,
+        },
+        { data: makeMoveData({ name: 'tackle', power: 40 }), currentPp: 35 },
+      ],
+    });
+    const defender = makeTestPokemon({ displayName: 'Defender', currentHp: 120 });
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      const choice = selectAiMove(attacker, defender);
+      assert.equal(choice, 0);
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('AI gives zero setup score when already capped', () => {
+    const attacker = makeTestPokemon({
+      statStages: { ...createStatStages(), attack: 6 },
+      moves: [
+        {
+          data: makeMoveData({
+            name: 'swords-dance',
+            category: 'status',
+            power: 0,
+            accuracy: null,
+            statChanges: [{ target: 'self', stat: 'attack', stages: 2, chance: 100 }],
+          }),
+          currentPp: 20,
+        },
+        { data: makeMoveData({ name: 'slash', power: 70 }), currentPp: 20 },
+      ],
+    });
+    const choice = selectAiMove(attacker, makeTestPokemon({ displayName: 'Defender' }));
+    assert.equal(choice, 1);
   });
 });

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -523,6 +523,28 @@ describe('resolveTurn', () => {
     // Should not throw; invalid switch is silently skipped
     assert.ok(Array.isArray(result.messages));
   });
+
+  it('same-slot switch does NOT reset stat stages (no-op cleanse exploit)', () => {
+    // Regression: a "switch" action targeting the already-active Pokemon must
+    // not act as a free, priority cleanse for stat-stage debuffs. The bug
+    // would let a debuffed mon erase its own stages by issuing a no-op switch.
+    const player = getActivePokemon(state.player);
+    player.statStages.attack = -3;
+    player.statStages.defense = -2;
+
+    const result = resolveTurn(
+      state,
+      { type: 'switch', pokemonIndex: state.player.activeIndex },
+      { type: 'move', moveIndex: 0 },
+    );
+
+    assert.equal(player.statStages.attack, -3, 'attack stage should remain unchanged');
+    assert.equal(player.statStages.defense, -2, 'defense stage should remain unchanged');
+    assert.ok(
+      !result.messages.some((m) => m.includes('교체') || m.toLowerCase().includes('switch')),
+      'No switch message should be emitted for a no-op switch',
+    );
+  });
 });
 
 describe('calculateDamage edge cases', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -82,6 +82,7 @@ function makeTestPokemon(overrides: Partial<BattlePokemon> = {}): BattlePokemon 
     fainted: false,
     statusCondition: null,
     toxicCounter: 0,
+    sleepCounter: 0,
     ...overrides,
   };
 }
@@ -149,6 +150,23 @@ describe('createBattlePokemon', () => {
     );
     assert.equal(bp.spAttack, calculateStat(80, 50));
     assert.equal(bp.spDefense, calculateStat(70, 50));
+  });
+
+  it('initializes status counters to zero', () => {
+    const bp = createBattlePokemon(
+      {
+        id: 4,
+        types: ['fire'],
+        level: 50,
+        baseStats: { hp: 39, attack: 52, defense: 43, speed: 65 },
+        displayName: 'Charmander',
+      },
+      [makeMoveData()],
+    );
+
+    assert.equal(bp.statusCondition, null);
+    assert.equal(bp.toxicCounter, 0);
+    assert.equal(bp.sleepCounter, 0);
   });
 });
 
@@ -657,6 +675,130 @@ describe('resolveTurn with status effects', () => {
     } finally {
       Math.random = origRandom;
     }
+  });
+
+  it('sleep skips the turn without consuming PP', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 2,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.equal(player.sleepCounter, 1);
+  });
+
+  it('wake-up turn still skips the move', () => {
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      sleepCounter: 1,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 10);
+    assert.ok(result.messages.some((m) => m.includes('깨어났다')));
+  });
+
+  it('freeze skips the turn without consuming PP when thaw roll fails', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.moves[0].currentPp, 10);
+      assert.equal(player.statusCondition, 'freeze');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('freeze exception moves act normally and thaw the user', () => {
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      moves: [{
+        data: makeMoveData({
+          name: 'scald',
+          nameKo: '열탕',
+          type: 'water',
+          category: 'special',
+          power: 80,
+          accuracy: 100,
+          pp: 15,
+        }),
+        currentPp: 15,
+      }],
+    });
+    const opp = makeTestPokemon({ displayName: 'Opp', sleepCounter: 0 });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(player.statusCondition, null);
+    assert.equal(player.moves[0].currentPp, 14);
+  });
+
+  it('fire-type attacks thaw frozen defenders before damage', () => {
+    const player = makeTestPokemon({
+      displayName: 'Fire',
+      speed: 999,
+      moves: [{ data: makeFireMove({ power: 60 }), currentPp: 25 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Frozen Target',
+      types: ['grass'],
+      statusCondition: 'freeze' as StatusCondition,
+      currentHp: 100,
+    });
+    const state = createBattleState([player], [opp]);
+
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
+    assert.ok(opp.currentHp < 100, 'Damage should still apply after thaw');
+    assert.ok(result.messages.some((m) => m.includes('녹았다')));
+  });
+
+  it('ice-type targets remain immune to freeze secondary effects', () => {
+    const effectMove = makeMoveData({ type: 'ice', category: 'special', power: 90 });
+    (effectMove as any).effect = { type: 'freeze', chance: 100 };
+    const player = makeTestPokemon({
+      displayName: 'P',
+      speed: 999,
+      moves: [{ data: effectMove, currentPp: 10 }],
+    });
+    const opp = makeTestPokemon({
+      displayName: 'Ice Target',
+      types: ['ice'],
+      statusCondition: null,
+    });
+    const state = createBattleState([player], [opp]);
+
+    resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+
+    assert.equal(opp.statusCondition, null);
   });
 
   it('simultaneous end-of-turn double KO results in opponent win (player loses)', () => {

--- a/test/turn-battle.test.ts
+++ b/test/turn-battle.test.ts
@@ -858,4 +858,114 @@ describe('resolveTurn with status effects', () => {
     assert.equal(player.fainted, false, 'Player should not faint from post-turn burn tick after battle decided');
     assert.equal(state.phase, 'battle_end');
   });
+
+  it('sleep blocks Struggle turn (no-PP asleep pokemon cannot act)', () => {
+    // Sleep must consume the turn even when the attacker has no PP and would
+    // otherwise be forced into Struggle. Assertion: opponent took no damage
+    // from the sleeper, proving the sleeper never acted.
+    const player = makeTestPokemon({
+      displayName: 'Sleeper',
+      speed: 999,
+      statusCondition: 'sleep' as StatusCondition,
+      toxicCounter: 0,
+      sleepCounter: 3,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    // Opponent has no usable moves either — guarantees opp does NOT attack
+    // the sleeper, so sleeper's HP should remain at maxHp (no opp damage, no
+    // struggle recoil on the sleeper side because sleeper never acted).
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      speed: 1,
+      statusCondition: 'sleep' as StatusCondition,
+      toxicCounter: 0,
+      sleepCounter: 3,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const result = resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+    // Neither mon should take damage — both were asleep and blocked from acting.
+    assert.equal(player.currentHp, player.maxHp, 'Sleeper should not take struggle recoil');
+    assert.equal(opp.currentHp, opp.maxHp, 'Neither mon should have dealt damage');
+    assert.ok(
+      result.messages.some((m) => m.includes('잠') || m.toLowerCase().includes('sleep')),
+      `Expected sleep message, got: ${JSON.stringify(result.messages)}`,
+    );
+  });
+
+  it('freeze blocks Struggle turn (no-PP frozen pokemon cannot act)', () => {
+    // Freeze must consume the turn even when Struggle would be forced.
+    // Pin Math.random to 0.9 so thaw roll (<0.2) never fires.
+    const player = makeTestPokemon({
+      displayName: 'Frozen',
+      speed: 999,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    // Opponent also frozen with no PP — so neither side should act
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      speed: 1,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.9;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(player.currentHp, player.maxHp, 'Neither mon should have taken damage');
+      assert.equal(opp.currentHp, opp.maxHp, 'Neither mon should have dealt damage');
+      assert.equal(player.statusCondition, 'freeze', 'Player should still be frozen');
+      assert.equal(opp.statusCondition, 'freeze', 'Opponent should still be frozen');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('will-o-wisp does not thaw a frozen defender (non-damaging fire status)', () => {
+    // Regression: a non-damaging fire move must not thaw a frozen target and
+    // then apply a new burn in the same action. Pin Math.random to 0.5 so
+    // the defender's own thaw roll (<0.2) does not fire.
+    const wow = makeMoveData({ type: 'fire', category: 'physical', power: 0, accuracy: 85 });
+    (wow as any).effect = { type: 'burn', chance: 100 };
+    const player = makeTestPokemon({ displayName: 'P', speed: 999, statusCondition: null, toxicCounter: 0, moves: [{ data: wow, currentPp: 10 }] });
+    // Opponent is frozen, has no PP (so they would Struggle but sleep/freeze
+    // check fires first). Types set to water so fire is not immune.
+    const opp = makeTestPokemon({
+      displayName: 'O',
+      types: ['water'],
+      speed: 1,
+      statusCondition: 'freeze' as StatusCondition,
+      toxicCounter: 0,
+      moves: [{ data: makeMoveData({ power: 40 }), currentPp: 0 }],
+    });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0.5;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(opp.statusCondition, 'freeze', 'Freeze should not be cleared by non-damaging fire move');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
+
+  it('damaging fire move (flamethrower) still thaws a frozen defender', () => {
+    const flamethrower = makeMoveData({ type: 'fire', category: 'special', power: 90 });
+    const player = makeTestPokemon({ displayName: 'P', speed: 999, statusCondition: null, toxicCounter: 0, moves: [{ data: flamethrower, currentPp: 10 }] });
+    const opp = makeTestPokemon({ displayName: 'O', types: ['water'], statusCondition: 'freeze' as StatusCondition, toxicCounter: 0 });
+    const state = createBattleState([player], [opp]);
+    const origRandom = Math.random;
+    try {
+      Math.random = () => 0;
+      resolveTurn(state, { type: 'move', moveIndex: 0 }, { type: 'move', moveIndex: 0 });
+      assert.equal(opp.statusCondition, null, 'Frozen defender should be thawed by damaging fire move');
+      assert.ok(opp.currentHp < opp.maxHp, 'Damage should still apply');
+    } finally {
+      Math.random = origRandom;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- 7-stat stat-stage system (-6..+6) integrated into damage, accuracy, speed, and switch mechanics
- 자기 버프 + 상대 디버프 + 데미지 기술 부가효과 (total ~25 new/modified moves)
- Gym AI 복잡 휴리스틱 (HP 비율, 현재 stage, 타입 면역 고려)
- 5 commits / 988 tests / 0 tsc errors

## Mechanics
- 7 stats: attack, defense, sp_attack, sp_defense, speed, accuracy, evasion
- Range -6..+6 (13 stages), clamp at ±6
- Battle stats: `max(2, 2+n) / max(2, 2-n)` (+1 = 1.5x, +6 = 4x, -6 = 0.25x)
- Acc/Eva: `max(3, 3+n) / max(3, 3-n)`
- Switch resets stat stages on switch-in; same-slot switch blocked (no free cleanse)

## Moves added
- **Self-buff**: swords-dance, nasty-plot, dragon-dance, calm-mind, iron-defense, agility
- **Debuff**: growl, tail-whip, leer, string-shot, charm, screech, scary-face, sweet-scent
- **Damage+drop secondary**: seed-bomb, crunch, icy-wind, psychic, flash-cannon, mystical-fire, acid-spray, bug-buzz, aurora-beam, shadow-ball

## Adversarial review fixes (4 rounds)
- **R1**: Same-slot switch stat-stage cleanse exploit → rejected
- **R2**: Inverted opponent debuff scoring (monotonic headroom-based)
- **R3**: Type-immune debuff moves (Ghost vs Growl) blocked in engine + AI
- **R4**: Immunity message before accuracy gate (Screech vs Ghost reports immunity, not miss)

## Test plan
- [x] 988 tests passing
- [x] TypeScript clean
- [x] 4 rounds Codex adversarial review
- [ ] Manual smoke: Swords Dance → massive physical attack boost
- [ ] Manual smoke: Thunder Wave into Ground (immunity message)
- [ ] Manual smoke: Same-slot switch does not cleanse stages