### PR TITLE
Add /tkm:friendly-battle skill + daemon turn loop (PR44)

### DIFF
--- a/docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md
+++ b/docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md
@@ -231,9 +231,36 @@ master
 3. **`TOKENMON_FORCE_DETERMINISTIC` 레거시 경로**: 기존 `friendly-battle-local.ts` deterministic 경로를 지우면 #42 의 기존 테스트가 깨질 수 있음. PR43 에서는 지우지 말고 flag 뒤로 격리.
 4. **Two-machine smoke**: 로컬 WSL2 + 별도 머신 조합이 없으면 VM 두 개로 대체. PR47 미완 상태로 PR46 까지 머지하는 건 허용.
 
-## 7. 한 줄 결론
+## 7. 한 줄 결론 (PR43 시점)
 
 **데몬 없음. gym 패턴 그대로. PR43(드라이버) → PR44(skill) → PR45(faint/surrender) → PR46(leave) → PR47(smoke). PR44/PR45 는 visual QA 필수.**
+
+> **⚠️ PR44에서 이 결론 일부가 수정됨** — §8 참고.
+
+## 8. Architecture revision (PR44 daemon reversal)
+
+PR43까지는 "데몬 없음, gym 패턴 그대로, 단일 프로세스 foreground-blocking" 을 전제로 작업했다. PR44 실행에 들어가자마자 이 전제가 깨졌다.
+
+### 8-1. 발견한 모순
+`src/friendly-battle/spike/tcp-direct.ts` 의 호스트/게스트 API 는 전부 **라이브 소켓 기반** 이다 (`waitForGuestJoin`, `markHostReady`, `waitUntilCanStart`, `startBattle`, `waitForGuestChoice`, `sendBattleEvents`, `submitChoice`, `waitForBattleEvent`). TCP 파일 디스크립터는 **tsx 프로세스 경계를 넘어갈 수 없다** — 디스크로 직렬화되지 않기 때문이다.
+
+gym 의 "단발 CLI + 디스크 state" 패턴은 gym 의 모든 state 가 로컬이기 때문에 성립한다. 친선전은 state 의 절반이 상대 머신에 있고 TCP 소켓으로 묶여 있어서 이 패턴이 성립하지 않는다.
+
+### 8-2. PR44 에서 반영한 최소 데몬 모델
+- `--init-host` / `--init-join` 는 `src/friendly-battle/daemon.ts` 를 **detached 자식 프로세스로 fork** 한다. 이 자식(데몬)이 TCP 소켓과 배틀 런타임을 붙잡고 있는다.
+- 데몬은 로컬 전용 UNIX 소켓을 `$CLAUDE_CONFIG_DIR/tokenmon/<gen>/friendly-battle/sessions/<id>.sock` 에 연다.
+- 액션 서브커맨드 (`--wait-next-event`, `--action move:N`, `--status`) 는 **gym 과 똑같이 단발 tsx 호출** 이다 — UNIX 소켓 열어서 JSON 한 줄 쓰고 한 줄 읽고 닫는다.
+- 세션 레코드가 PR43 의 `reapStaleFriendlyBattleSessions` 인프라를 그대로 쓰면서 `daemonPid` + `socketPath` 필드로 확장됐다. 고아 데몬은 다음 스캔 때 치워진다.
+- **유저 관점에서는 바뀐 게 없다.** `/tkm:friendly-battle open` 은 여전히 한 번의 연속적인 배틀 세션처럼 보인다. 데몬은 쉘 파이프처럼 보이지 않는 구현 디테일이다.
+
+### 8-3. 로드맵이 "데몬 금지"라고 말한 건 사실 이걸 말하는 게 아니었다
+§2 의 데몬 반대는 실제로는 **유저에게 노출되는 persistence / reconnect / "방 열고 딴 데 가서 놀다 와"** 시맨틱을 겨냥한 것이었다. 이 세 가지는 PR44 에서도 그대로 비범위다 — reconnect 없음, "열어두고 나가기" 없음, 데몬은 배틀이 끝나면 스스로 종료한다. 데몬을 유저 관점의 서비스가 아니라 단일 배틀 세션의 수명과 정확히 일치하는 자식 프로세스로 제한했다.
+
+### 8-4. 수정된 한 줄 결론
+**PR44 에서 숨겨진 최소 데몬 도입. 유저 경험은 그대로 gym 패턴. PR43(드라이버) → PR44(daemon + skill) → PR45(faint/surrender) → PR46(leave) → PR47(smoke). PR44/PR45 는 visual QA 필수.**
+
+### 8-5. 상세 계획 위치
+PR44 의 task 별 TDD 계획은 `docs/friendly-battle/roadmap/pr44-skill-and-turn-loop-plan.md` 에 있다. Daemon lifecycle, IPC protocol, 각 task 의 파일/테스트 구성은 그 문서에서 확인할 것.
 
 ## 관련 문서
 

--- a/docs/friendly-battle/roadmap/pr44-skill-and-turn-loop-plan.md
+++ b/docs/friendly-battle/roadmap/pr44-skill-and-turn-loop-plan.md
@@ -1,0 +1,269 @@
+# PR44 — `skills/friendly-battle/SKILL.md` + Turn Loop (with daemon reversal)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox syntax.
+
+**Goal:** Ship the first playable `/tkm:friendly-battle open` / `/tkm:friendly-battle join <code>` experience — two Claude Code sessions drive a gym-style AskUserQuestion turn loop that actually resolves moves over the TCP transport from PR #40/#42/#43.
+
+**Parent branch:** `feat/friendly-battle-pvp-driver` (PR #43)
+**This branch:** `feat/friendly-battle-pvp-skill`
+**Target PR base:** PR #43
+
+---
+
+## Architecture reversal notice
+
+The roadmap at `docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md` §2 committed to a "foreground-blocking, gym-style one-shot CLI" model and rejected a daemon. **That decision does not generalize to networked play.** Execution of PR43 and investigation of `src/friendly-battle/spike/tcp-direct.ts` revealed the concrete constraint:
+
+- Gym's `battle-turn.ts` is single-shot per call because its entire battle state is on disk — each call reads state, applies the action, writes state, exits.
+- Friendly-battle's `tcp-direct.ts` host/guest API is **entirely live-socket** (`waitForGuestJoin`, `markHostReady`, `waitUntilCanStart`, `startBattle`, `waitForGuestChoice`, `sendBattleEvents`, `submitChoice`, `waitForBattleEvent`). A TCP socket cannot survive across tsx invocations — file descriptors don't serialize to disk.
+- Therefore: **the process holding the TCP socket must stay alive across multiple SKILL.md subcommand calls.** That is, by definition, a daemon.
+
+This PR adopts a **minimal daemon model**:
+
+- `--init-host` and `--init-join` fork a detached child process (the daemon) that holds the TCP socket and maintains battle state via `battle-adapter.ts`.
+- The daemon exposes a local-only UNIX socket at `$CLAUDE_CONFIG_DIR/tokenmon/<gen>/friendly-battle/sessions/<id>.sock`.
+- Per-action subcommands (`--wait-next-event`, `--action`, `--status`) are one-shot tsx calls that open the UNIX socket, send a single JSON command, read the single JSON response, and exit. Same ergonomics as gym's `battle-turn.ts` from SKILL.md's perspective.
+- Session store already has PID + `reapStaleFriendlyBattleSessions` infra from PR43 — we extend the record with `daemonPid` and `socketPath`. Orphan daemons get reaped on the next session-store scan.
+- `--leave` (PR46) will SIGTERM the daemon via PID. Until then, Ctrl+C on the `--init-*` caller still leaves a live daemon; reap handles eventual cleanup.
+
+**Why this is not a full retreat from the roadmap**: the foreground-blocking mental model still holds from the **user's** perspective — running `/tkm:friendly-battle open` feels like one contiguous battle session, not a service. The daemon is an implementation detail invisible to the user, just like a shell pipe. The roadmap's rejection of daemons was specifically targeted at user-visible persistence / reconnect / "open a room and walk away" semantics — none of which we're adding.
+
+The roadmap doc gets an appended "Architecture revision" section as part of this PR.
+
+---
+
+## File structure
+
+**Create:**
+- `src/friendly-battle/daemon.ts` — long-lived event loop. Single entry that accepts a role (`'host' | 'guest'`) and the init options, holds the tcp-direct transport, and pumps battle events through `battle-adapter.ts`. Listens on a UNIX socket for local commands. ~400 LOC.
+- `src/friendly-battle/daemon-ipc.ts` — UNIX socket server (inside daemon) and client (for `--wait-next-event` / `--action` / `--status` subcommands). JSON-line protocol. ~180 LOC.
+- `src/friendly-battle/daemon-protocol.ts` — shared command/response types (`DaemonRequest`, `DaemonResponse`) so server and client can't drift. ~80 LOC.
+- `skills/friendly-battle/SKILL.md` — gym-style SKILL.md. Frontmatter, Execute section with dispatch for `open`/`join <code>`/`status`/`help`. Move-only turn loop in this PR; switch/surrender land in PR45. ~180 LOC.
+- `test/friendly-battle-daemon-ipc.test.ts` — unit test for IPC round-trip. ~140 LOC.
+- `test/friendly-battle-daemon-turn-loop.test.ts` — integration test: spawn two daemons, run a handshake + one full turn (both submit a move, receive resolved events), assert via real TCP + real UNIX sockets. ~280 LOC.
+- `test/friendly-battle-skill-contract.test.ts` — static parse of `skills/friendly-battle/SKILL.md` to verify every Bash block references a real `src/cli/friendly-battle-turn.ts` subcommand and no stale paths. ~120 LOC.
+
+**Modify:**
+- `src/friendly-battle/session-store.ts` — extend `FriendlyBattleSessionRecord` with `daemonPid: number` and `socketPath: string`. Update shape guard. ~20 LOC.
+- `src/cli/friendly-battle-turn.ts`:
+  - Refactor `runInitHost` / `runInitJoin`: instead of running the transport inline in the main process, fork `daemon.ts` as a detached child, wait for its "daemon-ready" message on stdout, write the session record with `daemonPid` + `socketPath`, emit the first JSON envelope, exit.
+  - Add `runWaitNextEvent` (`--wait-next-event --session <id> --timeout-ms N`): opens UNIX socket, sends `wait_next_event` request, reads single JSON response, prints, exits.
+  - Add `runAction` (real body for `--action move:N`): opens UNIX socket, sends `submit_action` request with `{kind:'move', index:N}`, reads single JSON response (updated envelope), prints, exits. Switch / surrender paths still throw `not implemented` (PR45 scope).
+  - Add `runStatus` (`--status --session <id>`): reads session store, optionally pings the daemon via UNIX socket for a fresh state snapshot, prints envelope. No transport side effects.
+  - ~300 LOC touched.
+- `src/friendly-battle/local-harness.ts` — gate deterministic choice paths behind `TOKENMON_FORCE_DETERMINISTIC=1`. Existing tests that rely on deterministic mode must set the flag. ~40 LOC touched.
+- `docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md` — append an "Architecture revision (PR44)" section that links to this plan and records the daemon reversal. ~25 LOC added.
+
+**Out of scope:**
+- `--action switch:N` / `--action surrender` (PR45)
+- `--leave` clean disconnect (PR46)
+- Two-machine smoke (PR47)
+- Faint-forced-switch flow (PR45)
+
+---
+
+## IPC protocol (daemon-protocol.ts)
+
+```ts
+// Request sent from CLI subcommand to daemon UNIX socket.
+export type DaemonRequest =
+  | { op: 'wait_next_event'; timeoutMs: number }
+  | { op: 'submit_action'; action: { kind: 'move'; index: number } }
+  | { op: 'status' }
+  | { op: 'ping' };
+
+// Response from daemon, always one JSON line terminated with \n.
+export type DaemonResponse =
+  | { op: 'event'; envelope: FriendlyBattleTurnJson }
+  | { op: 'ack'; envelope: FriendlyBattleTurnJson }
+  | { op: 'status'; envelope: FriendlyBattleTurnJson }
+  | { op: 'pong'; pid: number }
+  | { op: 'error'; code: string; message: string };
+```
+
+- Line protocol: one JSON object per line (`JSON.stringify` + `\n`).
+- Connection lifetime: one request, one response, close. No persistent client streams. Keeps the client side trivially stateless.
+- Daemon accepts parallel connections (each CLI call is its own connection).
+
+---
+
+## Daemon lifecycle
+
+1. `tsx friendly-battle-turn.ts --init-host ...` is invoked by the user (via SKILL.md).
+2. Parent process `child_process.spawn('tsx', [daemon.ts, '--role', 'host', '--options-json', <json>], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] })`.
+3. Parent reads one `DAEMON_READY <sessionId> <socketPath>` line from the child's stdout, then `child.unref()` so the parent can exit without waiting on the child.
+4. Parent writes the session record (PID, socketPath, phase='waiting_for_guest'), emits the first JSON envelope, exits.
+5. Daemon continues the transport handshake (`waitForGuestJoin` on host side). As phase transitions happen, daemon updates the session record on disk AND pushes events to a local event queue.
+6. Subsequent CLI calls (`--wait-next-event`, `--action move:N`) connect to the UNIX socket, send one request, get one response. Daemon services them against the live transport + the internal event queue.
+7. Battle ends: daemon sends final events, writes `phase='finished'`, closes UNIX socket, closes TCP transport, exits.
+8. On crash / parent SIGKILL: daemon is still alive (detached). Next call to `reapStaleFriendlyBattleSessions` (e.g. on next `/tkm:friendly-battle open`) cleans up its record if its PID is dead. The daemon itself will exit when its TCP socket closes.
+
+---
+
+## Tasks
+
+### Task 1 — Extend session-store record with daemonPid + socketPath
+
+- Modify `src/friendly-battle/session-store.ts`:
+  - Add `daemonPid: number` and `socketPath: string` to `FriendlyBattleSessionRecord`
+  - Extend `isValidRecord` shape guard to require both (number > 0 for daemonPid, string passing `SAFE_SEGMENT`-like check for socketPath basename)
+- Modify `test/friendly-battle-session-store.test.ts`:
+  - Update `makeRecord` fixture to include the two new fields
+  - Add one test that `readFriendlyBattleSessionRecord` returns null if `daemonPid` is missing on disk
+- Run `npx tsx --test test/friendly-battle-session-store.test.ts` — all pre-existing tests must still pass, new test passes.
+- Run `npx tsc --noEmit`.
+- Commit: `Extend friendly-battle session record with daemonPid and socketPath`
+
+### Task 2 — `daemon-protocol.ts` (types only, no runtime)
+
+- Create `src/friendly-battle/daemon-protocol.ts` with `DaemonRequest` / `DaemonResponse` union types as specified above.
+- Create `test/friendly-battle-daemon-protocol.test.ts` with a type-only smoke that imports both types and exercises each variant via a dummy function, catching any future shape drift.
+- Run tests + tsc.
+- Commit: `Add friendly-battle daemon IPC protocol types`
+
+### Task 3 — `daemon-ipc.ts` (UNIX socket server + client)
+
+- Create `src/friendly-battle/daemon-ipc.ts`:
+  - `createDaemonIpcServer(socketPath, handler)` — creates `net.createServer` listening on a UNIX domain socket, accepts one JSON line per connection, calls `handler(req)`, writes response, closes. Cleans up the socket file on close.
+  - `sendDaemonIpcRequest(socketPath, req, timeoutMs)` — opens a client `net.createConnection` to the socket, writes one JSON line, reads one JSON line, resolves, closes. Timeouts propagated as rejected promises.
+- Create `test/friendly-battle-daemon-ipc.test.ts`:
+  - Spin up a server in-process, send a `{ op: 'ping' }`, assert `{ op: 'pong', pid }` response
+  - Send `{ op: 'status' }` to an echo handler, assert round-trip
+  - Bad-path: server down → client rejects within timeout
+  - Cleanup: `afterEach` unlinks the socket file
+- Commit: `Add UNIX-socket IPC server/client for friendly-battle daemon`
+
+### Task 4 — `daemon.ts` (long-lived event loop, host + guest)
+
+- Create `src/friendly-battle/daemon.ts`:
+  - `main(argv)` reads `--role host|guest`, `--options-json <b64>` (base64-encoded init options to keep them out of process listing), starts the tcp-direct transport via `createFriendlyBattleSpikeHost` / `connectFriendlyBattleSpikeGuest`
+  - On host side: `waitForGuestJoin`, `markHostReady`, `waitUntilCanStart`, `startBattle`, then enter the turn loop.
+  - On guest side: `markReady`, `waitForStarted`, then enter the turn loop.
+  - Turn loop (both sides): pump events from the transport into a local `AsyncQueue<FriendlyBattleBattleEvent>`. The local player's choice comes in via a UNIX socket `submit_action` request. The daemon forwards it to the transport (`host.waitForGuestChoice` for host-waiting-on-guest; `guest.submitChoice` for guest-sending-to-host). When both choices are present, host resolves via `battle-adapter.ts` and `sendBattleEvents`. Events go into the local queue; `wait_next_event` IPC handler `.shift()`s them.
+  - Prints `DAEMON_READY <sessionId> <socketPath>` to stdout as soon as the UNIX socket is listening.
+  - On SIGTERM / transport error: close UNIX socket, close transport, write `phase='aborted'` to session record, exit.
+- Do NOT write test yet — this module is exercised via the Task 6 integration test.
+- Run tsc.
+- Commit: `Add friendly-battle daemon long-lived event loop`
+
+### Task 5 — Refactor `--init-host` / `--init-join` to fork the daemon
+
+- Modify `src/cli/friendly-battle-turn.ts`:
+  - `runInitHost` no longer runs the transport inline. Instead:
+    - Build the options object (same fields as before).
+    - `spawn(tsxPath, [daemonEntry, '--role', 'host', '--options-json', base64(optionsJson)], { detached: true, stdio: ['ignore', 'pipe', 'pipe'] })`
+    - Read one line from the child stdout, parse `DAEMON_READY <sessionId> <socketPath>`.
+    - `child.unref()`
+    - Write session record (with `daemonPid: child.pid`, `socketPath: <path>`, `phase: 'waiting_for_guest'`).
+    - Emit the first JSON envelope on stdout.
+    - Exit 0.
+  - `runInitJoin` does the symmetric thing for the guest side.
+  - Both retain the input validation (SAFE_NAME, SAFE_CODE, SAFE_GEN) from PR43's fixup.
+- Update `test/friendly-battle-turn-driver.test.ts`:
+  - The existing handshake test must still pass — it spawns `--init-host` + `--init-join`. Now each one forks a daemon behind the scenes. The test asserts both exit 0 with `phase: 'battle'` in stdout, same as before. Additionally assert that the session record on disk contains a non-zero `daemonPid` and a socketPath that exists as a UNIX socket file.
+  - Add teardown that sends SIGTERM to any daemons spawned (via session-store `listFriendlyBattleSessionRecords` + `process.kill(daemonPid, 'SIGTERM')`) so the test doesn't leak zombies.
+- Run full test suite.
+- Commit: `Fork the friendly-battle daemon from --init-host and --init-join`
+
+### Task 6 — Integration test: full turn loop
+
+- Create `test/friendly-battle-daemon-turn-loop.test.ts`:
+  - Spawn host + join with seeded `CLAUDE_CONFIG_DIR` (reuse PR43's pattern).
+  - Poll session records until both daemons have `phase='battle'` and `socketPath` exists.
+  - Via the IPC client, send `{ op: 'wait_next_event', timeoutMs: 2000 }` to each daemon and expect an envelope with `status='select_action'` and `moveOptions`.
+  - Via the IPC client, send `{ op: 'submit_action', action: { kind: 'move', index: 1 } }` to each daemon.
+  - Via the IPC client, send another `wait_next_event` to each; expect the resolved turn events (hit / drain / etc.) to appear.
+  - Continue until one side reports `status='victory'` or `status='defeat'`.
+  - Assert daemons exit cleanly after the battle ends (PID goes away within 2s).
+- This test is the single most important new test in PR44 — it proves the whole daemon + IPC + transport stack works end-to-end.
+- Commit: `Add end-to-end turn loop integration test across two daemons`
+
+### Task 7 — `--wait-next-event`, `--action move:N`, `--status` subcommands
+
+- Extend `src/cli/friendly-battle-turn.ts`:
+  - `runWaitNextEvent`: validates `--session <id>`, reads session record, `sendDaemonIpcRequest(record.socketPath, { op: 'wait_next_event', timeoutMs })`, prints the returned envelope to stdout, exits 0.
+  - `runAction`: parses `--action move:<N>` (use regex `^move:([1-4])$`), sends `submit_action` with `kind: 'move', index: N`. switch / surrender tokens still error out with "not implemented: PR45".
+  - `runStatus`: reads session record. If daemon is alive (PID check), `sendDaemonIpcRequest({ op: 'status' })` and prints that envelope. If daemon is dead, prints the last persisted session record as a frozen envelope. Never fails.
+- Extend the existing driver test file (`test/friendly-battle-turn-driver.test.ts`) with:
+  - One test per new subcommand. Each test spawns a minimal daemon via `--init-host` (alone — the waiting_for_guest phase is fine), then calls the new subcommand, asserts the expected JSON envelope, then SIGTERMs the daemon.
+- Run tests + tsc.
+- Commit: `Implement friendly-battle-turn --wait-next-event / --action move / --status`
+
+### Task 8 — Gate deterministic local-harness path behind TOKENMON_FORCE_DETERMINISTIC
+
+- Grep existing `src/friendly-battle/local-harness.ts` and `src/cli/friendly-battle-local.ts` for deterministic-choice short-circuits.
+- Add an `isDeterministicMode()` helper reading `process.env.TOKENMON_FORCE_DETERMINISTIC === '1'`. Wrap every deterministic path behind it.
+- Update `test/friendly-battle-local-harness.test.ts` / `test/friendly-battle-local-cli-interaction.test.ts` to set the env var on their spawn calls so they keep hitting the deterministic path.
+- Run full suite — all PR #42 friendly-battle tests must still pass.
+- Commit: `Gate friendly-battle deterministic paths behind TOKENMON_FORCE_DETERMINISTIC`
+
+### Task 9 — `skills/friendly-battle/SKILL.md`
+
+- Create `skills/friendly-battle/SKILL.md` with:
+  - frontmatter `description:` containing English + Korean triggers
+  - Execute section mirroring `skills/gym/SKILL.md` structure:
+    - Step 0: parse `$ARGUMENTS`. If `open` → init-host. If starts with `join ` → init-join (next token is session code). If `status` → status. Otherwise print help.
+    - Step 1: init via `$P/bin/tsx-resolve.sh $P/src/cli/friendly-battle-turn.ts --init-host ...` (or --init-join). Parse stdout JSON, read `sessionId`.
+    - Step 2: if the JSON's `phase === 'waiting_for_guest'`, print the room code from `questionContext`, tell the user how to abort (Ctrl+C will not work — they need to run `/tkm:friendly-battle status` to see if anyone connected; this PR leaves the abort story to PR46).
+    - Step 3: enter the turn loop: `--wait-next-event --session <id> --timeout-ms 60000` → parse envelope → if `status='select_action'` run gym-style AskUserQuestion over `moveOptions` → `--action move:<N>` → loop.
+    - Step 4: handle terminal states: `status='victory'` / `status='defeat'` → show messages, stop.
+  - Do NOT include switch / surrender paths — put a `# TODO(PR45)` comment in the stub where those flows would go.
+  - English-first copy with necessary Korean labels only, per memory.
+- Create `test/friendly-battle-skill-contract.test.ts`:
+  - Parse `skills/friendly-battle/SKILL.md` as a string.
+  - Extract every `$P/src/cli/friendly-battle-turn.ts` subcommand (`--init-host`, `--init-join`, `--wait-next-event`, `--action`, `--status`).
+  - For each, spawn the real CLI with `--help` or a known-safe invocation and assert it at least accepts the flag (exit code semantics match expected).
+- Run tests.
+- Commit: `Add skills/friendly-battle/SKILL.md and contract test`
+
+### Task 10 — Append roadmap architecture revision
+
+- Edit `docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md`: append an "Architecture revision (PR44)" section explaining the daemon reversal, pointing to this plan.
+- Edit the PR stack diagram to indicate PR44 introduces the daemon.
+- No test impact. Commit alone.
+- Commit: `Document the PR44 daemon reversal in the friendly-battle roadmap`
+
+### Task 11 — CI sanity + push + draft PR
+
+- `npm test` — must be green with all new tests.
+- `npx tsc --noEmit`.
+- `npm run build`.
+- `git push -u origin feat/friendly-battle-pvp-skill`.
+- `gh pr create` against base `feat/friendly-battle-pvp-driver`, draft, include the daemon-reversal explanation and the visual-QA handoff note in the PR body.
+
+---
+
+## Visual QA handoff (merge gate)
+
+Per project memory `feedback_visual_qa.md`: "Visual 요소는 실행→스크린샷→visual-verdict 리뷰 통과 필수". This PR introduces real `/tkm:friendly-battle open` / `join` with live AskUserQuestion UX. **Merge requires**:
+
+1. Two terminals with seeded tokenmon data (one host, one guest) on the same machine or LAN.
+2. Host runs `/tkm:friendly-battle open`, screenshot the waiting-for-guest AskUserQuestion state.
+3. Guest runs `/tkm:friendly-battle join <code>`, screenshot the connection + first move-select AskUserQuestion.
+4. Play through at least one full turn on both sides, screenshot the resolution display.
+5. `oh-my-claudecode:visual-verdict` review of all screenshots.
+
+This handoff is **not** autopilot scope. Autopilot will land the code, tests, and this plan, push the draft PR, and stop. The human operator runs the visual QA before flipping the PR from draft to ready.
+
+---
+
+## Known risks
+
+1. **Daemon orphans on crash**: if a parent `tsx --init-host` dies between forking the daemon and writing the session record, the daemon is unreachable. `reapStaleFriendlyBattleSessions` only sees recorded sessions. Mitigation: write the session record with a placeholder PID BEFORE forking, then update after. Follow-up PR can add a pidfile directory scan.
+2. **UNIX socket leftover files**: if a daemon crashes without unlinking its socket, the next `--init-*` reusing the same session id (unlikely due to UUID) would fail. Mitigation: always unlink the socket path before listen.
+3. **Battle adapter engine symmetry**: currently only the host authoritative resolves turns. Guest trusts events from host. Test must verify guest's reported state stays in lockstep with host's. If drift is found, that's a `battle-adapter.ts` bug and belongs in a separate fix.
+4. **`waitForGuestChoice` vs `submitChoice` timing**: if the guest submits before the host enters `waitForGuestChoice`, the choice queue buffers it (already handled by `AsyncQueue` in `tcp-direct.ts`). Verify this is still the case — a regression would cause turn-1 deadlock.
+
+---
+
+## Self-review
+
+- [x] Architecture reversal justified from concrete evidence in tcp-direct.ts
+- [x] Session store extensions match PR43's existing patterns (validation, shape guard, reap)
+- [x] Daemon lifecycle specified — spawn, ready signal, unref, reap
+- [x] IPC protocol typed end-to-end
+- [x] SKILL.md follows gym prior art (AskUserQuestion only, no chat parsing)
+- [x] Visual QA merge gate called out, not handwaved
+- [x] Out-of-scope items explicit (switch, surrender, leave, smoke)
+- [x] Tests are real TCP + real UNIX socket, no mocks (memory)
+- [x] OMC-independent (no OMC imports in skill file or daemon)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "./bin/tsx-resolve.sh src/setup/postinstall.ts",
     "build": "tsc",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test test/*.test.ts"
+    "test": "node --import tsx --test --test-concurrency=1 test/*.test.ts"
   },
   "dependencies": {
     "pngjs": "^7.0.0",

--- a/skills/friendly-battle/SKILL.md
+++ b/skills/friendly-battle/SKILL.md
@@ -1,0 +1,195 @@
+---
+description: "Tokenmon friendly battle. Real PvP turn loop against another player on the same network. Korean: 친선전, 친선 배틀, 배틀, 대전, friendly battle"
+---
+
+Open a friendly battle session and fight another player in real-time turn-based combat. One player opens a room (`open`), shares the session code + host:port with their opponent, who then joins (`join`). Switch / surrender / leave are not yet available (coming in PR45/46).
+
+## Execute
+
+### Step 0 — Parse `$ARGUMENTS`
+
+Read the first token of `$ARGUMENTS`:
+
+- `open` → go to **Step 1a** (open flow)
+- `join` → go to **Step 1b** (join flow); the second token must be `<code>@<host>:<port>`
+- `status` → go to **Step 3** (status flow)
+- `help` or empty → go to **Step 4** (help flow)
+- anything else → print `알 수 없는 명령어: <token>` and go to **Step 4**
+
+---
+
+### Step 1a — Open flow (host)
+
+**Initialize the host daemon:**
+
+```bash
+P="${CLAUDE_PLUGIN_ROOT:-$(ls -d ~/.claude/plugins/marketplaces/tkm 2>/dev/null || ls -d ~/.claude/plugins/cache/tkm/tkm/*/ 2>/dev/null | sort -V | tail -1)}"
+GEN=$(node -e "try{const g=JSON.parse(require('fs').readFileSync(require('path').join(require('os').homedir(),'.claude/tokenmon/global-config.json'),'utf-8'));console.log(g.active_generation||'gen1')}catch{console.log('gen1')}")
+SESSION_CODE=$(node -e "process.stdout.write(require('crypto').randomBytes(3).toString('hex'))")
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --init-host --session-code "$SESSION_CODE" --generation "$GEN" --listen-host 127.0.0.1 --port 0 --timeout-ms 300000 --player-name Host
+```
+
+Parse the JSON envelope on stdout. Store `sessionId` and `questionContext`. Also read the `PORT:` line from stderr to get the bound port.
+
+Tell the user:
+- "세션 코드: `<SESSION_CODE>`"
+- "호스트 주소: `127.0.0.1:<PORT>`"
+- "상대방에게 위 코드와 주소를 공유하고, 상대방이 `/tkm:friendly-battle join <code>@127.0.0.1:<port>` 를 실행하도록 안내하세요."
+- "게스트가 접속할 때까지 잠시 기다립니다..."
+
+Then enter the **wait-for-guest polling loop**:
+
+All subsequent friendly-battle-turn invocations use the same launcher:
+`"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" <flags>` — keep `$P`, `GEN`, and `sessionId` in scope.
+
+Poll loop:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --wait-next-event --session "$SESSION_ID" --generation "$GEN" --timeout-ms 60000
+```
+
+- If the returned envelope has `phase === 'battle'`: transition to **Step 2** (turn loop).
+- If the returned envelope has `phase === 'aborted'`: read the REASON from stderr, show it to the user, and stop.
+- Otherwise (still `waiting_for_guest`): repeat the poll (up to 5 times total, then stop with a "게스트가 응답하지 않습니다" message).
+
+---
+
+### Step 1b — Join flow (guest)
+
+Parse the second token of `$ARGUMENTS` as `<code>@<host>:<port>`. For example: `abc123@192.168.1.5:54321`.
+
+If the format is missing or malformed, use AskUserQuestion to ask:
+- Question: "접속 정보를 `<code>@<host>:<port>` 형식으로 입력해 주세요."
+- Other only (no buttons)
+
+Once you have the three parts (`SESSION_CODE`, `HOST`, `PORT`):
+
+```bash
+P="${CLAUDE_PLUGIN_ROOT:-$(ls -d ~/.claude/plugins/marketplaces/tkm 2>/dev/null || ls -d ~/.claude/plugins/cache/tkm/tkm/*/ 2>/dev/null | sort -V | tail -1)}"
+GEN=$(node -e "try{const g=JSON.parse(require('fs').readFileSync(require('path').join(require('os').homedir(),'.claude/tokenmon/global-config.json'),'utf-8'));console.log(g.active_generation||'gen1')}catch{console.log('gen1')}")
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --init-join --session-code "$SESSION_CODE" --host "$HOST" --port "$PORT" --generation "$GEN" --timeout-ms 30000 --player-name Guest
+```
+
+Parse the JSON envelope on stdout. Store `sessionId`.
+
+Tell the user: "호스트에 접속 중입니다... 잠시 기다려 주세요."
+
+Then poll with `--wait-next-event` (same loop as Step 1a) until `phase === 'battle'`, then transition to **Step 2**.
+
+If `phase === 'aborted'`: show the REASON from stderr and stop.
+
+---
+
+### Step 2 — Turn loop (shared after handshake)
+
+**Non-negotiable input rule:** ALWAYS use **AskUserQuestion** for action selection. Never parse actions from plain chat. If the user types `1`, `공격`, `교체`, `항복`, or anything else in free chat during battle, ignore it as a battle command and re-open the correct AskUserQuestion UI.
+
+**Turn loop:**
+
+1. Call `--wait-next-event`:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --wait-next-event --session "$SESSION_ID" --generation "$GEN" --timeout-ms 60000
+```
+
+2. Parse the returned envelope. Dispatch on `status`:
+
+   - **`select_action`**: build a move-select AskUserQuestion (see below).
+   - **`victory`**: show "승리! 배틀이 끝났습니다." and stop.
+   - **`defeat`**: show "패배... 배틀이 끝났습니다." and stop.
+   - **`aborted`**: read REASON from stderr, show it, and stop.
+   - Anything else: loop back to step 1.
+
+3. **Move-select AskUserQuestion** (when `status === 'select_action'`):
+
+   Show the `questionContext` as the question text. Build buttons from `moveOptions` only:
+   - Show exactly `min(moveOptions.length, 4)` buttons.
+   - Label each: `{index}. {nameKo} ({pp}/{maxPp})` — indexes are 1-based as provided.
+   - If a move has `disabled: true`, keep the slot visibly unavailable; do not replace with another action.
+   - Never add switch or surrender as buttons.
+   - Rely on the auto-provided `Other` field for non-move intents.
+
+   Parse the AskUserQuestion answer:
+   - Button 1-4 on a shown move slot: call `--action`:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --action "move:$N" --session "$SESSION_ID" --generation "$GEN"
+```
+
+   - `Other` text matching `/^(교체|switch|change)$/i`: respond with "교체는 PR45에서 추가됩니다. 기술 버튼을 선택해 주세요." and re-ask the same AskUserQuestion.
+   - `Other` text matching `/^(항복|surrender|quit|gg)$/i`: respond with "항복은 PR45에서 추가됩니다. 기술 버튼을 선택해 주세요." and re-ask the same AskUserQuestion.
+   - Anything else in `Other`: show "알아들을 수 없어. 기술 버튼을 눌러줘." and re-ask.
+
+4. After `--action` returns an ack envelope, parse `animationFrames`:
+   - If `animationFrames.length === 0`: loop back to step 1 immediately.
+   - If frames exist: display each frame's description as a message (no sleep loop for PR44). After displaying all frames, loop back to step 1.
+
+---
+
+### Step 3 — Status flow
+
+Requires a stored `sessionId` from the current session. If no session is active, tell the user to run `/tkm:friendly-battle open` or `/tkm:friendly-battle join` first and stop.
+
+```bash
+P="${CLAUDE_PLUGIN_ROOT:-$(ls -d ~/.claude/plugins/marketplaces/tkm 2>/dev/null || ls -d ~/.claude/plugins/cache/tkm/tkm/*/ 2>/dev/null | sort -V | tail -1)}"
+GEN=$(node -e "try{const g=JSON.parse(require('fs').readFileSync(require('path').join(require('os').homedir(),'.claude/tokenmon/global-config.json'),'utf-8'));console.log(g.active_generation||'gen1')}catch{console.log('gen1')}")
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --status --session "$SESSION_ID" --generation "$GEN"
+```
+
+Parse the JSON envelope and report `phase` and `status` to the user. This command never fails — if the daemon is dead it returns a frozen snapshot from disk.
+
+---
+
+### Step 4 — Help flow
+
+Show:
+
+```
+/tkm:friendly-battle open                       — 방을 열고 게스트를 기다림
+/tkm:friendly-battle join <code>@<host>:<port>  — 호스트 방에 참가
+/tkm:friendly-battle status                     — 현재 세션의 phase / status 확인
+/tkm:friendly-battle help                       — 이 도움말 표시
+
+/open 실행 후 출력된 세션 코드와 host:port 를 상대방과 공유하세요.
+교체 / 항복 / 나가기는 PR45/46에서 추가됩니다.
+```
+
+---
+
+## JSON Output Contract
+
+```json
+{
+  "sessionId": "fb-<uuid>",
+  "role": "host",
+  "phase": "waiting_for_guest",
+  "status": "waiting_for_guest",
+  "questionContext": "Waiting for guest (code abc123) — see /tkm:friendly-battle status",
+  "moveOptions": [
+    { "index": 1, "nameKo": "용의파동", "pp": 10, "maxPp": 10, "disabled": false }
+  ],
+  "partyOptions": [
+    { "index": 2, "name": "디아루가", "hp": 169, "maxHp": 169, "fainted": false }
+  ],
+  "animationFrames": [],
+  "currentFrameIndex": 0
+}
+```
+
+---
+
+## Display Guidelines
+
+- Show battle messages naturally in conversation, one per line.
+- Keep prompts SHORT and UI-driven: `questionContext` plus the next AskUserQuestion.
+- Respect `questionContext` when wording the question, but never use plain chat parsing instead of AskUserQuestion.
+- Do NOT add strategy commentary or analysis.
+
+## Usage
+
+| Command | Description |
+|---|---|
+| `/tkm:friendly-battle open` | Open a friendly battle room |
+| `/tkm:friendly-battle join <code>@<host>:<port>` | Join an open room |
+| `/tkm:friendly-battle status` | Check current session phase |
+| `/tkm:friendly-battle help` | Show this help |

--- a/src/cli/friendly-battle-turn.ts
+++ b/src/cli/friendly-battle-turn.ts
@@ -7,14 +7,18 @@ import { fileURLToPath } from 'node:url';
 import {
   type FriendlyBattleSessionRecord,
   writeFriendlyBattleSessionRecord,
+  readFriendlyBattleSessionRecord,
+  isPidAlive,
 } from '../friendly-battle/session-store.js';
 import { formatFriendlyBattleTurnJson } from '../friendly-battle/turn-json.js';
+import { sendDaemonIpcRequest } from '../friendly-battle/daemon-ipc.js';
 
 const DAEMON_ENTRY = resolve(fileURLToPath(new URL('../friendly-battle/daemon.ts', import.meta.url)));
 
 type Subcommand =
   | 'init-host'
   | 'init-join'
+  | 'wait-next-event'
   | 'action'
   | 'refresh'
   | 'status';
@@ -30,16 +34,18 @@ const USAGE = [
   'Subcommands:',
   '  --init-host --session-code <code> [--listen-host 127.0.0.1] [--port 0] [--timeout-ms 4000] [--generation gen4] [--player-name Host]',
   '  --init-join --session-code <code> --host <host> --port <port> [--timeout-ms 4000] [--generation gen4] [--player-name Guest]',
-  '  --action <move|switch:N|surrender> --session <id>',
+  '  --wait-next-event --session <id> --generation <gen> [--timeout-ms 60000]',
+  '  --action <move:N|switch:N|surrender> --session <id> --generation <gen>',
   '  --refresh (--frame <i> | --finalize) --session <id>',
-  '  --status --session <id>',
+  '  --status --session <id> --generation <gen>',
   '',
 ].join('\n');
 
 const SUBCOMMAND_FLAGS = new Set<string>([
   '--init-host',
   '--init-join',
-  '--action',
+  '--wait-next-event',
+  // '--action' is intentionally absent: it carries a value and is parsed by parseArgs directly
   '--refresh',
   '--status',
 ]);
@@ -112,6 +118,15 @@ function asStringFlag(flags: Record<string, string | boolean | undefined>, name:
   return typeof v === 'string' ? v : undefined;
 }
 
+const SAFE_ID = /^[A-Za-z0-9_.-]{1,128}$/;
+function validateSafeId(value: string, name: string): string {
+  if (!SAFE_ID.test(value)) {
+    process.stderr.write(`REASON: --${name} must match /^[A-Za-z0-9_.-]{1,128}$/, got ${JSON.stringify(value)}\n`);
+    process.exit(1);
+  }
+  return value;
+}
+
 // ---------------------------------------------------------------------------
 
 function printUsage(): void {
@@ -121,6 +136,7 @@ function printUsage(): void {
 function resolveSubcommand(argv: string[]): Subcommand | null {
   if (argv.includes('--init-host')) return 'init-host';
   if (argv.includes('--init-join')) return 'init-join';
+  if (argv.includes('--wait-next-event')) return 'wait-next-event';
   if (argv.includes('--action')) return 'action';
   if (argv.includes('--refresh')) return 'refresh';
   if (argv.includes('--status')) return 'status';
@@ -459,14 +475,114 @@ async function runInitJoin(flags: Record<string, string | boolean | undefined>):
   }))}\n`);
 }
 
-async function runAction(_flags: Record<string, string | boolean | undefined>): Promise<void> {
-  throw new Error('not implemented: --action');
+async function runWaitNextEvent(flags: Record<string, string | boolean | undefined>): Promise<void> {
+  const sessionId = validateSafeId(requireFlag(flags, 'session'), 'session');
+  const generation = validateGeneration(asStringFlag(flags, 'generation'));
+  const timeoutMs = requirePositiveInt(asStringFlag(flags, 'timeout-ms'), 'timeout-ms', 60_000);
+
+  const record = readFriendlyBattleSessionRecord(sessionId, generation);
+  if (!record || !record.socketPath || !record.daemonPid) {
+    process.stderr.write(`REASON: unknown session ${sessionId}\n`);
+    process.exit(1);
+  }
+
+  try {
+    const response = await sendDaemonIpcRequest(record.socketPath, { op: 'wait_next_event', timeoutMs }, timeoutMs + 2_000);
+    if (response.op === 'error') {
+      process.stderr.write(`REASON: ${response.message}\n`);
+      process.exit(1);
+    }
+    if (response.op !== 'event') {
+      process.stderr.write(`REASON: unexpected daemon response ${response.op}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${JSON.stringify(response.envelope)}\n`);
+  } catch (err) {
+    process.stderr.write(`REASON: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
 }
+
+async function runAction(flags: Record<string, string | boolean | undefined>): Promise<void> {
+  const sessionId = validateSafeId(requireFlag(flags, 'session'), 'session');
+  const generation = validateGeneration(asStringFlag(flags, 'generation'));
+  const token = requireFlag(flags, 'action');
+
+  let action: { kind: 'move'; index: number };
+  const moveMatch = /^move:([1-4])$/.exec(token);
+  if (moveMatch) {
+    action = { kind: 'move', index: Number.parseInt(moveMatch[1], 10) - 1 };
+  } else if (/^switch:\d+$/.test(token)) {
+    process.stderr.write(`REASON: switch action not implemented until PR45\n`);
+    process.exit(2);
+  } else if (token === 'surrender') {
+    process.stderr.write(`REASON: surrender action not implemented until PR45\n`);
+    process.exit(2);
+  } else {
+    process.stderr.write(`REASON: unknown action token ${JSON.stringify(token)}\n`);
+    process.exit(1);
+  }
+
+  const record = readFriendlyBattleSessionRecord(sessionId, generation);
+  if (!record || !record.socketPath || !record.daemonPid) {
+    process.stderr.write(`REASON: unknown session ${sessionId}\n`);
+    process.exit(1);
+  }
+
+  try {
+    const response = await sendDaemonIpcRequest(record.socketPath, { op: 'submit_action', action }, 10_000);
+    if (response.op === 'error') {
+      process.stderr.write(`REASON: ${response.message}\n`);
+      process.exit(1);
+    }
+    if (response.op !== 'ack') {
+      process.stderr.write(`REASON: unexpected daemon response ${response.op}\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${JSON.stringify(response.envelope)}\n`);
+  } catch (err) {
+    process.stderr.write(`REASON: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+}
+
 async function runRefresh(_flags: Record<string, string | boolean | undefined>): Promise<void> {
   throw new Error('not implemented: --refresh');
 }
-async function runStatus(_flags: Record<string, string | boolean | undefined>): Promise<void> {
-  throw new Error('not implemented: --status');
+
+async function runStatus(flags: Record<string, string | boolean | undefined>): Promise<void> {
+  const sessionId = validateSafeId(requireFlag(flags, 'session'), 'session');
+  const generation = validateGeneration(asStringFlag(flags, 'generation'));
+
+  const record = readFriendlyBattleSessionRecord(sessionId, generation);
+  if (!record) {
+    process.stderr.write(`REASON: unknown session ${sessionId}\n`);
+    process.exit(1);
+  }
+
+  const daemonAlive = typeof record.daemonPid === 'number' && isPidAlive(record.daemonPid);
+  if (daemonAlive && record.socketPath) {
+    try {
+      const response = await sendDaemonIpcRequest(record.socketPath, { op: 'status' }, 2_000);
+      if (response.op === 'status') {
+        process.stdout.write(`${JSON.stringify(response.envelope)}\n`);
+        return;
+      }
+    } catch {
+      // fall through to persisted snapshot
+    }
+  }
+
+  // Daemon is dead or unreachable — synthesize a frozen envelope from the record
+  const envelope = formatFriendlyBattleTurnJson({
+    record,
+    questionContext: daemonAlive ? 'Daemon unreachable' : 'Daemon no longer running',
+    moveOptions: [],
+    partyOptions: [],
+    animationFrames: [],
+    currentFrameIndex: 0,
+  });
+  process.stdout.write(`${JSON.stringify(envelope)}\n`);
 }
 
 function requireFlag(flags: Record<string, string | boolean | undefined>, name: string): string {
@@ -484,6 +600,9 @@ async function main(argv: string[]): Promise<void> {
       return;
     case 'init-join':
       await runInitJoin(parsed.flags);
+      return;
+    case 'wait-next-event':
+      await runWaitNextEvent(parsed.flags);
       return;
     case 'action':
       await runAction(parsed.flags);

--- a/src/cli/friendly-battle-turn.ts
+++ b/src/cli/friendly-battle-turn.ts
@@ -20,7 +20,6 @@ type Subcommand =
   | 'init-join'
   | 'wait-next-event'
   | 'action'
-  | 'refresh'
   | 'status';
 
 interface ParsedCliArgs {
@@ -36,7 +35,6 @@ const USAGE = [
   '  --init-join --session-code <code> --host <host> --port <port> [--timeout-ms 4000] [--generation gen4] [--player-name Guest]',
   '  --wait-next-event --session <id> --generation <gen> [--timeout-ms 60000]',
   '  --action <move:N|switch:N|surrender> --session <id> --generation <gen>',
-  '  --refresh (--frame <i> | --finalize) --session <id>',
   '  --status --session <id> --generation <gen>',
   '',
 ].join('\n');
@@ -46,7 +44,6 @@ const SUBCOMMAND_FLAGS = new Set<string>([
   '--init-join',
   '--wait-next-event',
   // '--action' is intentionally absent: it carries a value and is parsed by parseArgs directly
-  '--refresh',
   '--status',
 ]);
 
@@ -59,8 +56,6 @@ const CLI_FLAG_SCHEMA = {
   'timeout-ms': { type: 'string' as const },
   'generation': { type: 'string' as const },
   'player-name': { type: 'string' as const },
-  'frame': { type: 'string' as const },
-  'finalize': { type: 'boolean' as const },
   'action': { type: 'string' as const },
 };
 
@@ -138,7 +133,6 @@ function resolveSubcommand(argv: string[]): Subcommand | null {
   if (argv.includes('--init-join')) return 'init-join';
   if (argv.includes('--wait-next-event')) return 'wait-next-event';
   if (argv.includes('--action')) return 'action';
-  if (argv.includes('--refresh')) return 'refresh';
   if (argv.includes('--status')) return 'status';
   return null;
 }
@@ -252,11 +246,11 @@ async function runInitHost(flags: Record<string, string | boolean | undefined>):
   // Fork the daemon as a detached child
   const child = spawn(
     process.execPath,
-    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'host', '--options-json', optionsB64],
+    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'host'],
     {
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: { ...process.env, TKM_FB_OPTIONS_B64: optionsB64 },
     },
   );
 
@@ -276,7 +270,8 @@ async function runInitHost(flags: Record<string, string | boolean | undefined>):
     );
   } catch (err) {
     // Daemon failed to start — emit aborted envelope and exit 1
-    child.kill();
+    child.kill('SIGTERM');
+    child.unref();
     const record: FriendlyBattleSessionRecord = {
       sessionId,
       role: 'host',
@@ -382,11 +377,11 @@ async function runInitJoin(flags: Record<string, string | boolean | undefined>):
   // Fork the daemon as a detached child
   const child = spawn(
     process.execPath,
-    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'guest', '--options-json', optionsB64],
+    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'guest'],
     {
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
+      env: { ...process.env, TKM_FB_OPTIONS_B64: optionsB64 },
     },
   );
 
@@ -405,7 +400,8 @@ async function runInitJoin(flags: Record<string, string | boolean | undefined>):
     );
   } catch (err) {
     // Daemon failed to start — emit aborted envelope and exit 1
-    child.kill();
+    child.kill('SIGTERM');
+    child.unref();
     const record: FriendlyBattleSessionRecord = {
       sessionId,
       role: 'guest',
@@ -546,10 +542,6 @@ async function runAction(flags: Record<string, string | boolean | undefined>): P
   }
 }
 
-async function runRefresh(_flags: Record<string, string | boolean | undefined>): Promise<void> {
-  throw new Error('not implemented: --refresh');
-}
-
 async function runStatus(flags: Record<string, string | boolean | undefined>): Promise<void> {
   const sessionId = validateSafeId(requireFlag(flags, 'session'), 'session');
   const generation = validateGeneration(asStringFlag(flags, 'generation'));
@@ -606,9 +598,6 @@ async function main(argv: string[]): Promise<void> {
       return;
     case 'action':
       await runAction(parsed.flags);
-      return;
-    case 'refresh':
-      await runRefresh(parsed.flags);
       return;
     case 'status':
       await runStatus(parsed.flags);

--- a/src/cli/friendly-battle-turn.ts
+++ b/src/cli/friendly-battle-turn.ts
@@ -1,14 +1,16 @@
 #!/usr/bin/env -S npx tsx
 import { parseArgs } from 'node:util';
 import { randomUUID } from 'node:crypto';
-import { createFriendlyBattleSpikeHost, connectFriendlyBattleSpikeGuest } from '../friendly-battle/spike/tcp-direct.js';
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   type FriendlyBattleSessionRecord,
   writeFriendlyBattleSessionRecord,
 } from '../friendly-battle/session-store.js';
 import { formatFriendlyBattleTurnJson } from '../friendly-battle/turn-json.js';
-import { loadFriendlyBattleCurrentProfile } from '../friendly-battle/local-harness.js';
-import { buildFriendlyBattlePartySnapshot } from '../friendly-battle/snapshot.js';
+
+const DAEMON_ENTRY = resolve(fileURLToPath(new URL('../friendly-battle/daemon.ts', import.meta.url)));
 
 type Subcommand =
   | 'init-host'
@@ -156,7 +158,59 @@ function parseCliArgs(argv: string[]): ParsedCliArgs {
   return { subcommand, flags: values };
 }
 
+// ---------------------------------------------------------------------------
+// Reads lines from a Readable stream until a predicate matches, with timeout.
+// Returns the first matching line.
+// ---------------------------------------------------------------------------
+function readLineUntil(
+  stream: NodeJS.ReadableStream,
+  predicate: (line: string) => boolean,
+  timeoutMs: number,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      stream.removeListener('data', onData);
+      stream.removeListener('end', onEnd);
+      reject(new Error(`readLineUntil: timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    function onData(chunk: Buffer | string): void {
+      if (settled) return;
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      // Keep the last partial line in the buffer
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (predicate(line)) {
+          settled = true;
+          clearTimeout(timer);
+          stream.removeListener('data', onData);
+          stream.removeListener('end', onEnd);
+          resolve(line);
+          return;
+        }
+      }
+    }
+
+    function onEnd(): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error('readLineUntil: stream ended before predicate matched'));
+    }
+
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+  });
+}
+
 async function runInitHost(flags: Record<string, string | boolean | undefined>): Promise<void> {
+  // --- Input validation (must run before forking daemon) ---
   const sessionCode = validateSessionCode(requireFlag(flags, 'session-code'));
   const listenHost = asStringFlag(flags, 'listen-host') ?? '127.0.0.1';
   const port = requirePositiveInt(asStringFlag(flags, 'port'), 'port', 0);
@@ -164,21 +218,94 @@ async function runInitHost(flags: Record<string, string | boolean | undefined>):
   const generation = validateGeneration(asStringFlag(flags, 'generation'));
   const playerName = sanitizeName(asStringFlag(flags, 'player-name'), 'player-name', 'Host');
 
-  let currentStage: 'waiting_for_guest' | 'handshake' | 'ready' | 'battle' = 'waiting_for_guest';
-
-  const host = await createFriendlyBattleSpikeHost({
-    host: listenHost,
-    port,
-    sessionCode,
-    hostPlayerName: playerName,
-    generation,
-  });
-
-  process.stderr.write(`PORT: ${host.connectionInfo.port}\n`);
-
   const sessionId = `fb-${randomUUID()}`;
   const nowIso = () => new Date().toISOString();
 
+  // Build options JSON for the daemon
+  const daemonOptions = {
+    sessionId,
+    sessionCode,
+    host: listenHost,
+    port,
+    generation,
+    playerName,
+    timeoutMs,
+  };
+  const optionsB64 = Buffer.from(JSON.stringify(daemonOptions), 'utf8').toString('base64');
+
+  // Fork the daemon as a detached child
+  const child = spawn(
+    process.execPath,
+    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'host', '--options-json', optionsB64],
+    {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    },
+  );
+
+  // Relay daemon stderr to our stderr so errors are visible
+  child.stderr?.on('data', (chunk: Buffer) => {
+    process.stderr.write(chunk);
+  });
+
+  let daemonReadyLine: string;
+  try {
+    // Wait for DAEMON_READY <sessionId> <socketPath> <port>
+    // Use timeoutMs + 5s buffer so validation still fires even if daemon takes a moment
+    daemonReadyLine = await readLineUntil(
+      child.stdout,
+      (line) => line.startsWith('DAEMON_READY '),
+      timeoutMs + 5000,
+    );
+  } catch (err) {
+    // Daemon failed to start — emit aborted envelope and exit 1
+    child.kill();
+    const record: FriendlyBattleSessionRecord = {
+      sessionId,
+      role: 'host',
+      generation,
+      sessionCode,
+      phase: 'aborted',
+      status: 'aborted',
+      transport: { host: listenHost, port },
+      opponent: null,
+      pid: process.pid,
+      daemonPid: 0,
+      socketPath: '',
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
+      record,
+      questionContext: 'aborted',
+      moveOptions: [],
+      partyOptions: [],
+      animationFrames: [],
+      currentFrameIndex: 0,
+    }))}\n`);
+    process.stderr.write(`STAGE: waiting_for_guest\n`);
+    process.stderr.write(`FAILED_STAGE: waiting_for_guest\n`);
+    process.stderr.write(`REASON: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  // Parse DAEMON_READY <sessionId> <socketPath> <boundPort>
+  // Host emits 4 tokens; guest emits 3 (no port).
+  const parts = daemonReadyLine.trim().split(' ');
+  // parts[0] = 'DAEMON_READY', parts[1] = sessionId, parts[2] = socketPath, parts[3] = port
+  const socketPath = parts[2] ?? '';
+  const boundPort = parts[3] !== undefined ? Number.parseInt(parts[3], 10) : port;
+
+  const daemonPid = child.pid ?? 0;
+
+  // Detach from the daemon's stdio so the CLI's event loop can exit.
+  // Must happen before child.unref() so no handles keep the parent alive.
+  child.stdout.destroy();
+  child.stderr?.destroy();
+  child.unref();
+
+  // Write the session record with daemon PID and socket path
   const record: FriendlyBattleSessionRecord = {
     sessionId,
     role: 'host',
@@ -186,79 +313,33 @@ async function runInitHost(flags: Record<string, string | boolean | undefined>):
     sessionCode,
     phase: 'waiting_for_guest',
     status: 'waiting_for_guest',
-    transport: {
-      host: host.connectionInfo.host,
-      port: host.connectionInfo.port,
-    },
+    transport: { host: listenHost, port: boundPort },
     opponent: null,
     pid: process.pid,
+    daemonPid,
+    socketPath,
     createdAt: nowIso(),
     updatedAt: nowIso(),
   };
   writeFriendlyBattleSessionRecord(record);
 
+  // Emit PORT and STAGE on stderr (tests rely on these)
+  process.stderr.write(`PORT: ${boundPort}\n`);
+  process.stderr.write(`STAGE: waiting_for_guest\n`);
+
+  // Emit the first JSON envelope on stdout
   process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
     record,
-    questionContext: `Waiting for guest (code ${sessionCode}) — press Ctrl+C to cancel`,
+    questionContext: `Waiting for guest (code ${sessionCode}) — see /tkm:friendly-battle status`,
     moveOptions: [],
     partyOptions: [],
     animationFrames: [],
     currentFrameIndex: 0,
   }))}\n`);
-  process.stderr.write(`STAGE: waiting_for_guest\n`);
-
-  try {
-    const joined = await host.waitForGuestJoin(timeoutMs);
-    currentStage = 'handshake';
-    process.stderr.write(`STAGE: guest_joined (${joined.guestPlayerName})\n`);
-
-    // Mark host ready, wait for guest ready, then start the battle so the
-    // guest's waitForStarted() can resolve.
-    host.markHostReady();
-    await host.waitUntilCanStart(timeoutMs);
-    currentStage = 'ready';
-    await host.startBattle(randomUUID());
-    currentStage = 'battle';
-
-    record.phase = 'battle';
-    record.status = 'select_action';
-    record.opponent = { playerName: joined.guestPlayerName };
-    record.updatedAt = nowIso();
-    writeFriendlyBattleSessionRecord(record);
-
-    // PR43 scope: emit the ready envelope and exit 0. Turn loop (wait-next-event)
-    // is PR44.
-    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
-      record,
-      questionContext: `🤝 vs ${joined.guestPlayerName}`,
-      moveOptions: [],
-      partyOptions: [],
-      animationFrames: [],
-      currentFrameIndex: 0,
-    }))}\n`);
-  } catch (err) {
-    record.phase = 'aborted';
-    record.status = 'aborted';
-    record.updatedAt = nowIso();
-    writeFriendlyBattleSessionRecord(record);
-    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
-      record,
-      questionContext: `aborted`,
-      moveOptions: [],
-      partyOptions: [],
-      animationFrames: [],
-      currentFrameIndex: 0,
-    }))}\n`);
-    process.stderr.write(`STAGE: ${currentStage}\n`);
-    process.stderr.write(`FAILED_STAGE: ${currentStage}\n`);
-    process.stderr.write(`REASON: ${(err as Error).message}\n`);
-    await host.close().catch(() => undefined);
-    process.exit(1);
-  }
-  await host.close().catch(() => undefined);
 }
 
 async function runInitJoin(flags: Record<string, string | boolean | undefined>): Promise<void> {
+  // --- Input validation (must run before forking daemon) ---
   const sessionCode = validateSessionCode(requireFlag(flags, 'session-code'));
   const hostAddr = requireFlag(flags, 'host');
   const portStr = asStringFlag(flags, 'port') ?? requireFlag(flags, 'port');
@@ -267,10 +348,89 @@ async function runInitJoin(flags: Record<string, string | boolean | undefined>):
   const generation = validateGeneration(asStringFlag(flags, 'generation'));
   const playerName = sanitizeName(asStringFlag(flags, 'player-name'), 'player-name', 'Guest');
 
-  let currentStage: 'handshake' | 'ready' | 'battle' = 'handshake';
-
   const sessionId = `fb-${randomUUID()}`;
   const nowIso = () => new Date().toISOString();
+
+  // Build options JSON for the daemon
+  const daemonOptions = {
+    sessionId,
+    sessionCode,
+    host: hostAddr,
+    port,
+    generation,
+    playerName,
+    timeoutMs,
+  };
+  const optionsB64 = Buffer.from(JSON.stringify(daemonOptions), 'utf8').toString('base64');
+
+  // Fork the daemon as a detached child
+  const child = spawn(
+    process.execPath,
+    ['--import', 'tsx', DAEMON_ENTRY, '--role', 'guest', '--options-json', optionsB64],
+    {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    },
+  );
+
+  // Relay daemon stderr to our stderr so errors are visible
+  child.stderr?.on('data', (chunk: Buffer) => {
+    process.stderr.write(chunk);
+  });
+
+  let daemonReadyLine: string;
+  try {
+    // Wait for DAEMON_READY <sessionId> <socketPath>  (guest: 3 tokens, no port)
+    daemonReadyLine = await readLineUntil(
+      child.stdout,
+      (line) => line.startsWith('DAEMON_READY '),
+      timeoutMs + 5000,
+    );
+  } catch (err) {
+    // Daemon failed to start — emit aborted envelope and exit 1
+    child.kill();
+    const record: FriendlyBattleSessionRecord = {
+      sessionId,
+      role: 'guest',
+      generation,
+      sessionCode,
+      phase: 'aborted',
+      status: 'aborted',
+      transport: { host: hostAddr, port },
+      opponent: null,
+      pid: process.pid,
+      daemonPid: 0,
+      socketPath: '',
+      createdAt: nowIso(),
+      updatedAt: nowIso(),
+    };
+    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
+      record,
+      questionContext: 'aborted',
+      moveOptions: [],
+      partyOptions: [],
+      animationFrames: [],
+      currentFrameIndex: 0,
+    }))}\n`);
+    process.stderr.write(`STAGE: handshake\n`);
+    process.stderr.write(`FAILED_STAGE: handshake\n`);
+    process.stderr.write(`REASON: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  // Parse DAEMON_READY <sessionId> <socketPath>  (guest: 3 tokens)
+  const parts = daemonReadyLine.trim().split(' ');
+  const socketPath = parts[2] ?? '';
+
+  const daemonPid = child.pid ?? 0;
+
+  // Detach from the daemon's stdio so the CLI's event loop can exit.
+  child.stdout.destroy();
+  child.stderr?.destroy();
+  child.unref();
+
+  // Write the session record with daemon PID and socket path
   const record: FriendlyBattleSessionRecord = {
     sessionId,
     role: 'guest',
@@ -279,74 +439,24 @@ async function runInitJoin(flags: Record<string, string | boolean | undefined>):
     phase: 'handshake',
     status: 'connecting',
     transport: { host: hostAddr, port },
-    opponent: { playerName: 'Host' },
+    opponent: null,
     pid: process.pid,
+    daemonPid,
+    socketPath,
     createdAt: nowIso(),
     updatedAt: nowIso(),
   };
   writeFriendlyBattleSessionRecord(record);
 
-  let guest: Awaited<ReturnType<typeof connectFriendlyBattleSpikeGuest>> | undefined;
-  try {
-    const guestProfile = loadFriendlyBattleCurrentProfile(generation);
-    const guestSnapshot = buildFriendlyBattlePartySnapshot(guestProfile);
-
-    guest = await connectFriendlyBattleSpikeGuest({
-      host: hostAddr,
-      port,
-      sessionCode,
-      guestPlayerName: playerName,
-      generation,
-      guestSnapshot,
-      timeoutMs,
-    });
-    process.stderr.write(`STAGE: connected\n`);
-
-    await guest.markReady();
-    record.phase = 'ready';
-    record.status = 'connecting';
-    record.updatedAt = nowIso();
-    writeFriendlyBattleSessionRecord(record);
-    process.stderr.write(`STAGE: ready\n`);
-    currentStage = 'ready';
-
-    await guest.waitForStarted(timeoutMs);
-    record.phase = 'battle';
-    record.status = 'select_action';
-    record.updatedAt = nowIso();
-    writeFriendlyBattleSessionRecord(record);
-    process.stderr.write(`STAGE: battle_started\n`);
-    currentStage = 'battle';
-
-    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
-      record,
-      questionContext: `🤝 vs Host`,
-      moveOptions: [],
-      partyOptions: [],
-      animationFrames: [],
-      currentFrameIndex: 0,
-    }))}\n`);
-  } catch (err) {
-    record.phase = 'aborted';
-    record.status = 'aborted';
-    record.updatedAt = nowIso();
-    writeFriendlyBattleSessionRecord(record);
-    process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
-      record,
-      questionContext: `aborted`,
-      moveOptions: [],
-      partyOptions: [],
-      animationFrames: [],
-      currentFrameIndex: 0,
-    }))}\n`);
-    process.stderr.write(`STAGE: ${currentStage}\n`);
-    process.stderr.write(`FAILED_STAGE: ${currentStage}\n`);
-    process.stderr.write(`REASON: ${(err as Error).message}\n`);
-    await guest?.close().catch(() => undefined);
-    process.exit(1);
-  }
-
-  await guest?.close().catch(() => undefined);
+  // Emit the first JSON envelope on stdout
+  process.stdout.write(`${JSON.stringify(formatFriendlyBattleTurnJson({
+    record,
+    questionContext: `Joining battle (code ${sessionCode}) — see /tkm:friendly-battle status`,
+    moveOptions: [],
+    partyOptions: [],
+    animationFrames: [],
+    currentFrameIndex: 0,
+  }))}\n`);
 }
 
 async function runAction(_flags: Record<string, string | boolean | undefined>): Promise<void> {

--- a/src/friendly-battle/daemon-ipc.ts
+++ b/src/friendly-battle/daemon-ipc.ts
@@ -1,0 +1,164 @@
+// src/friendly-battle/daemon-ipc.ts
+import net from 'node:net';
+import { existsSync, unlinkSync } from 'node:fs';
+import {
+  decodeDaemonMessage,
+  encodeDaemonMessage,
+  type DaemonRequest,
+  type DaemonResponse,
+} from './daemon-protocol.js';
+
+export type DaemonIpcHandler = (
+  request: DaemonRequest,
+) => Promise<DaemonResponse> | DaemonResponse;
+
+export interface DaemonIpcServer {
+  readonly socketPath: string;
+  close(): Promise<void>;
+}
+
+export async function createDaemonIpcServer(
+  socketPath: string,
+  handler: DaemonIpcHandler,
+): Promise<DaemonIpcServer> {
+  // Remove any leftover socket file from a crashed previous run.
+  if (existsSync(socketPath)) {
+    unlinkSync(socketPath);
+  }
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding('utf8');
+    let buffer = '';
+    let handled = false;
+
+    const cleanup = (): void => {
+      if (!socket.destroyed) {
+        socket.end();
+      }
+    };
+
+    socket.on('data', (chunk: string) => {
+      if (handled) return;
+      buffer += chunk;
+      const newlineIdx = buffer.indexOf('\n');
+      if (newlineIdx < 0) return;
+
+      handled = true;
+      const line = buffer.slice(0, newlineIdx);
+      let request: DaemonRequest;
+      try {
+        request = decodeDaemonMessage<DaemonRequest>(line);
+      } catch (err) {
+        const response: DaemonResponse = {
+          op: 'error',
+          code: 'bad_request',
+          message: (err as Error).message,
+        };
+        socket.write(encodeDaemonMessage(response), () => cleanup());
+        return;
+      }
+
+      Promise.resolve(handler(request))
+        .then((response) => {
+          socket.write(encodeDaemonMessage(response), () => cleanup());
+        })
+        .catch((err: unknown) => {
+          const response: DaemonResponse = {
+            op: 'error',
+            code: 'handler_error',
+            message: (err as Error).message,
+          };
+          socket.write(encodeDaemonMessage(response), () => cleanup());
+        });
+    });
+
+    socket.on('error', () => {
+      cleanup();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+
+  return {
+    socketPath,
+    async close(): Promise<void> {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      if (existsSync(socketPath)) {
+        try {
+          unlinkSync(socketPath);
+        } catch {
+          // swallow — best effort
+        }
+      }
+    },
+  };
+}
+
+export async function sendDaemonIpcRequest(
+  socketPath: string,
+  request: DaemonRequest,
+  timeoutMs: number,
+): Promise<DaemonResponse> {
+  return new Promise<DaemonResponse>((resolve, reject) => {
+    const client = net.createConnection(socketPath);
+    let buffer = '';
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      client.destroy();
+      reject(new Error(`daemon IPC timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const finishError = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      client.destroy();
+      reject(err);
+    };
+
+    client.on('error', finishError);
+
+    client.on('connect', () => {
+      client.write(encodeDaemonMessage(request));
+    });
+
+    client.setEncoding('utf8');
+    client.on('data', (chunk: string) => {
+      if (settled) return;
+      buffer += chunk;
+      const newlineIdx = buffer.indexOf('\n');
+      if (newlineIdx < 0) return;
+
+      const line = buffer.slice(0, newlineIdx);
+      let response: DaemonResponse;
+      try {
+        response = decodeDaemonMessage<DaemonResponse>(line);
+      } catch (err) {
+        finishError(err as Error);
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timer);
+      client.end();
+      resolve(response);
+    });
+
+    client.on('close', () => {
+      if (!settled) {
+        finishError(new Error('daemon IPC connection closed before response'));
+      }
+    });
+  });
+}

--- a/src/friendly-battle/daemon-ipc.ts
+++ b/src/friendly-battle/daemon-ipc.ts
@@ -1,6 +1,6 @@
 // src/friendly-battle/daemon-ipc.ts
 import net from 'node:net';
-import { existsSync, unlinkSync } from 'node:fs';
+import { chmodSync, existsSync, unlinkSync } from 'node:fs';
 import {
   decodeDaemonMessage,
   encodeDaemonMessage,
@@ -17,6 +17,12 @@ export interface DaemonIpcServer {
   close(): Promise<void>;
 }
 
+/**
+ * Create a UNIX socket IPC server for the daemon.
+ *
+ * The server accepts exactly one request-response per connection — clients
+ * must not pipeline multiple requests on the same connection.
+ */
 export async function createDaemonIpcServer(
   socketPath: string,
   handler: DaemonIpcHandler,
@@ -31,6 +37,9 @@ export async function createDaemonIpcServer(
     let buffer = '';
     let handled = false;
 
+    // 5-second idle timeout — destroy the socket if no newline arrives in time.
+    socket.setTimeout(5000, () => socket.destroy());
+
     const cleanup = (): void => {
       if (!socket.destroyed) {
         socket.end();
@@ -40,6 +49,11 @@ export async function createDaemonIpcServer(
     socket.on('data', (chunk: string) => {
       if (handled) return;
       buffer += chunk;
+      // DoS cap: reject clients that send more than 64 KiB without a newline.
+      if (buffer.length > 64 * 1024) {
+        socket.destroy();
+        return;
+      }
       const newlineIdx = buffer.indexOf('\n');
       if (newlineIdx < 0) return;
 
@@ -84,6 +98,13 @@ export async function createDaemonIpcServer(
       resolve();
     });
   });
+
+  // Restrict socket access to owner only (security H1).
+  try {
+    chmodSync(socketPath, 0o600);
+  } catch {
+    // best effort — socket may be on a filesystem that ignores permissions
+  }
 
   return {
     socketPath,

--- a/src/friendly-battle/daemon-protocol.ts
+++ b/src/friendly-battle/daemon-protocol.ts
@@ -1,0 +1,32 @@
+import type { FriendlyBattleTurnJson } from './turn-json.js';
+
+export type DaemonRequest =
+  | { op: 'wait_next_event'; timeoutMs: number }
+  | { op: 'submit_action'; action: DaemonAction }
+  | { op: 'status' }
+  | { op: 'ping' };
+
+export type DaemonAction =
+  | { kind: 'move'; index: number };
+  // switch/surrender land in PR45 — add variants there, not here
+
+export type DaemonResponse =
+  | { op: 'event'; envelope: FriendlyBattleTurnJson }
+  | { op: 'ack'; envelope: FriendlyBattleTurnJson }
+  | { op: 'status'; envelope: FriendlyBattleTurnJson }
+  | { op: 'pong'; pid: number }
+  | { op: 'error'; code: string; message: string };
+
+export function encodeDaemonMessage(message: DaemonRequest | DaemonResponse): string {
+  return `${JSON.stringify(message)}\n`;
+}
+
+export function decodeDaemonMessage<T extends DaemonRequest | DaemonResponse>(
+  line: string,
+): T {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    throw new Error('daemon protocol: empty line');
+  }
+  return JSON.parse(trimmed) as T;
+}

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -298,6 +298,10 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
   const localEventQueue = new AsyncQueue<FriendlyBattleBattleEvent>();
   const localActionQueue = new AsyncQueue<FriendlyBattleChoiceEnvelope>();
 
+  // Sentinel set during clean shutdown: late wait_next_event callers get this
+  // finished envelope immediately instead of hanging until their own timeout.
+  let queueClosedEnvelope: ReturnType<typeof formatFriendlyBattleTurnJson> | null = null;
+
   // ---------------------------------------------------------------------------
   // Session record — written every time phase changes
   // ---------------------------------------------------------------------------
@@ -351,6 +355,10 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
       }
 
       case 'wait_next_event': {
+        // If the queue was closed cleanly, return the finished envelope immediately.
+        if (queueClosedEnvelope !== null) {
+          return { op: 'event', envelope: queueClosedEnvelope };
+        }
         const event = await localEventQueue.shift(req.timeoutMs, 'wait_next_event');
         const fields = eventToEnvelopeFields(event, role, runtime, ownSnapshot);
         // Update record status based on the event
@@ -402,6 +410,16 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
       while (localEventQueue.size > 0 && Date.now() < drainDeadline) {
         await new Promise<void>((resolve) => setTimeout(resolve, 20));
       }
+      // Arm the sentinel so late wait_next_event callers get the finished
+      // envelope immediately instead of hanging until their own timeout fires.
+      queueClosedEnvelope = formatFriendlyBattleTurnJson({
+        record,
+        questionContext: record.status === 'victory' ? 'You won!' : 'You lost!',
+        moveOptions: [],
+        partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : [],
+        animationFrames: [],
+        currentFrameIndex: 0,
+      });
     }
     await ipcServer.close().catch(() => undefined);
     process.exit(exitCode);
@@ -612,7 +630,6 @@ export async function startDaemon(role: FriendlyBattleRole, options: DaemonOptio
 
 function parseCliOptions(argv: string[]): { role: FriendlyBattleRole; options: DaemonOptions } {
   let role: FriendlyBattleRole | undefined;
-  let optionsJson: string | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--role' && argv[i + 1]) {
@@ -622,8 +639,6 @@ function parseCliOptions(argv: string[]): { role: FriendlyBattleRole; options: D
         process.exit(1);
       }
       role = r as FriendlyBattleRole;
-    } else if (argv[i] === '--options-json' && argv[i + 1]) {
-      optionsJson = argv[++i];
     }
   }
 
@@ -631,17 +646,19 @@ function parseCliOptions(argv: string[]): { role: FriendlyBattleRole; options: D
     process.stderr.write('daemon: missing --role\n');
     process.exit(1);
   }
-  if (!optionsJson) {
-    process.stderr.write('daemon: missing --options-json\n');
+
+  const optionsB64 = process.env.TKM_FB_OPTIONS_B64;
+  if (!optionsB64) {
+    process.stderr.write('daemon: missing TKM_FB_OPTIONS_B64 environment variable\n');
     process.exit(1);
   }
 
   let options: DaemonOptions;
   try {
-    const decoded = Buffer.from(optionsJson, 'base64').toString('utf8');
+    const decoded = Buffer.from(optionsB64, 'base64').toString('utf8');
     options = JSON.parse(decoded) as DaemonOptions;
   } catch (err) {
-    process.stderr.write(`daemon: failed to decode --options-json: ${(err as Error).message}\n`);
+    process.stderr.write(`daemon: failed to decode TKM_FB_OPTIONS_B64: ${(err as Error).message}\n`);
     process.exit(1);
   }
 

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -380,9 +380,6 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
   // ---------------------------------------------------------------------------
   const ipcServer = await createDaemonIpcServer(socketPath, ipcHandler);
 
-  // Signal to parent that we're ready
-  process.stdout.write(`DAEMON_READY ${sessionId} ${socketPath}\n`);
-
   // ---------------------------------------------------------------------------
   // Shutdown helper
   // ---------------------------------------------------------------------------
@@ -393,8 +390,19 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
     record.phase = phase;
     record.status = phase === 'finished' ? (record.status) : 'aborted';
     writeRecord();
-    localEventQueue.fail(new Error('daemon shutting down'));
+    // Fail action queue to unblock any turn-loop waiter.
     localActionQueue.fail(new Error('daemon shutting down'));
+    if (exitCode !== 0) {
+      // On error/abort, also fail the event queue so callers get an error.
+      localEventQueue.fail(new Error('daemon shutting down'));
+    } else {
+      // On clean finish: wait for the event queue to drain (all events consumed
+      // by IPC clients) before closing, with a 10s safety timeout.
+      const drainDeadline = Date.now() + 10_000;
+      while (localEventQueue.size > 0 && Date.now() < drainDeadline) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      }
+    }
     await ipcServer.close().catch(() => undefined);
     process.exit(exitCode);
   }
@@ -414,10 +422,14 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
       generation,
     });
 
+    // Signal ready with actual bound port so parent/test can connect guest
+    process.stdout.write(`DAEMON_READY ${sessionId} ${socketPath} ${host_transport.connectionInfo.port}\n`);
+
     try {
       // Handshake
       record.phase = 'waiting_for_guest';
       record.status = 'waiting_for_guest';
+      record.transport = { host: host_transport.connectionInfo.host, port: host_transport.connectionInfo.port };
       writeRecord();
 
       const joined = await host_transport.waitForGuestJoin(timeoutMs);
@@ -522,6 +534,9 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
     guestSnapshot,
     timeoutMs,
   });
+
+  // Signal ready to parent — guest doesn't emit a port
+  process.stdout.write(`DAEMON_READY ${sessionId} ${socketPath}\n`);
 
   try {
     await guest_transport.markReady();

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -1,0 +1,643 @@
+// src/friendly-battle/daemon.ts
+//
+// Long-lived daemon process that holds the TCP transport and drives the
+// friendly-battle turn loop. Spawned as a detached child by --init-host /
+// --init-join (Task 5). Exposes a UNIX socket for one-shot CLI subcommands.
+//
+// CLI:  tsx daemon.ts --role host|guest --options-json <base64>
+//
+// Options JSON shape:
+//   { sessionId, sessionCode, host, port, generation, playerName, timeoutMs }
+//
+// Stdout protocol:
+//   DAEMON_READY <sessionId> <socketPath>\n   ← emitted once, then silence
+//
+// SIGTERM / SIGINT → write phase='aborted', exit 1
+// battle_finished  → write phase='finished', exit 0
+
+import { randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  createFriendlyBattleSpikeHost,
+  connectFriendlyBattleSpikeGuest,
+} from './spike/tcp-direct.js';
+import {
+  createFriendlyBattleBattleRuntime,
+  submitFriendlyBattleChoice,
+} from './battle-adapter.js';
+import {
+  createBattleTeamFromFriendlyBattleSnapshot,
+  buildFriendlyBattlePartySnapshot,
+} from './snapshot.js';
+import {
+  loadFriendlyBattleCurrentProfile,
+  createFriendlyBattleChoiceEnvelope,
+  formatFriendlyBattleChoice,
+} from './local-harness.js';
+import {
+  friendlyBattleSessionsDir,
+  writeFriendlyBattleSessionRecord,
+  type FriendlyBattleSessionRecord,
+} from './session-store.js';
+import { createDaemonIpcServer } from './daemon-ipc.js';
+import type { DaemonRequest, DaemonResponse, DaemonAction } from './daemon-protocol.js';
+import {
+  formatFriendlyBattleTurnJson,
+  type FriendlyBattleTurnMoveOption,
+  type FriendlyBattleTurnPartyOption,
+  type FriendlyBattleTurnAnimationFrame,
+} from './turn-json.js';
+import type {
+  FriendlyBattleBattleEvent,
+  FriendlyBattleChoiceEnvelope,
+  FriendlyBattleRole,
+  FriendlyBattlePartySnapshot,
+} from './contracts.js';
+import type { FriendlyBattleBattleRuntime } from './battle-adapter.js';
+
+// ---------------------------------------------------------------------------
+// Minimal AsyncQueue — copied from tcp-direct.ts so this module is self-contained
+// ---------------------------------------------------------------------------
+
+class AsyncQueue<T> {
+  private readonly values: T[] = [];
+  private readonly waiters: Array<{
+    resolve: (value: T) => void;
+    reject: (error: Error) => void;
+    timer?: NodeJS.Timeout;
+  }> = [];
+
+  push(value: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.resolve(value);
+      return;
+    }
+    this.values.push(value);
+  }
+
+  fail(error: Error): void {
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift();
+      if (!waiter) continue;
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  }
+
+  shift(timeoutMs: number, label: string): Promise<T> {
+    if (this.values.length > 0) {
+      return Promise.resolve(this.values.shift() as T);
+    }
+    return new Promise<T>((resolve, reject) => {
+      const waiter = {
+        resolve,
+        reject,
+      } as {
+        resolve: (value: T) => void;
+        reject: (error: Error) => void;
+        timer?: NodeJS.Timeout;
+      };
+      waiter.timer = setTimeout(() => {
+        const index = this.waiters.indexOf(waiter);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.waiters.push(waiter);
+    });
+  }
+
+  get size(): number {
+    return this.values.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options JSON shape
+// ---------------------------------------------------------------------------
+
+interface DaemonOptions {
+  sessionId: string;
+  sessionCode: string;
+  host: string;       // listenHost for role=host, remote host for role=guest
+  port: number;
+  generation: string;
+  playerName: string;
+  timeoutMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: convert BattleEvents → turn-json fields
+// ---------------------------------------------------------------------------
+
+function buildMoveOptionsFromSnapshot(
+  snapshot: FriendlyBattlePartySnapshot,
+): FriendlyBattleTurnMoveOption[] {
+  // find the first alive pokemon (slot 0 is the active one for a fresh battle)
+  const active = snapshot.pokemon.slice().sort((a, b) => a.slot - b.slot)[0];
+  if (!active) return [];
+  return active.moves.map((move, index) => ({
+    index,
+    nameKo: move.name ?? `Move ${index + 1}`,
+    pp: move.pp,
+    maxPp: move.pp,
+    disabled: move.pp <= 0,
+  }));
+}
+
+function buildMoveOptionsFromRuntime(
+  runtime: FriendlyBattleBattleRuntime,
+  role: FriendlyBattleRole,
+): FriendlyBattleTurnMoveOption[] {
+  const team = role === 'host' ? runtime.state.player : runtime.state.opponent;
+  const active = team.pokemon[team.activeIndex];
+  if (!active) return [];
+  return active.moves.map((move, index) => ({
+    index,
+    nameKo: move.data.nameKo ?? move.data.name ?? `Move ${index + 1}`,
+    pp: move.currentPp,
+    maxPp: move.data.pp,
+    disabled: move.currentPp <= 0,
+  }));
+}
+
+function buildPartyOptionsFromRuntime(
+  runtime: FriendlyBattleBattleRuntime,
+  role: FriendlyBattleRole,
+): FriendlyBattleTurnPartyOption[] {
+  const team = role === 'host' ? runtime.state.player : runtime.state.opponent;
+  return team.pokemon.map((pokemon, index) => ({
+    index,
+    name: pokemon.displayName ?? `Pokemon ${index + 1}`,
+    hp: pokemon.currentHp,
+    maxHp: pokemon.maxHp,
+    fainted: pokemon.fainted,
+  }));
+}
+
+function buildPartyOptionsFromSnapshot(
+  snapshot: FriendlyBattlePartySnapshot,
+): FriendlyBattleTurnPartyOption[] {
+  return snapshot.pokemon.map((pokemon, index) => ({
+    index,
+    name: pokemon.displayName,
+    hp: pokemon.baseStats.hp,
+    maxHp: pokemon.baseStats.hp,
+    fainted: false,
+  }));
+}
+
+function eventToEnvelopeFields(
+  event: FriendlyBattleBattleEvent,
+  role: FriendlyBattleRole,
+  runtime: FriendlyBattleBattleRuntime | null,
+  ownSnapshot: FriendlyBattlePartySnapshot | null,
+): {
+  questionContext: string;
+  moveOptions: FriendlyBattleTurnMoveOption[];
+  partyOptions: FriendlyBattleTurnPartyOption[];
+  animationFrames: FriendlyBattleTurnAnimationFrame[];
+  currentFrameIndex: number;
+} {
+  switch (event.type) {
+    case 'battle_initialized':
+      return {
+        questionContext: 'Battle started!',
+        moveOptions: [],
+        partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : (ownSnapshot ? buildPartyOptionsFromSnapshot(ownSnapshot) : []),
+        animationFrames: [{ kind: 'message', text: 'Battle started!', durationMs: 300 }],
+        currentFrameIndex: 0,
+      };
+    case 'choices_requested': {
+      const moveOptions = runtime
+        ? buildMoveOptionsFromRuntime(runtime, role)
+        : (ownSnapshot ? buildMoveOptionsFromSnapshot(ownSnapshot) : []);
+      const partyOptions = runtime
+        ? buildPartyOptionsFromRuntime(runtime, role)
+        : (ownSnapshot ? buildPartyOptionsFromSnapshot(ownSnapshot) : []);
+      return {
+        questionContext: `Turn ${event.turn}: Choose your action`,
+        moveOptions,
+        partyOptions,
+        animationFrames: [],
+        currentFrameIndex: 0,
+      };
+    }
+    case 'turn_resolved': {
+      const frames: FriendlyBattleTurnAnimationFrame[] = event.messages.map((msg) => ({
+        kind: 'message',
+        text: msg,
+        durationMs: 300,
+      }));
+      return {
+        questionContext: event.messages.join(' '),
+        moveOptions: [],
+        partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : [],
+        animationFrames: frames,
+        currentFrameIndex: 0,
+      };
+    }
+    case 'battle_finished':
+      return {
+        questionContext: event.winner === role ? 'You won!' : 'You lost!',
+        moveOptions: [],
+        partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : [],
+        animationFrames: [],
+        currentFrameIndex: 0,
+      };
+  }
+}
+
+function eventStatus(
+  event: FriendlyBattleBattleEvent,
+  role: FriendlyBattleRole,
+): FriendlyBattleSessionRecord['status'] {
+  switch (event.type) {
+    case 'battle_initialized':
+      return 'ongoing';
+    case 'choices_requested':
+      return event.phase === 'awaiting_fainted_switch' ? 'fainted_switch' : 'select_action';
+    case 'turn_resolved':
+      return 'ongoing';
+    case 'battle_finished':
+      return event.winner === role ? 'victory' : 'defeat';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialize a DaemonAction for use with connectFriendlyBattleSpikeGuest.submitChoice
+// ---------------------------------------------------------------------------
+
+function serializeDaemonAction(action: DaemonAction): string {
+  switch (action.kind) {
+    case 'move':
+      return `move:${action.index}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main daemon entry
+// ---------------------------------------------------------------------------
+
+async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Promise<void> {
+  const { sessionId, sessionCode, host, port, generation, playerName, timeoutMs } = options;
+
+  // Derive the socket path — lives in the same dir as session records
+  const sessionsDir = friendlyBattleSessionsDir(generation);
+  mkdirSync(sessionsDir, { recursive: true });
+  const socketPath = join(sessionsDir, `${sessionId}.sock`);
+
+  const nowIso = () => new Date().toISOString();
+
+  // ---------------------------------------------------------------------------
+  // Event queue (delivered to UNIX socket wait_next_event callers)
+  // Action queue (populated by UNIX socket submit_action callers)
+  // ---------------------------------------------------------------------------
+  const localEventQueue = new AsyncQueue<FriendlyBattleBattleEvent>();
+  const localActionQueue = new AsyncQueue<FriendlyBattleChoiceEnvelope>();
+
+  // ---------------------------------------------------------------------------
+  // Session record — written every time phase changes
+  // ---------------------------------------------------------------------------
+  const record: FriendlyBattleSessionRecord = {
+    sessionId,
+    role,
+    generation,
+    sessionCode,
+    phase: role === 'host' ? 'waiting_for_guest' : 'handshake',
+    status: role === 'host' ? 'waiting_for_guest' : 'connecting',
+    transport: { host, port },
+    opponent: null,
+    pid: process.pid,
+    daemonPid: process.pid,
+    socketPath,
+    createdAt: nowIso(),
+    updatedAt: nowIso(),
+  };
+
+  function writeRecord(): void {
+    record.updatedAt = nowIso();
+    writeFriendlyBattleSessionRecord(record);
+  }
+
+  writeRecord();
+
+  // ---------------------------------------------------------------------------
+  // Runtime reference (only host sets this)
+  // ---------------------------------------------------------------------------
+  let runtime: FriendlyBattleBattleRuntime | null = null;
+  // Own snapshot (for guest-side move option construction before first event)
+  let ownSnapshot: FriendlyBattlePartySnapshot | null = null;
+
+  // ---------------------------------------------------------------------------
+  // IPC handler
+  // ---------------------------------------------------------------------------
+  async function ipcHandler(req: DaemonRequest): Promise<DaemonResponse> {
+    switch (req.op) {
+      case 'ping':
+        return { op: 'pong', pid: process.pid };
+
+      case 'status': {
+        const fields = {
+          questionContext: `phase=${record.phase} status=${record.status}`,
+          moveOptions: runtime ? buildMoveOptionsFromRuntime(runtime, role) : (ownSnapshot ? buildMoveOptionsFromSnapshot(ownSnapshot) : []),
+          partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : (ownSnapshot ? buildPartyOptionsFromSnapshot(ownSnapshot) : []),
+          animationFrames: [] as FriendlyBattleTurnAnimationFrame[],
+          currentFrameIndex: 0,
+        };
+        return { op: 'status', envelope: formatFriendlyBattleTurnJson({ record, ...fields }) };
+      }
+
+      case 'wait_next_event': {
+        const event = await localEventQueue.shift(req.timeoutMs, 'wait_next_event');
+        const fields = eventToEnvelopeFields(event, role, runtime, ownSnapshot);
+        // Update record status based on the event
+        record.status = eventStatus(event, role);
+        writeRecord();
+        return { op: 'event', envelope: formatFriendlyBattleTurnJson({ record, ...fields }) };
+      }
+
+      case 'submit_action': {
+        const envelope = createFriendlyBattleChoiceEnvelope(role, serializeDaemonAction(req.action));
+        localActionQueue.push(envelope);
+        // Return current status snapshot
+        const fields = {
+          questionContext: `Action submitted: ${serializeDaemonAction(req.action)}`,
+          moveOptions: [] as FriendlyBattleTurnMoveOption[],
+          partyOptions: runtime ? buildPartyOptionsFromRuntime(runtime, role) : [],
+          animationFrames: [] as FriendlyBattleTurnAnimationFrame[],
+          currentFrameIndex: 0,
+        };
+        return { op: 'ack', envelope: formatFriendlyBattleTurnJson({ record, ...fields }) };
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Start the IPC server before doing anything else so DAEMON_READY can fire
+  // ---------------------------------------------------------------------------
+  const ipcServer = await createDaemonIpcServer(socketPath, ipcHandler);
+
+  // Signal to parent that we're ready
+  process.stdout.write(`DAEMON_READY ${sessionId} ${socketPath}\n`);
+
+  // ---------------------------------------------------------------------------
+  // Shutdown helper
+  // ---------------------------------------------------------------------------
+  let shutdownCalled = false;
+  async function shutdown(exitCode: number, phase: FriendlyBattleSessionRecord['phase']): Promise<void> {
+    if (shutdownCalled) return;
+    shutdownCalled = true;
+    record.phase = phase;
+    record.status = phase === 'finished' ? (record.status) : 'aborted';
+    writeRecord();
+    localEventQueue.fail(new Error('daemon shutting down'));
+    localActionQueue.fail(new Error('daemon shutting down'));
+    await ipcServer.close().catch(() => undefined);
+    process.exit(exitCode);
+  }
+
+  process.once('SIGTERM', () => { void shutdown(1, 'aborted'); });
+  process.once('SIGINT',  () => { void shutdown(1, 'aborted'); });
+
+  // ---------------------------------------------------------------------------
+  // Host path
+  // ---------------------------------------------------------------------------
+  if (role === 'host') {
+    const host_transport = await createFriendlyBattleSpikeHost({
+      host,
+      port,
+      sessionCode,
+      hostPlayerName: playerName,
+      generation,
+    });
+
+    try {
+      // Handshake
+      record.phase = 'waiting_for_guest';
+      record.status = 'waiting_for_guest';
+      writeRecord();
+
+      const joined = await host_transport.waitForGuestJoin(timeoutMs);
+      record.opponent = { playerName: joined.guestPlayerName };
+      record.phase = 'handshake';
+      record.status = 'ongoing';
+      writeRecord();
+
+      // Load host profile & build teams
+      const hostProfile = loadFriendlyBattleCurrentProfile(generation);
+      const hostSnapshot = buildFriendlyBattlePartySnapshot(hostProfile);
+      ownSnapshot = hostSnapshot;
+      const hostTeam = createBattleTeamFromFriendlyBattleSnapshot(hostSnapshot);
+      const guestTeam = createBattleTeamFromFriendlyBattleSnapshot(joined.guestSnapshot);
+
+      const battleId = randomUUID();
+      const { runtime: rt, events: initEvents } = createFriendlyBattleBattleRuntime({
+        battleId,
+        hostTeam,
+        guestTeam,
+      });
+      runtime = rt;
+
+      // Ready up
+      host_transport.markHostReady();
+      await host_transport.waitUntilCanStart(timeoutMs);
+      record.phase = 'ready';
+      writeRecord();
+
+      await host_transport.startBattle(battleId);
+      record.phase = 'battle';
+      record.status = 'select_action';
+      writeRecord();
+
+      // Send initial events to guest over TCP
+      host_transport.sendBattleEvents(initEvents);
+
+      // Push init events to local queue
+      for (const event of initEvents) {
+        localEventQueue.push(event);
+      }
+
+      // ---------------------------------------------------------------------------
+      // Host turn loop
+      // ---------------------------------------------------------------------------
+      while (runtime.phase !== 'completed') {
+        // Wait for both host action (from UNIX socket) and guest choice (from TCP)
+        const [hostEnvelope, guestEnvelope] = await Promise.all([
+          localActionQueue.shift(timeoutMs, 'host action'),
+          host_transport.waitForGuestChoice(timeoutMs),
+        ]);
+
+        // submitFriendlyBattleChoice requires two calls; first returns [], second returns events
+        submitFriendlyBattleChoice(runtime, hostEnvelope);
+        const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
+
+        // Push events to local queue and send to guest
+        for (const event of resolvedEvents) {
+          localEventQueue.push(event);
+        }
+        host_transport.sendBattleEvents(resolvedEvents);
+
+        // Check if battle is over
+        const finished = resolvedEvents.find((e) => e.type === 'battle_finished');
+        if (finished) {
+          record.phase = 'finished';
+          record.status = eventStatus(finished, role);
+          writeRecord();
+          break;
+        }
+      }
+
+      // If runtime completed but we didn't catch battle_finished (shouldn't happen)
+      if (runtime.phase === 'completed' && record.phase !== 'finished') {
+        record.phase = 'finished';
+        writeRecord();
+      }
+
+      await host_transport.close().catch(() => undefined);
+      await shutdown(0, 'finished');
+    } catch (err) {
+      process.stderr.write(`daemon host error: ${(err as Error).message}\n`);
+      await host_transport.close().catch(() => undefined);
+      await shutdown(1, 'aborted');
+    }
+    return;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Guest path
+  // ---------------------------------------------------------------------------
+  const guestProfile = loadFriendlyBattleCurrentProfile(generation);
+  const guestSnapshot = buildFriendlyBattlePartySnapshot(guestProfile);
+  ownSnapshot = guestSnapshot;
+
+  const guest_transport = await connectFriendlyBattleSpikeGuest({
+    host,
+    port,
+    sessionCode,
+    guestPlayerName: playerName,
+    generation,
+    guestSnapshot,
+    timeoutMs,
+  });
+
+  try {
+    await guest_transport.markReady();
+    record.phase = 'ready';
+    record.status = 'connecting';
+    writeRecord();
+
+    const started = await guest_transport.waitForStarted(timeoutMs);
+    record.phase = 'battle';
+    record.status = 'select_action';
+    writeRecord();
+
+    // Synthesize an initial choices_requested event from own snapshot so the
+    // guest has something to display before the first real TCP event arrives.
+    const initialChoicesEvent: FriendlyBattleBattleEvent = {
+      type: 'choices_requested',
+      turn: 1,
+      waitingFor: ['host', 'guest'],
+      phase: 'waiting_for_choices',
+    };
+    localEventQueue.push(initialChoicesEvent);
+
+    // We don't actually need the battleId from started for anything, but keep
+    // the variable to silence unused-import TS noise
+    void started;
+
+    // ---------------------------------------------------------------------------
+    // Guest turn loop
+    // ---------------------------------------------------------------------------
+    let battleFinished = false;
+    while (!battleFinished) {
+      // Wait for the local player to submit an action via UNIX socket
+      const myAction = await localActionQueue.shift(timeoutMs, 'guest action');
+
+      // Forward to host over TCP using the parsed choice from the envelope
+      await guest_transport.submitChoice(formatFriendlyBattleChoice(myAction.choice));
+
+      // Pump events from TCP until we see choices_requested or battle_finished
+      let turnDone = false;
+      while (!turnDone) {
+        const event = await guest_transport.waitForBattleEvent(timeoutMs);
+        localEventQueue.push(event);
+        if (event.type === 'battle_finished') {
+          battleFinished = true;
+          turnDone = true;
+          record.phase = 'finished';
+          record.status = event.winner === 'guest' ? 'victory' : 'defeat';
+          writeRecord();
+        } else if (event.type === 'choices_requested') {
+          turnDone = true;
+        }
+        // turn_resolved: keep pumping (battle_finished or choices_requested will follow)
+      }
+    }
+
+    await guest_transport.close().catch(() => undefined);
+    await shutdown(0, 'finished');
+  } catch (err) {
+    process.stderr.write(`daemon guest error: ${(err as Error).message}\n`);
+    await guest_transport.close().catch(() => undefined);
+    await shutdown(1, 'aborted');
+  }
+}
+
+// Re-export for test: parse the options JSON and run
+export async function startDaemon(role: FriendlyBattleRole, options: DaemonOptions): Promise<void> {
+  return runDaemon(role, options);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point (for `tsx daemon.ts --role host|guest --options-json <b64>`)
+// ---------------------------------------------------------------------------
+
+function parseCliOptions(argv: string[]): { role: FriendlyBattleRole; options: DaemonOptions } {
+  let role: FriendlyBattleRole | undefined;
+  let optionsJson: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--role' && argv[i + 1]) {
+      const r = argv[++i];
+      if (r !== 'host' && r !== 'guest') {
+        process.stderr.write(`daemon: --role must be 'host' or 'guest', got ${JSON.stringify(r)}\n`);
+        process.exit(1);
+      }
+      role = r as FriendlyBattleRole;
+    } else if (argv[i] === '--options-json' && argv[i + 1]) {
+      optionsJson = argv[++i];
+    }
+  }
+
+  if (!role) {
+    process.stderr.write('daemon: missing --role\n');
+    process.exit(1);
+  }
+  if (!optionsJson) {
+    process.stderr.write('daemon: missing --options-json\n');
+    process.exit(1);
+  }
+
+  let options: DaemonOptions;
+  try {
+    const decoded = Buffer.from(optionsJson, 'base64').toString('utf8');
+    options = JSON.parse(decoded) as DaemonOptions;
+  } catch (err) {
+    process.stderr.write(`daemon: failed to decode --options-json: ${(err as Error).message}\n`);
+    process.exit(1);
+  }
+
+  return { role, options };
+}
+
+const isEntryScript = import.meta.url === `file://${process.argv[1]}`;
+if (isEntryScript) {
+  const { role, options } = parseCliOptions(process.argv.slice(2));
+  runDaemon(role, options).catch((err: unknown) => {
+    process.stderr.write(`daemon fatal: ${(err as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -359,7 +359,17 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
         if (queueClosedEnvelope !== null) {
           return { op: 'event', envelope: queueClosedEnvelope };
         }
-        const event = await localEventQueue.shift(req.timeoutMs, 'wait_next_event');
+        let event: FriendlyBattleBattleEvent;
+        try {
+          event = await localEventQueue.shift(req.timeoutMs, 'wait_next_event');
+        } catch (err) {
+          // If shutdown armed the sentinel while we were blocked on shift(),
+          // fall through to the finished envelope. Otherwise propagate.
+          if (queueClosedEnvelope !== null) {
+            return { op: 'event', envelope: queueClosedEnvelope };
+          }
+          throw err;
+        }
         const fields = eventToEnvelopeFields(event, role, runtime, ownSnapshot);
         // Update record status based on the event
         record.status = eventStatus(event, role);
@@ -404,14 +414,17 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
       // On error/abort, also fail the event queue so callers get an error.
       localEventQueue.fail(new Error('daemon shutting down'));
     } else {
-      // On clean finish: wait for the event queue to drain (all events consumed
-      // by IPC clients) before closing, with a 10s safety timeout.
+      // On clean finish: drain any already-buffered events first so legitimate
+      // wait_next_event callers can consume them, with a 10s safety timeout.
       const drainDeadline = Date.now() + 10_000;
       while (localEventQueue.size > 0 && Date.now() < drainDeadline) {
         await new Promise<void>((resolve) => setTimeout(resolve, 20));
       }
-      // Arm the sentinel so late wait_next_event callers get the finished
-      // envelope immediately instead of hanging until their own timeout fires.
+      // Arm the sentinel AFTER drain so new wait_next_event callers get the
+      // finished envelope immediately instead of blocking on the now-empty
+      // queue. Any waiter that was blocked on shift() during drain gets
+      // unblocked by the subsequent localEventQueue.fail(); the IPC handler
+      // catches that rejection and returns the sentinel.
       queueClosedEnvelope = formatFriendlyBattleTurnJson({
         record,
         questionContext: record.status === 'victory' ? 'You won!' : 'You lost!',
@@ -420,6 +433,9 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
         animationFrames: [],
         currentFrameIndex: 0,
       });
+      // Unblock any shift() that's already in flight so it can fall through
+      // to the sentinel check in the IPC handler's catch branch.
+      localEventQueue.fail(new Error('daemon finished cleanly'));
     }
     await ipcServer.close().catch(() => undefined);
     process.exit(exitCode);

--- a/src/friendly-battle/session-store.ts
+++ b/src/friendly-battle/session-store.ts
@@ -32,6 +32,8 @@ export interface FriendlyBattleSessionRecord {
   transport: { host: string; port: number };
   opponent: { playerName: string } | null;
   pid: number;
+  daemonPid?: number;
+  socketPath?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -51,6 +53,8 @@ function isValidRecord(value: unknown): value is FriendlyBattleSessionRecord {
   if (typeof r.generation !== 'string' || !SAFE_SEGMENT.test(r.generation)) return false;
   if (r.role !== 'host' && r.role !== 'guest') return false;
   if (typeof r.pid !== 'number' || !Number.isInteger(r.pid) || r.pid <= 0) return false;
+  if (typeof r.daemonPid !== 'number' || !Number.isInteger(r.daemonPid) || r.daemonPid <= 0) return false;
+  if (typeof r.socketPath !== 'string' || r.socketPath.length === 0) return false;
   if (typeof r.phase !== 'string') return false;
   if (typeof r.status !== 'string') return false;
   if (typeof r.sessionCode !== 'string') return false;

--- a/src/friendly-battle/session-store.ts
+++ b/src/friendly-battle/session-store.ts
@@ -124,7 +124,7 @@ export function reapStaleFriendlyBattleSessions(generation: string): string[] {
   return reaped;
 }
 
-function isPidAlive(pid: number): boolean {
+export function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/src/friendly-battle/session-store.ts
+++ b/src/friendly-battle/session-store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 
 export type FriendlyBattlePhase =
   | 'waiting_for_guest'
@@ -32,8 +32,8 @@ export interface FriendlyBattleSessionRecord {
   transport: { host: string; port: number };
   opponent: { playerName: string } | null;
   pid: number;
-  daemonPid?: number;
-  socketPath?: string;
+  daemonPid: number;
+  socketPath: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -55,6 +55,17 @@ function isValidRecord(value: unknown): value is FriendlyBattleSessionRecord {
   if (typeof r.pid !== 'number' || !Number.isInteger(r.pid) || r.pid <= 0) return false;
   if (typeof r.daemonPid !== 'number' || !Number.isInteger(r.daemonPid) || r.daemonPid <= 0) return false;
   if (typeof r.socketPath !== 'string' || r.socketPath.length === 0) return false;
+  // Security: socketPath must be contained within the generation's sessions dir
+  // and its basename must be <sessionId>.sock to prevent path traversal.
+  try {
+    const expectedDir = friendlyBattleSessionsDir(r.generation as string);
+    const resolvedSocket = resolve(r.socketPath as string);
+    const resolvedDir = resolve(expectedDir);
+    if (!resolvedSocket.startsWith(resolvedDir + sep)) return false;
+    if (!resolvedSocket.endsWith(`${sep}${r.sessionId as string}.sock`)) return false;
+  } catch {
+    return false;
+  }
   if (typeof r.phase !== 'string') return false;
   if (typeof r.status !== 'string') return false;
   if (typeof r.sessionCode !== 'string') return false;
@@ -80,7 +91,7 @@ export function friendlyBattleSessionRecordPath(sessionId: string, generation: s
 
 export function writeFriendlyBattleSessionRecord(record: FriendlyBattleSessionRecord): void {
   const path = friendlyBattleSessionRecordPath(record.sessionId, record.generation);
-  mkdirSync(dirname(path), { recursive: true });
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const tmpPath = `${path}.tmp`;
   writeFileSync(tmpPath, JSON.stringify(record, null, 2), 'utf8');
   renameSync(tmpPath, path);
@@ -116,7 +127,8 @@ export function reapFriendlyBattleSessionRecord(sessionId: string, generation: s
 export function reapStaleFriendlyBattleSessions(generation: string): string[] {
   const reaped: string[] = [];
   for (const record of listFriendlyBattleSessionRecords(generation)) {
-    if (!isPidAlive(record.pid)) {
+    const pidToCheck = record.daemonPid ?? record.pid;
+    if (!isPidAlive(pidToCheck)) {
       reapFriendlyBattleSessionRecord(record.sessionId, generation);
       reaped.push(record.sessionId);
     }

--- a/test/friendly-battle-daemon-ipc.test.ts
+++ b/test/friendly-battle-daemon-ipc.test.ts
@@ -1,0 +1,107 @@
+import { after, afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import net from 'node:net';
+import {
+  createDaemonIpcServer,
+  sendDaemonIpcRequest,
+  type DaemonIpcServer,
+} from '../src/friendly-battle/daemon-ipc.js';
+import type { DaemonRequest, DaemonResponse } from '../src/friendly-battle/daemon-protocol.js';
+
+const tmpDirs: string[] = [];
+const servers: DaemonIpcServer[] = [];
+
+function tempSocketPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tkm-fb-ipc-'));
+  tmpDirs.push(dir);
+  return join(dir, 'daemon.sock');
+}
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    const server = servers.pop();
+    if (server) await server.close().catch(() => undefined);
+  }
+});
+
+after(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('friendly-battle daemon IPC', () => {
+  it('round-trips a ping/pong via UNIX socket', async () => {
+    const socketPath = tempSocketPath();
+    const server = await createDaemonIpcServer(socketPath, (req) => {
+      assert.equal(req.op, 'ping');
+      return { op: 'pong', pid: 12345 };
+    });
+    servers.push(server);
+
+    const response = await sendDaemonIpcRequest(socketPath, { op: 'ping' }, 1000);
+    assert.deepEqual(response, { op: 'pong', pid: 12345 });
+  });
+
+  it('handles async handler errors as error responses', async () => {
+    const socketPath = tempSocketPath();
+    const server = await createDaemonIpcServer(socketPath, async () => {
+      throw new Error('simulated failure');
+    });
+    servers.push(server);
+
+    const response = await sendDaemonIpcRequest(socketPath, { op: 'ping' }, 1000);
+    assert.equal(response.op, 'error');
+    if (response.op === 'error') {
+      assert.equal(response.code, 'handler_error');
+      assert.match(response.message, /simulated failure/);
+    }
+  });
+
+  it('rejects the client with a timeout when the server is down', async () => {
+    const socketPath = tempSocketPath();
+    await assert.rejects(
+      () => sendDaemonIpcRequest(socketPath, { op: 'ping' }, 200),
+      /(timeout|ENOENT|ECONNREFUSED|connection closed)/,
+    );
+  });
+
+  it('rejects a bad request with op=error code=bad_request', async () => {
+    const socketPath = tempSocketPath();
+    const server = await createDaemonIpcServer(socketPath, () => {
+      throw new Error('handler should not run on bad request');
+    });
+    servers.push(server);
+
+    // Send garbage bytes directly via net (imported at top of file)
+    await new Promise<void>((resolve, reject) => {
+      const client = net.createConnection(socketPath, () => {
+        client.write('not json\n');
+      });
+      client.setEncoding('utf8');
+      let buffer = '';
+      client.on('data', (chunk: string) => {
+        buffer += chunk;
+        if (buffer.includes('\n')) {
+          const line = buffer.slice(0, buffer.indexOf('\n'));
+          const response = JSON.parse(line) as DaemonResponse;
+          try {
+            assert.equal(response.op, 'error');
+            if (response.op === 'error') {
+              assert.equal(response.code, 'bad_request');
+            }
+            resolve();
+          } catch (err) {
+            reject(err as Error);
+          } finally {
+            client.destroy();
+          }
+        }
+      });
+      client.on('error', reject);
+    });
+  });
+});

--- a/test/friendly-battle-daemon-ipc.test.ts
+++ b/test/friendly-battle-daemon-ipc.test.ts
@@ -69,6 +69,37 @@ describe('friendly-battle daemon IPC', () => {
     );
   });
 
+  it('rejects a client that writes 128 KiB without a newline', async () => {
+    const socketPath = tempSocketPath();
+    const server = await createDaemonIpcServer(socketPath, () => {
+      throw new Error('handler should not run on oversized request');
+    });
+    servers.push(server);
+
+    // Send 128 KiB of data with no newline — the server should destroy the socket.
+    const bigBuf = Buffer.alloc(128 * 1024, 'x');
+    await new Promise<void>((resolve, reject) => {
+      const client = net.createConnection(socketPath, () => {
+        client.write(bigBuf);
+      });
+      client.on('close', () => resolve());
+      client.on('error', (err: NodeJS.ErrnoException) => {
+        // ECONNRESET or EPIPE is expected when the server destroys the socket
+        if (err.code === 'ECONNRESET' || err.code === 'EPIPE') {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+      // Safety timeout
+      const timer = setTimeout(() => {
+        client.destroy();
+        reject(new Error('server did not close the connection after 2s'));
+      }, 2000);
+      if (timer.unref) timer.unref();
+    });
+  });
+
   it('rejects a bad request with op=error code=bad_request', async () => {
     const socketPath = tempSocketPath();
     const server = await createDaemonIpcServer(socketPath, () => {

--- a/test/friendly-battle-daemon-protocol.test.ts
+++ b/test/friendly-battle-daemon-protocol.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  decodeDaemonMessage,
+  encodeDaemonMessage,
+  type DaemonRequest,
+  type DaemonResponse,
+} from '../src/friendly-battle/daemon-protocol.js';
+
+describe('friendly-battle daemon protocol', () => {
+  it('encodes and decodes each DaemonRequest variant', () => {
+    const variants: DaemonRequest[] = [
+      { op: 'wait_next_event', timeoutMs: 1000 },
+      { op: 'submit_action', action: { kind: 'move', index: 2 } },
+      { op: 'status' },
+      { op: 'ping' },
+    ];
+
+    for (const variant of variants) {
+      const encoded = encodeDaemonMessage(variant);
+      assert.ok(encoded.endsWith('\n'), 'encoded message must end with newline');
+      const decoded = decodeDaemonMessage<DaemonRequest>(encoded);
+      assert.deepEqual(decoded, variant);
+    }
+  });
+
+  it('encodes and decodes each DaemonResponse variant', () => {
+    const stubEnvelope = {
+      sessionId: 'fb-001',
+      role: 'host' as const,
+      phase: 'battle',
+      status: 'select_action',
+      questionContext: 'ctx',
+      moveOptions: [],
+      partyOptions: [],
+      animationFrames: [],
+      currentFrameIndex: 0,
+    };
+    const variants: DaemonResponse[] = [
+      { op: 'event', envelope: stubEnvelope },
+      { op: 'ack', envelope: stubEnvelope },
+      { op: 'status', envelope: stubEnvelope },
+      { op: 'pong', pid: 12345 },
+      { op: 'error', code: 'not_ready', message: 'daemon not ready' },
+    ];
+
+    for (const variant of variants) {
+      const decoded = decodeDaemonMessage<DaemonResponse>(encodeDaemonMessage(variant));
+      assert.deepEqual(decoded, variant);
+    }
+  });
+
+  it('rejects empty or whitespace-only lines', () => {
+    assert.throws(() => decodeDaemonMessage(''), /empty line/);
+    assert.throws(() => decodeDaemonMessage('   \n'), /empty line/);
+  });
+});

--- a/test/friendly-battle-daemon-turn-loop.test.ts
+++ b/test/friendly-battle-daemon-turn-loop.test.ts
@@ -59,13 +59,14 @@ function spawnDaemon(
   return new Promise((resolve, reject) => {
     const child = spawn(
       process.execPath,
-      ['--import', 'tsx', DAEMON_ENTRY, '--role', role, '--options-json', encodeOptionsJson(options)],
+      ['--import', 'tsx', DAEMON_ENTRY, '--role', role],
       {
         env: {
           ...process.env,
           CLAUDE_CONFIG_DIR: claudeDir,
           TSX_DISABLE_CACHE: '1',
           TOKENMON_TEST: '1',
+          TKM_FB_OPTIONS_B64: encodeOptionsJson(options),
         },
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,

--- a/test/friendly-battle-daemon-turn-loop.test.ts
+++ b/test/friendly-battle-daemon-turn-loop.test.ts
@@ -1,0 +1,353 @@
+// test/friendly-battle-daemon-turn-loop.test.ts
+//
+// End-to-end integration test: spawn host + guest daemons with real TCP
+// transport and real UNIX socket IPC. Drives a full move-only turn until
+// battle_finished, then asserts both daemons exit cleanly.
+
+import { after, afterEach, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { sendDaemonIpcRequest } from '../src/friendly-battle/daemon-ipc.js';
+import type { DaemonResponse } from '../src/friendly-battle/daemon-protocol.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const DAEMON_ENTRY = resolve(REPO_ROOT, 'src/friendly-battle/daemon.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeClaudeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tkm-fb-turn-loop-'));
+  const genDir = join(dir, 'tokenmon', 'gen4');
+  mkdirSync(genDir, { recursive: true });
+  writeFileSync(
+    join(genDir, 'config.json'),
+    JSON.stringify({ party: ['387'], starter_chosen: true }),
+  );
+  writeFileSync(
+    join(genDir, 'state.json'),
+    JSON.stringify({
+      pokemon: {
+        '387': { id: 387, xp: 100, level: 16, friendship: 0, ev: 0, moves: [33, 45] },
+      },
+    }),
+  );
+  return dir;
+}
+
+function encodeOptionsJson(options: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(options)).toString('base64');
+}
+
+interface DaemonInfo {
+  child: ChildProcess;
+  sessionId: string;
+  socketPath: string;
+  port?: number;   // only for host
+}
+
+function spawnDaemon(
+  role: 'host' | 'guest',
+  options: Record<string, unknown>,
+  claudeDir: string,
+): Promise<DaemonInfo> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', DAEMON_ENTRY, '--role', role, '--options-json', encodeOptionsJson(options)],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: claudeDir,
+          TSX_DISABLE_CACHE: '1',
+          TOKENMON_TEST: '1',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      },
+    );
+
+    let stdoutBuf = '';
+    let settled = false;
+
+    child.stdout!.setEncoding('utf8');
+    child.stdout!.on('data', (chunk: string) => {
+      stdoutBuf += chunk;
+      // DAEMON_READY <sessionId> <socketPath> [port]
+      const newline = stdoutBuf.indexOf('\n');
+      if (newline < 0) return;
+      const line = stdoutBuf.slice(0, newline).trim();
+      if (!line.startsWith('DAEMON_READY ')) return;
+      const parts = line.split(' ');
+      const sessionId = parts[1];
+      const socketPath = parts[2];
+      const port = parts[3] ? Number.parseInt(parts[3], 10) : undefined;
+      if (!sessionId || !socketPath) {
+        reject(new Error(`Malformed DAEMON_READY line: ${JSON.stringify(line)}`));
+        return;
+      }
+      if (!settled) {
+        settled = true;
+        resolve({ child, sessionId, socketPath, port });
+      }
+    });
+
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (_chunk: string) => {
+      // stderr is intentionally suppressed; uncomment for debugging:
+      // process.stderr.write(`[${role} daemon] ${_chunk}`);
+    });
+
+    child.once('error', (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+
+    // If child exits before DAEMON_READY, reject
+    child.once('close', (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`${role} daemon exited with code ${code} before DAEMON_READY`));
+      }
+    });
+
+    // Timeout guard
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill('SIGTERM');
+        reject(new Error(`${role} daemon did not emit DAEMON_READY within 10s`));
+      }
+    }, 10_000);
+    // Don't let the timer prevent process exit if test ends early
+    if (timer.unref) timer.unref();
+  });
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    if (child.exitCode !== null) {
+      resolve(child.exitCode);
+      return;
+    }
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`Process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    if (timer.unref) timer.unref();
+    child.once('close', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Keep track of spawned children for afterEach cleanup
+// ---------------------------------------------------------------------------
+const liveChildren: ChildProcess[] = [];
+
+afterEach(() => {
+  for (const child of liveChildren.splice(0)) {
+    if (child.exitCode === null && !child.killed) {
+      child.kill('SIGTERM');
+    }
+  }
+});
+
+after(() => {
+  // Final cleanup pass — belt and suspenders
+  for (const child of liveChildren) {
+    if (child.exitCode === null && !child.killed) {
+      child.kill('SIGTERM');
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('friendly-battle daemon turn loop (end-to-end)', () => {
+  it('both daemons emit DAEMON_READY and complete a full battle turn loop', async () => {
+    // One shared CLAUDE_CONFIG_DIR so both daemons load the same pokemon profile
+    const claudeDir = makeClaudeConfigDir();
+    try {
+      const sessionId = `test-${Date.now()}`;
+      const sessionCode = 'turnloop-01';
+
+      // Spawn host with port 0 (OS picks)
+      const hostOptions = {
+        sessionId: `${sessionId}-host`,
+        sessionCode,
+        host: '127.0.0.1',
+        port: 0,
+        generation: 'gen4',
+        playerName: 'HostPlayer',
+        timeoutMs: 15_000,
+      };
+
+      const hostInfo = await spawnDaemon('host', hostOptions, claudeDir);
+      liveChildren.push(hostInfo.child);
+
+      // Host must have emitted a port
+      assert.ok(hostInfo.port && hostInfo.port > 0, `host port must be > 0, got ${hostInfo.port}`);
+
+      // 1. Both daemons passed DAEMON_READY
+      assert.ok(hostInfo.sessionId, 'host sessionId present');
+      assert.ok(hostInfo.socketPath, 'host socketPath present');
+
+      // Spawn guest connecting to host's actual port
+      const guestOptions = {
+        sessionId: `${sessionId}-guest`,
+        sessionCode,
+        host: '127.0.0.1',
+        port: hostInfo.port,
+        generation: 'gen4',
+        playerName: 'GuestPlayer',
+        timeoutMs: 15_000,
+      };
+
+      const guestInfo = await spawnDaemon('guest', guestOptions, claudeDir);
+      liveChildren.push(guestInfo.child);
+
+      assert.ok(guestInfo.sessionId, 'guest sessionId present');
+      assert.ok(guestInfo.socketPath, 'guest socketPath present');
+
+      // 2. Both sides should serve wait_next_event with status=select_action
+      const [hostFirstEvent, guestFirstEvent] = await Promise.all([
+        sendDaemonIpcRequest(
+          hostInfo.socketPath,
+          { op: 'wait_next_event', timeoutMs: 5_000 },
+          6_000,
+        ),
+        sendDaemonIpcRequest(
+          guestInfo.socketPath,
+          { op: 'wait_next_event', timeoutMs: 5_000 },
+          6_000,
+        ),
+      ]);
+
+      assert.equal(hostFirstEvent.op, 'event', `host first event op should be 'event', got ${hostFirstEvent.op}`);
+      assert.equal(guestFirstEvent.op, 'event', `guest first event op should be 'event', got ${guestFirstEvent.op}`);
+
+      // The first event the host gets is battle_initialized, then choices_requested.
+      // Wait for the choices_requested one (status=select_action):
+      let hostEventEnv = hostFirstEvent.op === 'event' ? hostFirstEvent.envelope : undefined;
+      let guestEventEnv = guestFirstEvent.op === 'event' ? guestFirstEvent.envelope : undefined;
+
+      // If the first event is battle_initialized, drain one more to get choices_requested
+      if (hostEventEnv && hostEventEnv.status !== 'select_action') {
+        const second = await sendDaemonIpcRequest(
+          hostInfo.socketPath,
+          { op: 'wait_next_event', timeoutMs: 5_000 },
+          6_000,
+        );
+        assert.equal(second.op, 'event');
+        hostEventEnv = second.op === 'event' ? second.envelope : hostEventEnv;
+      }
+
+      if (guestEventEnv && guestEventEnv.status !== 'select_action') {
+        const second = await sendDaemonIpcRequest(
+          guestInfo.socketPath,
+          { op: 'wait_next_event', timeoutMs: 5_000 },
+          6_000,
+        );
+        assert.equal(second.op, 'event');
+        guestEventEnv = second.op === 'event' ? second.envelope : guestEventEnv;
+      }
+
+      // 3. Both sides should now have status=select_action and moveOptions
+      assert.equal(hostEventEnv?.status, 'select_action', `host status: ${JSON.stringify(hostEventEnv?.status)}`);
+      assert.equal(guestEventEnv?.status, 'select_action', `guest status: ${JSON.stringify(guestEventEnv?.status)}`);
+      assert.ok(Array.isArray(hostEventEnv?.moveOptions) && (hostEventEnv?.moveOptions.length ?? 0) > 0, 'host has moveOptions');
+      assert.ok(Array.isArray(guestEventEnv?.moveOptions) && (guestEventEnv?.moveOptions.length ?? 0) > 0, 'guest has moveOptions');
+
+      // 4. Submit a move from each side
+      const [hostAck, guestAck] = await Promise.all([
+        sendDaemonIpcRequest(
+          hostInfo.socketPath,
+          { op: 'submit_action', action: { kind: 'move', index: 0 } },
+          5_000,
+        ),
+        sendDaemonIpcRequest(
+          guestInfo.socketPath,
+          { op: 'submit_action', action: { kind: 'move', index: 0 } },
+          5_000,
+        ),
+      ]);
+
+      assert.equal(hostAck.op, 'ack', `host submit_action should ack, got ${hostAck.op}`);
+      assert.equal(guestAck.op, 'ack', `guest submit_action should ack, got ${guestAck.op}`);
+
+      // 5. Drain events until battle_finished on both sides
+      async function drainUntilDone(socketPath: string, maxEvents = 20): Promise<DaemonResponse> {
+        for (let i = 0; i < maxEvents; i++) {
+          const ev = await sendDaemonIpcRequest(
+            socketPath,
+            { op: 'wait_next_event', timeoutMs: 10_000 },
+            11_000,
+          );
+          if (ev.op !== 'event') return ev;
+          const status = ev.envelope.status;
+          if (status === 'victory' || status === 'defeat') {
+            return ev;
+          }
+          if (status === 'select_action') {
+            // Another turn needed — submit move again
+            await sendDaemonIpcRequest(
+              socketPath,
+              { op: 'submit_action', action: { kind: 'move', index: 0 } },
+              5_000,
+            );
+          }
+        }
+        throw new Error(`Did not reach battle_finished within ${maxEvents} events`);
+      }
+
+      const [hostFinalEv, guestFinalEv] = await Promise.all([
+        drainUntilDone(hostInfo.socketPath),
+        drainUntilDone(guestInfo.socketPath),
+      ]);
+
+      // 6. Both sides see a terminal status
+      assert.equal(hostFinalEv.op, 'event', `host final op: ${hostFinalEv.op}`);
+      assert.equal(guestFinalEv.op, 'event', `guest final op: ${guestFinalEv.op}`);
+
+      const hostFinalStatus = hostFinalEv.op === 'event' ? hostFinalEv.envelope.status : undefined;
+      const guestFinalStatus = guestFinalEv.op === 'event' ? guestFinalEv.envelope.status : undefined;
+
+      assert.ok(
+        hostFinalStatus === 'victory' || hostFinalStatus === 'defeat',
+        `host final status should be victory or defeat, got ${hostFinalStatus}`,
+      );
+      assert.ok(
+        guestFinalStatus === 'victory' || guestFinalStatus === 'defeat',
+        `guest final status should be victory or defeat, got ${guestFinalStatus}`,
+      );
+
+      // Winners should be complementary (one wins, one loses)
+      const hostWon = hostFinalStatus === 'victory';
+      const guestWon = guestFinalStatus === 'victory';
+      assert.ok(hostWon !== guestWon, 'exactly one side should win');
+
+      // 7. Both daemons should exit within 5 seconds after battle_finished
+      const [hostExit, guestExit] = await Promise.all([
+        waitForExit(hostInfo.child, 5_000),
+        waitForExit(guestInfo.child, 5_000),
+      ]);
+
+      assert.equal(hostExit, 0, `host daemon should exit 0, got ${hostExit}`);
+      assert.equal(guestExit, 0, `guest daemon should exit 0, got ${guestExit}`);
+    } finally {
+      rmSync(claudeDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/friendly-battle-session-store.test.ts
+++ b/test/friendly-battle-session-store.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   friendlyBattleSessionRecordPath,
+  friendlyBattleSessionsDir,
   readFriendlyBattleSessionRecord,
   writeFriendlyBattleSessionRecord,
   listFriendlyBattleSessionRecords,
@@ -25,11 +26,18 @@ function withTempClaudeDir(fn: (dir: string) => void): void {
   }
 }
 
+/** Compute the canonical socket path for a session (must be called inside withTempClaudeDir). */
+function makeSocketPath(sessionId: string, generation = 'gen4'): string {
+  return join(friendlyBattleSessionsDir(generation), `${sessionId}.sock`);
+}
+
 function makeRecord(overrides: Partial<FriendlyBattleSessionRecord> = {}): FriendlyBattleSessionRecord {
+  const sessionId = overrides.sessionId ?? 'fb-session-001';
+  const generation = overrides.generation ?? 'gen4';
   return {
-    sessionId: 'fb-session-001',
+    sessionId,
     role: 'host',
-    generation: 'gen4',
+    generation,
     sessionCode: 'alpha-123',
     phase: 'waiting_for_guest',
     status: 'waiting_for_guest',
@@ -37,7 +45,7 @@ function makeRecord(overrides: Partial<FriendlyBattleSessionRecord> = {}): Frien
     opponent: null,
     pid: process.pid,
     daemonPid: process.pid,
-    socketPath: '/tmp/fb-test.sock',
+    socketPath: makeSocketPath(sessionId, generation),
     createdAt: '2026-04-14T00:00:00.000Z',
     updatedAt: '2026-04-14T00:00:00.000Z',
     ...overrides,
@@ -71,10 +79,10 @@ describe('friendly-battle session store', () => {
     });
   });
 
-  it('reaps records whose pids are no longer running', () => {
+  it('reaps records whose daemonPids are no longer running', () => {
     withTempClaudeDir(() => {
-      const liveRecord = makeRecord({ sessionId: 'alive', pid: process.pid });
-      const deadRecord = makeRecord({ sessionId: 'dead', pid: 1 << 22 });
+      const liveRecord = makeRecord({ sessionId: 'alive', pid: process.pid, daemonPid: process.pid });
+      const deadRecord = makeRecord({ sessionId: 'dead', pid: process.pid, daemonPid: 1 << 22 });
       writeFriendlyBattleSessionRecord(liveRecord);
       writeFriendlyBattleSessionRecord(deadRecord);
 
@@ -130,6 +138,42 @@ describe('friendly-battle session store', () => {
       writeFileSync(path, JSON.stringify(withoutDaemonPid), 'utf8');
       const loaded = readFriendlyBattleSessionRecord('no-daemon-pid', 'gen4');
       assert.equal(loaded, null);
+    });
+  });
+
+  it('reap uses daemonPid: does not reap when daemonPid is alive even if parent pid is dead', () => {
+    withTempClaudeDir(() => {
+      // pid = dead CLI parent (1 << 22), daemonPid = live process — should NOT be reaped
+      const liveRecord = makeRecord({ sessionId: 'live-daemon', pid: 1 << 22, daemonPid: process.pid });
+      writeFriendlyBattleSessionRecord(liveRecord);
+
+      const reaped = reapStaleFriendlyBattleSessions('gen4');
+      assert.deepEqual(reaped, [], 'live daemonPid should not be reaped');
+
+      const remaining = listFriendlyBattleSessionRecords('gen4').map((r) => r.sessionId);
+      assert.deepEqual(remaining, ['live-daemon'], 'record should still exist');
+
+      // Now write a second record with a dead daemonPid — it SHOULD be reaped
+      const deadRecord = makeRecord({ sessionId: 'dead-daemon', pid: process.pid, daemonPid: 1 << 22 });
+      writeFriendlyBattleSessionRecord(deadRecord);
+
+      const reaped2 = reapStaleFriendlyBattleSessions('gen4');
+      assert.deepEqual(reaped2, ['dead-daemon'], 'dead daemonPid should be reaped');
+      const remaining2 = listFriendlyBattleSessionRecords('gen4').map((r) => r.sessionId);
+      assert.deepEqual(remaining2, ['live-daemon'], 'only the dead-daemon record should be removed');
+    });
+  });
+
+  it('returns null when socketPath is outside the sessions directory (path traversal)', () => {
+    withTempClaudeDir(() => {
+      const valid = makeRecord({ sessionId: 'tampered' });
+      writeFriendlyBattleSessionRecord(valid);
+      const path = friendlyBattleSessionRecordPath('tampered', 'gen4');
+      // Overwrite with a tampered socketPath pointing outside the sessions dir
+      const tampered = { ...valid, socketPath: '/tmp/evil.sock' };
+      writeFileSync(path, JSON.stringify(tampered), 'utf8');
+      const loaded = readFriendlyBattleSessionRecord('tampered', 'gen4');
+      assert.equal(loaded, null, 'tampered socketPath should be rejected');
     });
   });
 });

--- a/test/friendly-battle-session-store.test.ts
+++ b/test/friendly-battle-session-store.test.ts
@@ -36,6 +36,8 @@ function makeRecord(overrides: Partial<FriendlyBattleSessionRecord> = {}): Frien
     transport: { host: '127.0.0.1', port: 52345 },
     opponent: null,
     pid: process.pid,
+    daemonPid: process.pid,
+    socketPath: '/tmp/fb-test.sock',
     createdAt: '2026-04-14T00:00:00.000Z',
     updatedAt: '2026-04-14T00:00:00.000Z',
     ...overrides,
@@ -114,6 +116,19 @@ describe('friendly-battle session store', () => {
       // Corrupt the file — overwrite with an object missing required keys.
       writeFileSync(path, JSON.stringify({ sessionId: 'corrupt', role: 'observer' }), 'utf8');
       const loaded = readFriendlyBattleSessionRecord('corrupt', 'gen4');
+      assert.equal(loaded, null);
+    });
+  });
+
+  it('returns null when daemonPid is missing from an on-disk record', () => {
+    withTempClaudeDir(() => {
+      const valid = makeRecord({ sessionId: 'no-daemon-pid' });
+      writeFriendlyBattleSessionRecord(valid);
+      const path = friendlyBattleSessionRecordPath('no-daemon-pid', 'gen4');
+      // Write a record with daemonPid removed (simulates a PR43 on-disk record).
+      const withoutDaemonPid = { ...valid, daemonPid: undefined as unknown as number };
+      writeFileSync(path, JSON.stringify(withoutDaemonPid), 'utf8');
+      const loaded = readFriendlyBattleSessionRecord('no-daemon-pid', 'gen4');
       assert.equal(loaded, null);
     });
   });

--- a/test/friendly-battle-skill-contract.test.ts
+++ b/test/friendly-battle-skill-contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SKILL_PATH = resolve(import.meta.dirname, '..', 'skills', 'friendly-battle', 'SKILL.md');
+const CLI_PATH = resolve(import.meta.dirname, '..', 'src', 'cli', 'friendly-battle-turn.ts');
+
+describe('friendly-battle SKILL.md contract', () => {
+  it('exists and has a valid description frontmatter', () => {
+    const content = readFileSync(SKILL_PATH, 'utf8');
+    assert.match(content, /^---\s*\ndescription:\s*".+?"\s*\n---/);
+  });
+
+  it('references only CLI subcommands that actually exist in friendly-battle-turn.ts', () => {
+    const skillContent = readFileSync(SKILL_PATH, 'utf8');
+    const cliContent = readFileSync(CLI_PATH, 'utf8');
+
+    // Collect every --<flag> mentioned inside a bash block referencing friendly-battle-turn.ts
+    const bashBlocks = [...skillContent.matchAll(/```bash\n([\s\S]*?)```/g)].map((m) => m[1]);
+    const flags = new Set<string>();
+    for (const block of bashBlocks) {
+      if (!block.includes('friendly-battle-turn.ts')) continue;
+      for (const match of block.matchAll(/\s(--[a-z][a-z0-9-]*)/g)) {
+        flags.add(match[1]);
+      }
+    }
+
+    // Extract the SUBCOMMAND_FLAGS set + CLI_FLAG_SCHEMA keys from the CLI source to know which flags are supported
+    const supported = new Set<string>();
+    for (const match of cliContent.matchAll(/'(--[a-z][a-z0-9-]*)'/g)) {
+      supported.add(match[1]);
+    }
+    for (const match of cliContent.matchAll(/'([a-z][a-z0-9-]*)':\s*\{\s*type:/g)) {
+      supported.add(`--${match[1]}`);
+    }
+
+    const missing = [...flags].filter((flag) => !supported.has(flag));
+    assert.deepEqual(missing, [], `SKILL.md references CLI flags not supported by friendly-battle-turn.ts: ${missing.join(', ')}`);
+  });
+
+  it('references only --action tokens that the CLI actually accepts', () => {
+    const content = readFileSync(SKILL_PATH, 'utf8');
+
+    // Any --action <token> used in bash blocks
+    const tokens = new Set<string>();
+    for (const match of content.matchAll(/--action\s+"?([a-z]+(?::[^\s"']+)?)"?/gi)) {
+      tokens.add(match[1]);
+    }
+
+    // PR44 supports only move:<N>. switch/surrender are deferred with explicit errors.
+    // Template placeholders like move:<N> or move:$N count as move family.
+    const accepted = (token: string): boolean => {
+      if (/^move:[\d<$]/.test(token) || token === 'move:') return true;
+      return false;
+    };
+
+    const bad = [...tokens].filter((token) => !accepted(token));
+    assert.deepEqual(bad, [], `SKILL.md uses --action tokens that PR44 does not support: ${bad.join(', ')}`);
+  });
+
+  it('mentions the gym-style AskUserQuestion non-negotiable rule', () => {
+    const content = readFileSync(SKILL_PATH, 'utf8');
+    assert.match(content, /AskUserQuestion/);
+    assert.match(content, /never\s+parse|chat\s+parsing|plain chat/i);
+  });
+});

--- a/test/friendly-battle-turn-driver.test.ts
+++ b/test/friendly-battle-turn-driver.test.ts
@@ -171,6 +171,8 @@ describe('friendly-battle-turn --init-host', () => {
 
 import {
   readFriendlyBattleSessionRecord,
+  writeFriendlyBattleSessionRecord,
+  listFriendlyBattleSessionRecords,
 } from '../src/friendly-battle/session-store.js';
 
 /** Poll fn() every intervalMs until it returns a truthy value or deadline passes. */
@@ -316,5 +318,526 @@ describe('friendly-battle-turn init handshake', () => {
       assert.match(guest.stdout, /"phase":\s*"aborted"/);
       assert.match(guest.stderr, /FAILED_STAGE:/);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers for per-action subcommand tests
+// ---------------------------------------------------------------------------
+
+import { randomUUID } from 'node:crypto';
+import { afterEach as afterEachFb } from 'node:test';
+
+const REPO_ROOT_FB = resolve(import.meta.dirname, '..');
+const DAEMON_ENTRY_FB = resolve(REPO_ROOT_FB, 'src/friendly-battle/daemon.ts');
+
+function encodeDaemonOptionsB64(options: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(options)).toString('base64');
+}
+
+interface SpawnedDaemonInfo {
+  child: import('node:child_process').ChildProcess;
+  sessionId: string;
+  socketPath: string;
+  port?: number;
+}
+
+function spawnFbDaemon(
+  role: 'host' | 'guest',
+  options: Record<string, unknown>,
+  claudeDir: string,
+): Promise<SpawnedDaemonInfo> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', DAEMON_ENTRY_FB, '--role', role, '--options-json', encodeDaemonOptionsB64(options)],
+      {
+        env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, TSX_DISABLE_CACHE: '1', TOKENMON_TEST: '1' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      },
+    );
+    let stdoutBuf = '';
+    let settled = false;
+    child.stdout!.setEncoding('utf8');
+    child.stdout!.on('data', (chunk: string) => {
+      stdoutBuf += chunk;
+      const nl = stdoutBuf.indexOf('\n');
+      if (nl < 0) return;
+      const line = stdoutBuf.slice(0, nl).trim();
+      if (!line.startsWith('DAEMON_READY ')) return;
+      const parts = line.split(' ');
+      const sessionId = parts[1];
+      const socketPath = parts[2];
+      const port = parts[3] ? Number.parseInt(parts[3], 10) : undefined;
+      if (!sessionId || !socketPath) {
+        rejectP(new Error(`Malformed DAEMON_READY line: ${JSON.stringify(line)}`));
+        return;
+      }
+      if (!settled) {
+        settled = true;
+        resolveP({ child, sessionId, socketPath, port });
+      }
+    });
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (_chunk: string) => { /* suppress */ });
+    child.once('error', (err) => { if (!settled) { settled = true; rejectP(err); } });
+    child.once('close', (code) => { if (!settled) { settled = true; rejectP(new Error(`${role} daemon exited ${code} before DAEMON_READY`)); } });
+    const timer = setTimeout(() => {
+      if (!settled) { settled = true; child.kill('SIGTERM'); rejectP(new Error(`${role} daemon timeout`)); }
+    }, 15_000);
+    if (timer.unref) timer.unref();
+  });
+}
+
+/** Read a session record under a specific CLAUDE_CONFIG_DIR without mutating process.env. */
+function readRecordInDirFb(claudeDir: string, sessionId: string, generation: string) {
+  const prev = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  try {
+    return readFriendlyBattleSessionRecord(sessionId, generation);
+  } finally {
+    if (prev === undefined) { delete process.env.CLAUDE_CONFIG_DIR; } else { process.env.CLAUDE_CONFIG_DIR = prev; }
+  }
+}
+
+/** Poll until the session record exists with a matching phase, or timeout. */
+async function waitForRecordPhase(
+  claudeDir: string,
+  sessionId: string,
+  generation: string,
+  phase: string,
+  timeoutMs: number,
+  intervalMs = 150,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const r = readRecordInDirFb(claudeDir, sessionId, generation);
+    if (r?.phase === phase) return r;
+    await new Promise<void>((r2) => setTimeout(r2, intervalMs));
+  }
+  throw new Error(`waitForRecordPhase: timed out waiting for phase=${phase} on session=${sessionId}`);
+}
+
+/** Run the driver CLI with CLAUDE_CONFIG_DIR scoped to claudeDir. */
+function runDriver(claudeDir: string, args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(process.execPath, ['--import', 'tsx', CLI, ...args], {
+      env: { ...process.env, TOKENMON_TEST: '1', TSX_DISABLE_CACHE: '1', CLAUDE_CONFIG_DIR: claudeDir },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => { stdout += c.toString(); });
+    child.stderr.on('data', (c: Buffer) => { stderr += c.toString(); });
+    child.once('error', rejectP);
+    child.once('close', (exitCode) => resolveP({ stdout, stderr, exitCode }));
+  });
+}
+
+/** Kill all daemons listed in the session store for the given claudeDir + generation. */
+function killAllDaemons(claudeDir: string, generation: string): void {
+  const prev = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  try {
+    for (const record of listFriendlyBattleSessionRecords(generation)) {
+      if (record.daemonPid && record.daemonPid > 0) {
+        try { process.kill(record.daemonPid, 'SIGTERM'); } catch { /* ESRCH */ }
+      }
+    }
+  } finally {
+    if (prev === undefined) { delete process.env.CLAUDE_CONFIG_DIR; } else { process.env.CLAUDE_CONFIG_DIR = prev; }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-action subcommand tests
+// ---------------------------------------------------------------------------
+
+/** Create a seeded CLAUDE_CONFIG_DIR without automatic cleanup (managed by afterEach). */
+function makeSeededDir(): string {
+  const dir = mkdtempSync(joinPath(tmpdir(), 'tkm-fb-action-'));
+  const genDir = joinPath(dir, 'tokenmon', 'gen4');
+  mkdirSync(genDir, { recursive: true });
+  writeFileSync(
+    joinPath(genDir, 'config.json'),
+    JSON.stringify({ party: ['387'], starter_chosen: true }),
+  );
+  writeFileSync(
+    joinPath(genDir, 'state.json'),
+    JSON.stringify({
+      pokemon: {
+        '387': { id: 387, xp: 100, level: 16, friendship: 0, ev: 0, moves: [33, 45] },
+      },
+    }),
+  );
+  return dir;
+}
+
+/** Write a session record scoped to claudeDir without touching process.env. */
+function writeRecordInDir(claudeDir: string, record: Parameters<typeof writeFriendlyBattleSessionRecord>[0]): void {
+  const prev = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  try {
+    writeFriendlyBattleSessionRecord(record);
+  } finally {
+    if (prev === undefined) { delete process.env.CLAUDE_CONFIG_DIR; } else { process.env.CLAUDE_CONFIG_DIR = prev; }
+  }
+}
+
+describe('friendly-battle-turn per-action subcommands', () => {
+  // Track claudeDirs to cleanup + kill daemons after each test
+  const cleanupDirs: string[] = [];
+
+  afterEachFb(() => {
+    for (const dir of cleanupDirs.splice(0)) {
+      killAllDaemons(dir, 'gen4');
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('--status returns the persisted envelope when the daemon is alive', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionCode = `status-alive-${randomUUID().slice(0, 8)}`;
+    const sessionId = `test-alive-${Date.now()}`;
+
+    const hostInfo = await spawnFbDaemon('host', {
+      sessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: 0,
+      generation: 'gen4',
+      playerName: 'Host',
+      timeoutMs: 15_000,
+    }, claudeDir);
+
+    writeRecordInDir(claudeDir, {
+      sessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode,
+      phase: 'waiting_for_guest',
+      status: 'waiting_for_guest',
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
+      opponent: null,
+      pid: process.pid,
+      daemonPid: hostInfo.child.pid!,
+      socketPath: hostInfo.socketPath,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await runDriver(claudeDir, [
+      '--status',
+      '--session', sessionId,
+      '--generation', 'gen4',
+    ]);
+
+    assert.equal(result.exitCode, 0, `stderr:\n${result.stderr}`);
+    const envelope = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+    assert.ok(typeof envelope.sessionId === 'string', 'envelope has sessionId');
+    assert.ok(typeof envelope.phase === 'string', 'envelope has phase');
+
+    hostInfo.child.kill('SIGTERM');
+    // afterEachFb will rmSync
+  });
+
+  it('--status returns a frozen envelope when the daemon is dead', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionId = `test-dead-${Date.now()}`;
+    writeRecordInDir(claudeDir, {
+      sessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode: 'dead-session',
+      phase: 'battle',
+      status: 'select_action',
+      transport: { host: '127.0.0.1', port: 9999 },
+      opponent: { playerName: 'Ghost' },
+      pid: process.pid,
+      daemonPid: 1 << 22, // non-running PID
+      socketPath: '/tmp/nonexistent-socket-fb.sock',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await runDriver(claudeDir, [
+      '--status',
+      '--session', sessionId,
+      '--generation', 'gen4',
+    ]);
+
+    assert.equal(result.exitCode, 0, `stderr:\n${result.stderr}`);
+    const envelope = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+    assert.equal(envelope.sessionId, sessionId, 'sessionId matches');
+    assert.equal(envelope.phase, 'battle', 'phase from persisted record');
+    assert.equal(envelope.status, 'select_action', 'status from persisted record');
+  });
+
+  it('--wait-next-event returns the first choices_requested envelope from a full handshake', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionCode = `wne-${randomUUID().slice(0, 8)}`;
+    const hostSessionId = `host-wne-${Date.now()}`;
+    const guestSessionId = `guest-wne-${Date.now()}`;
+
+    const hostInfo = await spawnFbDaemon('host', {
+      sessionId: hostSessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: 0,
+      generation: 'gen4',
+      playerName: 'Host',
+      timeoutMs: 20_000,
+    }, claudeDir);
+
+    const guestInfo = await spawnFbDaemon('guest', {
+      sessionId: guestSessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: hostInfo.port,
+      generation: 'gen4',
+      playerName: 'Guest',
+      timeoutMs: 20_000,
+    }, claudeDir);
+
+    const nowIso = new Date().toISOString();
+    writeRecordInDir(claudeDir, {
+      sessionId: hostSessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode,
+      phase: 'battle',
+      status: 'ongoing',
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
+      opponent: { playerName: 'Guest' },
+      pid: process.pid,
+      daemonPid: hostInfo.child.pid!,
+      socketPath: hostInfo.socketPath,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    writeRecordInDir(claudeDir, {
+      sessionId: guestSessionId,
+      role: 'guest',
+      generation: 'gen4',
+      sessionCode,
+      phase: 'battle',
+      status: 'ongoing',
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
+      opponent: { playerName: 'Host' },
+      pid: process.pid,
+      daemonPid: guestInfo.child.pid!,
+      socketPath: guestInfo.socketPath,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    // Run --wait-next-event for host and guest in parallel
+    const [hostWneResult, guestWneResult] = await Promise.all([
+      runDriver(claudeDir, [
+        '--wait-next-event',
+        '--session', hostSessionId,
+        '--generation', 'gen4',
+        '--timeout-ms', '8000',
+      ]),
+      runDriver(claudeDir, [
+        '--wait-next-event',
+        '--session', guestSessionId,
+        '--generation', 'gen4',
+        '--timeout-ms', '8000',
+      ]),
+    ]);
+
+    assert.equal(hostWneResult.exitCode, 0, `host wne stderr:\n${hostWneResult.stderr}`);
+    const hostEnvelope = JSON.parse(hostWneResult.stdout.trim()) as Record<string, unknown>;
+    assert.ok(hostEnvelope.status !== undefined, 'host envelope has status');
+    assert.ok(Array.isArray(hostEnvelope.moveOptions), 'host has moveOptions array');
+
+    assert.equal(guestWneResult.exitCode, 0, `guest wne stderr:\n${guestWneResult.stderr}`);
+    const guestEnvelope = JSON.parse(guestWneResult.stdout.trim()) as Record<string, unknown>;
+    assert.ok(guestEnvelope.status !== undefined, 'guest envelope has status');
+
+    // afterEachFb will SIGTERM daemons via killAllDaemons + rmSync
+  });
+
+  it('--action move:1 submits a move to the daemon', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionCode = `action-${randomUUID().slice(0, 8)}`;
+    const hostSessionId = `host-act-${Date.now()}`;
+    const guestSessionId = `guest-act-${Date.now()}`;
+
+    const hostInfo = await spawnFbDaemon('host', {
+      sessionId: hostSessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: 0,
+      generation: 'gen4',
+      playerName: 'Host',
+      timeoutMs: 20_000,
+    }, claudeDir);
+
+    const guestInfo = await spawnFbDaemon('guest', {
+      sessionId: guestSessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: hostInfo.port,
+      generation: 'gen4',
+      playerName: 'Guest',
+      timeoutMs: 20_000,
+    }, claudeDir);
+
+    const nowIso = new Date().toISOString();
+    writeRecordInDir(claudeDir, {
+      sessionId: hostSessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode,
+      phase: 'battle',
+      status: 'ongoing',
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
+      opponent: { playerName: 'Guest' },
+      pid: process.pid,
+      daemonPid: hostInfo.child.pid!,
+      socketPath: hostInfo.socketPath,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+    writeRecordInDir(claudeDir, {
+      sessionId: guestSessionId,
+      role: 'guest',
+      generation: 'gen4',
+      sessionCode,
+      phase: 'battle',
+      status: 'ongoing',
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
+      opponent: { playerName: 'Host' },
+      pid: process.pid,
+      daemonPid: guestInfo.child.pid!,
+      socketPath: guestInfo.socketPath,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    });
+
+    // Drain events until both sides reach select_action
+    async function drainToSelectAction(sessionId: string): Promise<void> {
+      for (let i = 0; i < 5; i++) {
+        const result = await runDriver(claudeDir, [
+          '--wait-next-event',
+          '--session', sessionId,
+          '--generation', 'gen4',
+          '--timeout-ms', '8000',
+        ]);
+        if (result.exitCode !== 0) throw new Error(`wait-next-event failed: ${result.stderr}`);
+        const env = JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+        if (env.status === 'select_action') return;
+      }
+      throw new Error('never reached select_action after 5 events');
+    }
+
+    await Promise.all([
+      drainToSelectAction(hostSessionId),
+      drainToSelectAction(guestSessionId),
+    ]);
+
+    // Submit move:1 from host (1-based in CLI = index 0 in daemon)
+    const hostActionResult = await runDriver(claudeDir, [
+      '--action', 'move:1',
+      '--session', hostSessionId,
+      '--generation', 'gen4',
+    ]);
+    assert.equal(hostActionResult.exitCode, 0, `host action stderr:\n${hostActionResult.stderr}`);
+    const hostAck = JSON.parse(hostActionResult.stdout.trim()) as Record<string, unknown>;
+    assert.ok(hostAck.sessionId !== undefined || hostAck.phase !== undefined, 'host ack has envelope fields');
+
+    // Submit move:1 from guest
+    const guestActionResult = await runDriver(claudeDir, [
+      '--action', 'move:1',
+      '--session', guestSessionId,
+      '--generation', 'gen4',
+    ]);
+    assert.equal(guestActionResult.exitCode, 0, `guest action stderr:\n${guestActionResult.stderr}`);
+    const guestAck = JSON.parse(guestActionResult.stdout.trim()) as Record<string, unknown>;
+    assert.ok(guestAck.sessionId !== undefined || guestAck.phase !== undefined, 'guest ack has envelope fields');
+
+    // --wait-next-event on host should get another event (turn resolved or next select_action)
+    const postMoveResult = await runDriver(claudeDir, [
+      '--wait-next-event',
+      '--session', hostSessionId,
+      '--generation', 'gen4',
+      '--timeout-ms', '8000',
+    ]);
+    assert.equal(postMoveResult.exitCode, 0, `post-move wne stderr:\n${postMoveResult.stderr}`);
+
+    // afterEachFb kills daemons + rmSync
+  });
+
+  it('--action switch:1 errors with PR45 not-implemented (exit 2)', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionId = `switch-${Date.now()}`;
+    writeRecordInDir(claudeDir, {
+      sessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode: 'switch-test',
+      phase: 'battle',
+      status: 'select_action',
+      transport: { host: '127.0.0.1', port: 9999 },
+      opponent: { playerName: 'Guest' },
+      pid: process.pid,
+      daemonPid: 1 << 22,
+      socketPath: '/tmp/nonexistent-switch.sock',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await runDriver(claudeDir, [
+      '--action', 'switch:1',
+      '--session', sessionId,
+      '--generation', 'gen4',
+    ]);
+
+    assert.equal(result.exitCode, 2, `expected exit 2 for switch, got ${result.exitCode}\nstderr: ${result.stderr}`);
+    assert.match(result.stderr, /PR45/, 'stderr mentions PR45');
+  });
+
+  it('--action surrender errors with PR45 not-implemented (exit 2)', async () => {
+    const claudeDir = makeSeededDir();
+    cleanupDirs.push(claudeDir);
+
+    const sessionId = `surrender-${Date.now()}`;
+    writeRecordInDir(claudeDir, {
+      sessionId,
+      role: 'host',
+      generation: 'gen4',
+      sessionCode: 'surrender-test',
+      phase: 'battle',
+      status: 'select_action',
+      transport: { host: '127.0.0.1', port: 9999 },
+      opponent: { playerName: 'Guest' },
+      pid: process.pid,
+      daemonPid: 1 << 22,
+      socketPath: '/tmp/nonexistent-surrender.sock',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const result = await runDriver(claudeDir, [
+      '--action', 'surrender',
+      '--session', sessionId,
+      '--generation', 'gen4',
+    ]);
+
+    assert.equal(result.exitCode, 2, `expected exit 2 for surrender, got ${result.exitCode}\nstderr: ${result.stderr}`);
+    assert.match(result.stderr, /PR45/, 'stderr mentions PR45');
   });
 });

--- a/test/friendly-battle-turn-driver.test.ts
+++ b/test/friendly-battle-turn-driver.test.ts
@@ -102,7 +102,6 @@ describe('friendly-battle-turn CLI', () => {
     assert.match(combined, /--init-host/);
     assert.match(combined, /--init-join/);
     assert.match(combined, /--action/);
-    assert.match(combined, /--refresh/);
     assert.match(combined, /--status/);
   });
 
@@ -350,9 +349,9 @@ function spawnFbDaemon(
   return new Promise((resolveP, rejectP) => {
     const child = spawn(
       process.execPath,
-      ['--import', 'tsx', DAEMON_ENTRY_FB, '--role', role, '--options-json', encodeDaemonOptionsB64(options)],
+      ['--import', 'tsx', DAEMON_ENTRY_FB, '--role', role],
       {
-        env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, TSX_DISABLE_CACHE: '1', TOKENMON_TEST: '1' },
+        env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, TSX_DISABLE_CACHE: '1', TOKENMON_TEST: '1', TKM_FB_OPTIONS_B64: encodeDaemonOptionsB64(options) },
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: false,
       },
@@ -465,8 +464,15 @@ async function killAllDaemons(claudeDir: string, generation: string): Promise<vo
   for (const pid of pids) {
     try { process.kill(pid, 'SIGKILL'); } catch { /* ESRCH */ }
   }
-  // Brief wait after SIGKILL so the process table clears before rmSync
-  await new Promise<void>((resolve) => setTimeout(resolve, 100));
+  // Poll up to 500ms for SIGKILL to take effect rather than a fixed sleep.
+  const killDeadline = Date.now() + 500;
+  while (Date.now() < killDeadline) {
+    const stillAlive = pids.filter((pid) => {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    });
+    if (stillAlive.length === 0) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -568,6 +574,8 @@ describe('friendly-battle-turn per-action subcommands', () => {
     cleanupDirs.push(claudeDir);
 
     const sessionId = `test-dead-${Date.now()}`;
+    // socketPath must be inside the sessions dir to pass isValidRecord containment check.
+    const socketPath = joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions', `${sessionId}.sock`);
     writeRecordInDir(claudeDir, {
       sessionId,
       role: 'host',
@@ -579,7 +587,7 @@ describe('friendly-battle-turn per-action subcommands', () => {
       opponent: { playerName: 'Ghost' },
       pid: process.pid,
       daemonPid: 1 << 22, // non-running PID
-      socketPath: '/tmp/nonexistent-socket-fb.sock',
+      socketPath,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -814,7 +822,7 @@ describe('friendly-battle-turn per-action subcommands', () => {
       opponent: { playerName: 'Guest' },
       pid: process.pid,
       daemonPid: 1 << 22,
-      socketPath: '/tmp/nonexistent-switch.sock',
+      socketPath: joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions', `${sessionId}.sock`),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -845,7 +853,7 @@ describe('friendly-battle-turn per-action subcommands', () => {
       opponent: { playerName: 'Guest' },
       pid: process.pid,
       daemonPid: 1 << 22,
-      socketPath: '/tmp/nonexistent-surrender.sock',
+      socketPath: joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions', `${sessionId}.sock`),
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });

--- a/test/friendly-battle-turn-driver.test.ts
+++ b/test/friendly-battle-turn-driver.test.ts
@@ -120,7 +120,12 @@ describe('friendly-battle-turn CLI', () => {
 });
 
 describe('friendly-battle-turn --init-host', () => {
-  it('emits JSON with phase=waiting_for_guest before timing out and then writes phase=aborted', async () => {
+  it('emits JSON with phase=waiting_for_guest and exits 0; daemon eventually writes phase=aborted', async () => {
+    // After the Task 5 refactor, --init-host forks a daemon and exits 0 immediately
+    // after receiving DAEMON_READY. The parent always exits 0; the daemon times out
+    // and updates the session record to phase=aborted asynchronously.
+    // We accept either waiting_for_guest or aborted in the stdout envelope because
+    // the parent snapshot is captured before the daemon timeout fires.
     const result = await spawnDriver([
       '--init-host',
       '--session-code', 'waiting-123',
@@ -131,10 +136,10 @@ describe('friendly-battle-turn --init-host', () => {
       '--player-name', 'Host',
     ]);
 
-    assert.notEqual(result.exitCode, 0);
-    // waiting line should have been printed before we gave up
-    assert.match(result.stdout, /"phase":\s*"waiting_for_guest"/);
-    assert.match(result.stderr, /STAGE:\s*waiting_for_guest/);
+    assert.equal(result.exitCode, 0, `unexpected exit; stderr:\n${result.stderr}`);
+    // Parent emits waiting_for_guest envelope before exiting
+    assert.match(result.stdout, /"phase":\s*"waiting_for_guest"/, 'parent envelope phase');
+    assert.match(result.stderr, /STAGE:\s*waiting_for_guest/, 'STAGE line present');
   });
 
   it('rejects a non-integer --port with a REASON line and exit 1', async () => {
@@ -160,8 +165,57 @@ describe('friendly-battle-turn --init-host', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Helpers for the updated handshake test
+// ---------------------------------------------------------------------------
+
+import {
+  readFriendlyBattleSessionRecord,
+} from '../src/friendly-battle/session-store.js';
+
+/** Poll fn() every intervalMs until it returns a truthy value or deadline passes. */
+async function pollUntil<T>(
+  fn: () => T | null | undefined | false,
+  timeoutMs: number,
+  intervalMs = 100,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const val = fn();
+    if (val) return val;
+    await new Promise<void>((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`pollUntil: timed out after ${timeoutMs}ms`);
+}
+
+/** Read a JSON envelope from a line of stdout. */
+function parseFirstEnvelope(stdout: string): Record<string, unknown> | null {
+  const line = stdout.split('\n').find((l) => l.trim().startsWith('{'));
+  if (!line) return null;
+  try { return JSON.parse(line) as Record<string, unknown>; } catch { return null; }
+}
+
+/**
+ * Read a session record scoped to a specific CLAUDE_CONFIG_DIR.
+ * readFriendlyBattleSessionRecord uses process.env.CLAUDE_CONFIG_DIR so we
+ * temporarily swap it for the duration of the call.
+ */
+function readRecordInDir(claudeDir: string, sessionId: string, generation: string) {
+  const prev = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  try {
+    return readFriendlyBattleSessionRecord(sessionId, generation);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = prev;
+    }
+  }
+}
+
 describe('friendly-battle-turn init handshake', () => {
-  it('init-join connects to an init-host and both exit 0 with battle phase', async () => {
+  it('init-join connects to an init-host and both exit 0 with phase=waiting_for_guest/handshake, daemons advance to battle', async () => {
     await withSeededClaudeConfigDir(async (claudeDir) => {
       const sessionCode = 'handshake-321';
       const host = spawnDriverWithClaudeDir(claudeDir, [
@@ -174,6 +228,7 @@ describe('friendly-battle-turn init handshake', () => {
         '--player-name', 'Host',
       ]);
 
+      // Step 1: Wait for PORT: line from host
       const hostPort = await readPortFromHostStderr(host);
 
       const join = spawnDriverWithClaudeDir(claudeDir, [
@@ -186,12 +241,61 @@ describe('friendly-battle-turn init handshake', () => {
         '--player-name', 'Guest',
       ]);
 
+      // Step 2: Both parent processes should exit 0 quickly (they fork daemons and exit)
       const [hostResult, joinResult] = await Promise.all([host.completion, join.completion]);
-      assert.equal(joinResult.exitCode, 0, `join stderr:\n${joinResult.stderr}`);
       assert.equal(hostResult.exitCode, 0, `host stderr:\n${hostResult.stderr}`);
-      assert.match(hostResult.stdout, /"phase":\s*"battle"/);
-      assert.match(joinResult.stdout, /"phase":\s*"battle"/);
-      assert.match(joinResult.stdout, /"role":\s*"guest"/);
+      assert.equal(joinResult.exitCode, 0, `join stderr:\n${joinResult.stderr}`);
+
+      // Step 3: Host emits waiting_for_guest, guest emits handshake
+      assert.match(hostResult.stdout, /"phase":\s*"waiting_for_guest"/, 'host envelope phase');
+      assert.match(joinResult.stdout, /"phase":\s*"handshake"/, 'join envelope phase');
+      assert.match(joinResult.stdout, /"role":\s*"guest"/, 'join envelope role');
+
+      // Step 4: Poll session store — both records must exist with daemonPid > 0 and socketPath
+      const hostEnv = parseFirstEnvelope(hostResult.stdout);
+      const joinEnv = parseFirstEnvelope(joinResult.stdout);
+      assert.ok(hostEnv, 'host envelope parseable');
+      assert.ok(joinEnv, 'join envelope parseable');
+
+      const hostSessionId = (hostEnv as Record<string, unknown>).sessionId as string;
+      const joinSessionId = (joinEnv as Record<string, unknown>).sessionId as string;
+      assert.ok(hostSessionId, 'host sessionId present');
+      assert.ok(joinSessionId, 'join sessionId present');
+
+      const daemonPids: number[] = [];
+
+      // Poll for host record (records live under claudeDir, not the test process's default)
+      const hostRecord = await pollUntil(
+        () => readRecordInDir(claudeDir, hostSessionId, 'gen4'),
+        5000,
+      );
+      assert.ok((hostRecord.daemonPid ?? 0) > 0, 'host daemonPid > 0');
+      assert.ok(hostRecord.socketPath && hostRecord.socketPath.length > 0, 'host socketPath set');
+      daemonPids.push(hostRecord.daemonPid!);
+
+      // Poll for guest record
+      const guestRecord = await pollUntil(
+        () => readRecordInDir(claudeDir, joinSessionId, 'gen4'),
+        5000,
+      );
+      assert.ok((guestRecord.daemonPid ?? 0) > 0, 'guest daemonPid > 0');
+      assert.ok(guestRecord.socketPath && guestRecord.socketPath.length > 0, 'guest socketPath set');
+      daemonPids.push(guestRecord.daemonPid!);
+
+      // Step 5: Poll for host record to advance to phase='battle' (daemon handles this async)
+      await pollUntil(
+        () => {
+          const r = readRecordInDir(claudeDir, hostSessionId, 'gen4');
+          return r?.phase === 'battle' ? r : null;
+        },
+        15000,
+        200,
+      );
+
+      // Step 6: Cleanup — SIGTERM both daemon PIDs
+      for (const pid of daemonPids) {
+        try { process.kill(pid, 'SIGTERM'); } catch { /* ESRCH: already gone */ }
+      }
     });
   });
 

--- a/test/friendly-battle-turn-driver.test.ts
+++ b/test/friendly-battle-turn-driver.test.ts
@@ -435,19 +435,38 @@ function runDriver(claudeDir: string, args: string[]): Promise<{ stdout: string;
   });
 }
 
-/** Kill all daemons listed in the session store for the given claudeDir + generation. */
-function killAllDaemons(claudeDir: string, generation: string): void {
+/** Kill all daemons listed in the session store for the given claudeDir + generation,
+ *  then wait for each PID to actually exit before returning so subsequent rmSync
+ *  does not race the daemon's socket-unlink + session-record write. */
+async function killAllDaemons(claudeDir: string, generation: string): Promise<void> {
   const prev = process.env.CLAUDE_CONFIG_DIR;
   process.env.CLAUDE_CONFIG_DIR = claudeDir;
+  const pids: number[] = [];
   try {
     for (const record of listFriendlyBattleSessionRecords(generation)) {
       if (record.daemonPid && record.daemonPid > 0) {
+        pids.push(record.daemonPid);
         try { process.kill(record.daemonPid, 'SIGTERM'); } catch { /* ESRCH */ }
       }
     }
   } finally {
     if (prev === undefined) { delete process.env.CLAUDE_CONFIG_DIR; } else { process.env.CLAUDE_CONFIG_DIR = prev; }
   }
+
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const stillAlive = pids.filter((pid) => {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    });
+    if (stillAlive.length === 0) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  }
+  // Final sweep with SIGKILL for any still-stuck daemons
+  for (const pid of pids) {
+    try { process.kill(pid, 'SIGKILL'); } catch { /* ESRCH */ }
+  }
+  // Brief wait after SIGKILL so the process table clears before rmSync
+  await new Promise<void>((resolve) => setTimeout(resolve, 100));
 }
 
 // ---------------------------------------------------------------------------
@@ -489,9 +508,9 @@ describe('friendly-battle-turn per-action subcommands', () => {
   // Track claudeDirs to cleanup + kill daemons after each test
   const cleanupDirs: string[] = [];
 
-  afterEachFb(() => {
+  afterEachFb(async () => {
     for (const dir of cleanupDirs.splice(0)) {
-      killAllDaemons(dir, 'gen4');
+      await killAllDaemons(dir, 'gen4');
       rmSync(dir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

First playable \`/tkm:friendly-battle open\` / \`join <code>@<host>:<port>\` / \`status\` — two Claude Code sessions drive a gym-style AskUserQuestion turn loop that actually resolves moves over the TCP transport from PR #40/#42/#43.

## Architecture reversal (documented inline)

PR43's roadmap claimed a "no daemon, foreground-blocking, gym-style one-shot" model. Execution of PR44 revealed that the gym model **cannot** be literally transplanted because \`tcp-direct.ts\` exposes an entirely live-socket API — a TCP file descriptor cannot survive across tsx process invocations. Gym works because its state is purely local; friendly-battle's is not.

PR44 adopts a **minimal daemon per side**:
- \`--init-host\` / \`--init-join\` fork a detached child process (\`src/friendly-battle/daemon.ts\`) that holds the TCP socket and battle-adapter runtime
- The daemon exposes a local-only UNIX socket at \`$CLAUDE_CONFIG_DIR/.../<sessionId>.sock\` (mode 0600 after security fixup)
- Per-action subcommands (\`--wait-next-event\`, \`--action move:N\`, \`--status\`) are one-shot tsx calls that open the socket, send one JSON command, read one response, close — same ergonomics as gym from SKILL.md's perspective
- Session store gains \`daemonPid\` + \`socketPath\` fields; PR43's \`reapStaleFriendlyBattleSessions\` reaps orphans (fixed post-review to check \`daemonPid\`, not the exiting CLI parent's \`pid\`)
- User-visible experience is unchanged — the daemon is an implementation detail, not a product surface

Full rationale in \`docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md\` §8 and \`docs/friendly-battle/roadmap/pr44-skill-and-turn-loop-plan.md\`.

## What landed

- \`src/friendly-battle/daemon-protocol.ts\` — shared IPC request/response types with \`encodeDaemonMessage\` / \`decodeDaemonMessage\`
- \`src/friendly-battle/daemon-ipc.ts\` — UNIX socket server + client (one request/response per connection, 0600 perms, 64 KiB line cap, 5s idle timeout)
- \`src/friendly-battle/daemon.ts\` — ~680 LOC long-lived event loop. Host daemon owns the authoritative \`battle-adapter\` runtime and resolves turns; guest daemon forwards events from TCP to its local queue. Clean shutdown drains the event queue, fails in-flight waiters, and arms a sentinel so late \`wait_next_event\` callers get the finished envelope instead of hanging.
- \`src/cli/friendly-battle-turn.ts\` — \`--init-host\`/\`--init-join\` refactored to fork the daemon (options passed via env var \`TKM_FB_OPTIONS_B64\`, not argv, so the session code isn't visible via \`ps\`) and exit; new \`--wait-next-event\`, \`--action move:N\`, \`--status\`. \`--action switch:N\` / \`--action surrender\` fail with a PR45-deferred message. \`--refresh\` wiring fully removed (was dead stub).
- \`src/friendly-battle/session-store.ts\` — extended with \`daemonPid\` + \`socketPath\` required fields + shape-guard rejection for old records + socketPath containment validation
- \`skills/friendly-battle/SKILL.md\` — first gym-style skill file for friendly battle
- 4 new test files (daemon-protocol / daemon-ipc / daemon-turn-loop / skill-contract) + extended turn-driver + session-store tests
- \`package.json\` — \`--test-concurrency=1\` for deterministic daemon-test execution
- \`docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md\` — §8 "Architecture revision" documenting the daemon reversal

## Out of scope (explicit deferrals)

- \`--action switch:N\` / \`--action surrender\` → PR45
- Fainted forced-switch UX → PR45
- \`--leave\` clean disconnect + SIGTERM from skill → PR46
- Two-machine smoke evidence → PR47
- \`TOKENMON_FORCE_DETERMINISTIC\` gating of \`local-harness\` — confirmed not needed by PR44; hygiene follow-up
- Parent-crash-between-fork-and-record race + SKILL.md bash arg-quoting hardening + environment whitelist → PR45

## Stacked PR

- Base: \`feat/friendly-battle-pvp-driver\` (PR #43)
- This branch: \`feat/friendly-battle-pvp-skill\`
- **Do not merge until #42 → #43 → #44 stack lands in order.**

## ⚠️ Visual QA merge gate

Per project memory: Visual 요소는 실행→스크린샷→visual-verdict 리뷰 통과 필수. PR44 introduces real AskUserQuestion UX. **Merging requires the human operator to:**

1. Open two Claude Code terminals with seeded tokenmon data
2. Host runs \`/tkm:friendly-battle open\`, screenshot waiting-for-guest state
3. Guest runs \`/tkm:friendly-battle join <code>@<host>:<port>\`, screenshot connection + first move-select AskUserQuestion
4. Play through at least one full turn on both sides, screenshot the resolution display
5. Run \`oh-my-claudecode:visual-verdict\` against the screenshots

**This PR stays draft until visual QA passes.** Autopilot explicitly stops here.

## Verification (automated)

- \`npm test\` → 1195 pass, 0 fail across multiple runs
- \`npx tsc --noEmit\` → exit 0
- \`npm run build\` → exit 0
- Integration test spawns two daemons over real TCP + real UNIX socket IPC; proves end-to-end daemon + battle-adapter + transport stack
- Reviewed by \`oh-my-claudecode:architect\`, \`oh-my-claudecode:security-reviewer\`, \`oh-my-claudecode:code-reviewer\` (all APPROVE WITH MINOR FIXES) + \`codex:codex-rescue\` second-pass validation (all 12 fixes PASS, one residual race caught and fixed in \`32d11b3\`)

## Commits

1. \`8848917\` — Plan PR44 with a minimal daemon reversal for the turn loop
2. \`d9a29c4\` — Extend friendly-battle session record with daemonPid and socketPath
3. \`33402af\` — Add friendly-battle daemon IPC protocol types
4. \`0ac54c1\` — Add UNIX-socket IPC server/client for friendly-battle daemon
5. \`f8fa767\` — Add friendly-battle daemon long-lived event loop
6. \`2a08262\` — Add end-to-end turn loop integration test across two daemons
7. \`3fe1792\` — Fork the friendly-battle daemon from --init-host and --init-join
8. \`096abc2\` — Implement friendly-battle-turn --wait-next-event / --action move / --status
9. \`bd89b73\` — Add skills/friendly-battle/SKILL.md and contract test
10. \`87d53ae\` — Document the PR44 daemon reversal in the friendly-battle roadmap
11. \`505bbd3\` — Stabilize PR44 test suite against concurrency + daemon teardown races
12. \`e5dca7c\` — Apply PR44 reviewer fixups: reap daemon PID, socket ACL, DoS cap, path validation
13. \`32d11b3\` — Close the drain-sentinel arming race flagged by the Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the autopilot skill