### PR TITLE
fix(data): replace Toxtricity with Houndstone in Ryme's gym team

### DIFF
--- a/data/gyms/gen9.json
+++ b/data/gyms/gen9.json
@@ -81,7 +81,7 @@
       "team": [
         { "species": 778, "level": 38, "moves": [421, 583, 425, 163] },
         { "species": 354, "level": 40, "moves": [247, 425, 389, 194] },
-        { "species": 849, "level": 42, "moves": [304, 188, 85, 34] }
+        { "species": 926, "level": 42, "moves": [247, 425, 421, 583] }
       ]
     },
     {


### PR DESCRIPTION
## Summary

- Ryme는 고스트 타입 관장인데 팀에 Toxtricity(#849, Electric/Poison)가 잘못 포함되어 있어 Houndstone(#926, Ghost)으로 교체
- 기술도 Ryme 팀의 다른 포켓몬과 일관된 고스트 타입 기술로 변경 (Shadow Ball, Phantom Force, Shadow Claw, Play Rough)

## Changes

`data/gyms/gen9.json` — Ryme 팀 3번째 포켓몬:
- Before: `{ "species": 849, "level": 42, "moves": [304, 188, 85, 34] }`
- After: `{ "species": 926, "level": 42, "moves": [247, 425, 421, 583] }`

## Review context

ThunderConch/tkm#21 코드리뷰에서 발견된 데이터 오류 수정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)