### PR TITLE
fix(battle): player pokemon on left, opponent on right

### DIFF
--- a/src/battle-tui/renderer.ts
+++ b/src/battle-tui/renderer.ts
@@ -80,14 +80,14 @@ export function renderBattleScreen(
   lines.push(doubleLine());
   lines.push('');
 
-  // Opponent pokemon (top-left, minimal indent)
-  const opponent = getActivePokemon(state.opponent);
-  lines.push(pokemonLine(opponent, 2));
+  // Player pokemon (left, minimal indent)
+  const player = getActivePokemon(state.player);
+  lines.push(pokemonLine(player, 2));
   lines.push('');
 
-  // Player pokemon (bottom-right, larger indent)
-  const player = getActivePokemon(state.player);
-  lines.push(pokemonLine(player, 10));
+  // Opponent pokemon (right, larger indent)
+  const opponent = getActivePokemon(state.opponent);
+  lines.push(pokemonLine(opponent, 10));
   lines.push('');
 
   // Message area


### PR DESCRIPTION
## Summary
- TUI 배틀 화면에서 플레이어 포켓몬이 왼쪽(indent 2), 상대(체육관 관장 포함)가 오른쪽(indent 10)에 렌더링되도록 순서 스왑
- 원래 포켓몬 프랜차이즈 관행(내 포켓몬은 항상 왼쪽)과 일치
- `renderBattleScreen()`은 체육관/일반 배틀 모두에서 공유되므로 모든 TUI 배틀에 동일하게 적용됨

## Changed
- `src/battle-tui/renderer.ts` (+6/-6, 한 블록 내부만)

## Verification
- ✅ `npm run build` — TypeScript 컴파일 에러 없음
- ✅ `npm test` — 1084/1084 통과
- ✅ Grep sweep — `renderBattleScreen` 호출부(`game-loop.ts`) 외에 렌더링 순서에 의존하는 코드 없음
- ⚠️ **Visual QA 필요**: `tkm gym` 실행해서 실제 배틀 화면이 의도대로 보이는지 확인 후 머지해주세요

## Test plan
- [ ] `tkm gym`으로 체육관 배틀 진입 → 내 포켓몬 왼쪽/관장 오른쪽 확인
- [ ] 일반 배틀에서도 같은 배치 확인 (의도된 결과)
- [ ] HP 바, 이름 라벨, 기술 메뉴 정상 렌더링 확인

## Consensus trail
Ralplan consensus (Planner → Architect → Critic) — `APPROVE` (1 iteration).
- Option A 선택: 최소 diff로 전체 배틀 공통 스왑
- Option B (체육관 한정 분기) / Option C (설정 플래그) 기각 — 근거는 ADR에 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)