### PR TITLE
fix(sprites): compact transparent braille via CSI CUF for ghostty

### DIFF
--- a/src/status-line.ts
+++ b/src/status-line.ts
@@ -203,6 +203,38 @@ export function scatterWeatherParticles(line: string, condition: WeatherConditio
   });
 }
 
+// ── Transparent-cell compaction for font-width-unstable terminals ──
+//
+// Ghostty (and any terminal whose font fallback routes \u2800 Braille Pattern
+// Blank to a different glyph stack than the non-zero braille range) renders
+// transparent sprite cells at a subtly different advance width than opaque
+// cells. Sprite rows with different opaque/transparent ratios then drift
+// relative to each other, producing the "feet pushed forward" artifact
+// even though every row has the same character count.
+//
+// Fix: emit explicit CSI CUF (cursor forward) sequences for transparent
+// runs instead of relying on \u2800 glyph advance. The terminal advances
+// exactly N cells regardless of what font is in use. We apply this only
+// for terminals where we know it's safe — opaque braille must still be
+// rendered at 1 cell per EAW:Neutral default, which holds for ghostty but
+// not for some CJK terminals where non-zero braille is 2-wide. b5b8796
+// (preserve sprite alignment during weather effects) is still the right
+// fix for that CJK case, so we leave non-ghostty terminals untouched.
+
+/** True when the current terminal needs CSI compaction for transparent
+ *  braille cells. Only ghostty is known to need this today — keep the
+ *  list narrow so CJK-wide-braille terminals aren't regressed. */
+export function shouldCompactBlanks(env: Record<string, string | undefined> = process.env): boolean {
+  return env.TERM === 'xterm-ghostty' || env.TERM_PROGRAM === 'ghostty';
+}
+
+/** Replace runs of \u2800 with explicit CSI CUF (cursor forward) escapes so
+ *  transparent cells advance by exact cell count, bypassing font-level
+ *  advance-width inconsistencies between \u2800 and non-zero braille. */
+export function compactBlanksToCsi(line: string): string {
+  return line.replace(/\u2800+/g, (run) => run.length === 1 ? '\x1b[C' : `\x1b[${run.length}C`);
+}
+
 function detectTermWidth(): number {
   // 1. Read per-session term-width file written by status-wrapper.mjs (if present)
   try {
@@ -347,6 +379,7 @@ function renderBattleMode(battleData: {
   }
 
   const baseGapChars = Math.max(2, Math.floor((printWidth - SPRITE_WIDTH * 2) / 2));
+  const useCsiBlanks = shouldCompactBlanks();
 
   if (firstRow <= lastRow) {
     for (let row = firstRow; row <= lastRow; row++) {
@@ -358,7 +391,8 @@ function renderBattleMode(battleData: {
       const playerVisible = playerLine.replace(/\x1b\[[^m]*m/g, '').length;
       const playerPadded = playerVisible < SPRITE_WIDTH ? playerLine + '\u2800'.repeat(SPRITE_WIDTH - playerVisible) : playerLine;
 
-      console.log(oppPadded + '\u2800'.repeat(baseGapChars) + playerPadded);
+      const fullLine = oppPadded + '\u2800'.repeat(baseGapChars) + playerPadded;
+      console.log(useCsiBlanks ? compactBlanksToCsi(fullLine) : fullLine);
     }
   }
 
@@ -399,7 +433,8 @@ function renderBattleMode(battleData: {
 
   // Gym info bottom line
   const gymLine = `\u2800\u2800\u2800\u2800\u2800\u2800\u2800\u2800⚔️ ${gym.leaderKo}의 체육관 — ${gym.type}`;
-  console.log(charWrap(gymLine, printWidth));
+  const wrappedGym = charWrap(gymLine, printWidth);
+  console.log(useCsiBlanks ? compactBlanksToCsi(wrappedGym) : wrappedGym);
 }
 
 function main(): void {
@@ -553,6 +588,8 @@ function main(): void {
       } catch { /* ignore */ }
     }
 
+    const useCsiBlanks = shouldCompactBlanks();
+
     for (let gi = 0; gi < spriteEntries.length; gi += spritesPerRow) {
       const group = spriteEntries.slice(gi, gi + spritesPerRow);
       const maxRows = Math.max(...group.map(s => s.length), 0);
@@ -571,14 +608,19 @@ function main(): void {
         if (weatherCondition) {
           rowStr = scatterWeatherParticles(rowStr, weatherCondition);
         }
-        // Keep \u2800 (braille blank) in output instead of converting to ASCII space.
-        // In some CJK terminals, non-zero braille (sprite art) and \u2800 are both
-        // rendered at the same width while ASCII space is narrower — mixing them
-        // causes per-row width variance proportional to sprite opacity, which is
+        // Default path: keep \u2800 (braille blank) in output instead of converting to
+        // ASCII space. In some CJK terminals, non-zero braille (sprite art) and \u2800
+        // are both rendered at the same width while ASCII space is narrower — mixing
+        // them causes per-row width variance proportional to sprite opacity, which is
         // invisible without weather but blatant once particles land on random cells.
         // Keeping every transparent position as \u2800 guarantees uniform row width
         // regardless of the terminal's actual braille glyph width.
-        console.log(rowStr);
+        //
+        // Ghostty path: \u2800 and non-zero braille disagree on advance width in
+        // ghostty's font fallback, so transparent cells drift the row. Replace runs
+        // of \u2800 with CSI cursor-forward to advance by exact cell count and
+        // sidestep the font-level width math. See shouldCompactBlanks().
+        console.log(useCsiBlanks ? compactBlanksToCsi(rowStr) : rowStr);
       }
     }
   }

--- a/test/compact-blanks.test.ts
+++ b/test/compact-blanks.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for ghostty-targeted CSI transparent-cell compaction.
+ *
+ * Root cause: ghostty's font fallback renders \u2800 (Braille Pattern Blank)
+ * at a subtly different advance width than non-zero braille cells. Sprite
+ * rows with different opaque/transparent ratios drift relative to each other
+ * even though every row has the same character count. See fix commit
+ * message for full details.
+ *
+ * Fix: for ghostty terminals only, replace runs of \u2800 with explicit
+ * CSI CUF (\x1b[NC) escapes so the terminal advances by exact cell count
+ * instead of consulting the font's glyph advance width. Non-ghostty
+ * terminals keep the existing \u2800 pipeline that b5b8796 established.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  compactBlanksToCsi,
+  shouldCompactBlanks,
+  scatterWeatherParticles,
+} from '../src/status-line.js';
+
+function stripAnsi(s: string): string {
+  return s.replace(/\x1b\[[^m]*m/g, '');
+}
+
+describe('compactBlanksToCsi', () => {
+  it('converts a single \\u2800 to \\x1b[C', () => {
+    assert.equal(compactBlanksToCsi('\u2800'), '\x1b[C');
+  });
+
+  it('converts a run of N \\u2800 to \\x1b[NC', () => {
+    assert.equal(compactBlanksToCsi('\u2800\u2800\u2800'), '\x1b[3C');
+    assert.equal(compactBlanksToCsi('\u2800'.repeat(20)), '\x1b[20C');
+  });
+
+  it('leaves non-blank chars untouched', () => {
+    assert.equal(compactBlanksToCsi('⣿⣿⣿'), '⣿⣿⣿');
+    assert.equal(compactBlanksToCsi('hello'), 'hello');
+  });
+
+  it('leaves an empty string unchanged', () => {
+    assert.equal(compactBlanksToCsi(''), '');
+  });
+
+  it('handles mixed opaque + transparent runs', () => {
+    assert.equal(
+      compactBlanksToCsi('⣿\u2800⣿\u2800\u2800⣿'),
+      '⣿\x1b[C⣿\x1b[2C⣿',
+    );
+  });
+
+  it('compacts leading and trailing blank runs', () => {
+    assert.equal(
+      compactBlanksToCsi('\u2800\u2800⣿\u2800\u2800\u2800'),
+      '\x1b[2C⣿\x1b[3C',
+    );
+  });
+
+  it('preserves SGR color escape sequences around opaque cells', () => {
+    const input = '\x1b[38;5;66m⣿\x1b[0m\u2800\u2800\x1b[38;5;66m⣿\x1b[0m';
+    const expected = '\x1b[38;5;66m⣿\x1b[0m\x1b[2C\x1b[38;5;66m⣿\x1b[0m';
+    assert.equal(compactBlanksToCsi(input), expected);
+  });
+
+  it('does not touch non-braille ASCII whitespace', () => {
+    // ASCII space and tab must stay as-is — they belong to text-layout
+    // code paths that are not part of the braille render pipeline.
+    assert.equal(compactBlanksToCsi('a b\tc'), 'a b\tc');
+  });
+
+  it('advances exactly SPRITE_WIDTH cells for an entirely blank row', () => {
+    // A fully-transparent sprite row in isolation becomes a single CUF
+    // of SPRITE_WIDTH (20) — the cursor lands on the same column it
+    // would have landed on if the row were rendered with \u2800 glyphs
+    // of width 1.
+    const blankRow = '\u2800'.repeat(20);
+    assert.equal(compactBlanksToCsi(blankRow), '\x1b[20C');
+  });
+});
+
+describe('compactBlanksToCsi after scatterWeatherParticles', () => {
+  it('leaves zero \\u2800 in the final output', () => {
+    // Compose a sprite row with both opaque and transparent cells,
+    // overlay weather particles (replaces some \u2800 with colored braille),
+    // then compact. The final string must contain no \u2800 codepoint.
+    const row = '\x1b[38;5;66m⣿\x1b[0m'.repeat(8) + '\u2800'.repeat(12);
+    for (let i = 0; i < 50; i++) {
+      const scattered = scatterWeatherParticles(row, 'rain');
+      const compacted = compactBlanksToCsi(scattered);
+      assert.ok(
+        !compacted.includes('\u2800'),
+        `iter=${i}: output still contains \\u2800: ${JSON.stringify(compacted)}`,
+      );
+    }
+  });
+
+  it('preserves non-\\u2800 codepoints bit-for-bit through compaction', () => {
+    // Everything that is not \u2800 must survive the replace untouched —
+    // SGR escapes, opaque braille, and any weather-injected particles.
+    const row = '\x1b[38;5;66m⣿\x1b[0m\u2800⠡\u2800\u2800\x1b[34m⠑\x1b[0m';
+    const compacted = compactBlanksToCsi(row);
+    // Strip CSI CUF (\x1b[NC) and CSI SGR (\x1b[...m) — what remains must
+    // match the non-blank codepoints of the original in order.
+    const cufStripped = compacted.replace(/\x1b\[\d*C/g, '');
+    const allStripped = cufStripped.replace(/\x1b\[[^m]*m/g, '');
+    const originalNonBlank = stripAnsi(row).replace(/\u2800/g, '');
+    assert.equal(allStripped, originalNonBlank);
+  });
+});
+
+describe('shouldCompactBlanks', () => {
+  it('detects ghostty via TERM=xterm-ghostty', () => {
+    assert.equal(shouldCompactBlanks({ TERM: 'xterm-ghostty' }), true);
+  });
+
+  it('detects ghostty via TERM_PROGRAM=ghostty', () => {
+    assert.equal(
+      shouldCompactBlanks({ TERM: 'xterm-256color', TERM_PROGRAM: 'ghostty' }),
+      true,
+    );
+  });
+
+  it('returns false for kitty', () => {
+    assert.equal(shouldCompactBlanks({ TERM: 'xterm-kitty' }), false);
+  });
+
+  it('returns false for unknown terminal', () => {
+    assert.equal(shouldCompactBlanks({ TERM: 'xterm-256color' }), false);
+  });
+
+  it('returns false for wezterm (keeps the b5b8796 CJK fix path)', () => {
+    assert.equal(
+      shouldCompactBlanks({ TERM: 'xterm-256color', TERM_PROGRAM: 'WezTerm' }),
+      false,
+    );
+  });
+
+  it('returns false for iTerm.app', () => {
+    assert.equal(
+      shouldCompactBlanks({ TERM: 'xterm-256color', TERM_PROGRAM: 'iTerm.app' }),
+      false,
+    );
+  });
+
+  it('returns false on an empty env', () => {
+    assert.equal(shouldCompactBlanks({}), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Sprite "도트 깨짐" (feet pulled forward) on ghostty (Mac → SSH → Linux) traced to a font advance-width mismatch between `\u2800` (Braille Pattern Blank) and non-zero braille glyphs, despite both being EAW:Neutral. b5b8796 already addressed the analogous CJK-terminal case by collapsing transparent cells to `\u2800`, but the same trick can't help when `\u2800` itself is the offending glyph.
- For ghostty only (`TERM=xterm-ghostty` or `TERM_PROGRAM=ghostty`), replace runs of `\u2800` with explicit CSI CUF (`\x1b[NC`) right before `console.log`. The terminal advances exactly N cells per CUF regardless of font, so opaque vs transparent cells stop competing on glyph advance width. Non-ghostty terminals stay on the existing `\u2800` pipeline so the b5b8796 CJK fix is preserved.
- Touches three render paths in `src/status-line.ts`: party tier 1/2 sprite grid (post weather overlay), battle-mode dual sprite row, and battle-mode gym info bottom line (post `charWrap`). Each path caches `shouldCompactBlanks()` once per render. `compactBlanksToCsi` and `shouldCompactBlanks` are exported for direct test access.

## Why CSI cursor-forward and not a different transparent glyph

Cursor-forward bypasses font glyph dispatch entirely — the terminal advances N character cells regardless of which font (or fallback) would have been chosen for `\u2800`. We assume opaque braille is rendered at 1 cell per EAW:Neutral default. That holds for ghostty but not for some CJK terminals where non-zero braille is 2-wide, which is exactly why this is gated on the ghostty env check rather than applied universally.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — **1102/1102 pass** (was 2 fails on the first run because the worktree had no `dist/`; once `npm run build` populated it, all session-start child-process tests passed)
- [x] New `test/compact-blanks.test.ts` (18 cases): single/multi `\u2800` runs, leading/trailing runs, mixed opaque+transparent, SGR escape preservation, post-`scatterWeatherParticles` integration (no `\u2800` left in output, non-blank codepoints survive bit-for-bit), env detection for ghostty / kitty / WezTerm / iTerm.app / unknown / empty
- [x] Smoke test under `TERM=xterm-ghostty`: `compactBlanksToCsi` collapses `⠀⠀⠀⠀⠀` → `\x1b[5C` and `⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀` → `\x1b[10C`, opaque cells preserved exactly, output contains zero `\u2800`
- [ ] **Ghostty manual verification**: render `/tokenmon` party + battle in ghostty (Mac → SSH → Linux) and confirm Dialga's feet (and any other party member's bottom row) sit under the body instead of drifting forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)