### PR TITLE
Activate friendly-battle fainted forced-switch + surrender (PR45)

### DIFF
--- a/docs/friendly-battle/roadmap/pr45-fainted-surrender-plan.md
+++ b/docs/friendly-battle/roadmap/pr45-fainted-surrender-plan.md
@@ -1,0 +1,202 @@
+# PR45 — Fainted Forced-Switch + Surrender Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** Activate the `switch:N` and `surrender` paths that PR44 intentionally stubbed, so `/tkm:friendly-battle` can resolve a full battle including forced switches after a faint and explicit user surrender.
+
+**Parent branch:** `feat/friendly-battle-pvp-skill` (PR #44)
+**This branch:** `feat/friendly-battle-pvp-fainted`
+**Target PR base:** PR #44
+
+---
+
+## Good news: most of the machinery is already wired
+
+Investigation of the PR44 daemon surface shows that `battle-adapter.ts` already handles all three `TurnAction` variants (`move`, `switch`, `surrender`), and `daemon.ts:eventStatus` already maps `choices_requested{phase: 'awaiting_fainted_switch'}` → `'fainted_switch'` status. The gaps are purely at the **user-input surface**:
+
+- `DaemonAction` union in `daemon-protocol.ts` is move-only
+- `serializeDaemonAction` in `daemon.ts` has only a `move` case
+- `runAction` in `friendly-battle-turn.ts` rejects `switch:N` / `surrender` with a "PR45 deferred" error
+- `skills/friendly-battle/SKILL.md` has no switch menu flow, no surrender confirm, no forced-switch handling
+- `eventToEnvelopeFields` emits moveOptions even on `choices_requested{phase:'awaiting_fainted_switch'}`, which confuses the skill's AskUserQuestion logic
+
+This PR is much smaller than PR44 — mostly surface exposure + 1 integration test with a 2-pokemon party fixture.
+
+---
+
+## File structure
+
+**Modify:**
+- `src/friendly-battle/daemon-protocol.ts` — extend `DaemonAction` union
+- `src/friendly-battle/daemon.ts` — `serializeDaemonAction` switch/surrender cases + `eventToEnvelopeFields` zero-out moveOptions on fainted_switch
+- `src/cli/friendly-battle-turn.ts` — `runAction` parses `switch:N` (1-based) and `surrender`, forwards to daemon via IPC
+- `skills/friendly-battle/SKILL.md` — switch-menu AskUserQuestion flow (mirror gym Step 4), surrender-confirm AskUserQuestion flow (gym Step 5), forced-switch flow (gym Step 6)
+- `test/friendly-battle-daemon-protocol.test.ts` — expand to cover new action variants
+- `test/friendly-battle-turn-driver.test.ts` — remove the "PR45 deferred" assertions, add real switch/surrender tests
+- `test/friendly-battle-skill-contract.test.ts` — the regex for accepted `--action` tokens must now accept `switch:<N>` and `surrender`
+
+**New:**
+- `test/friendly-battle-daemon-fainted-switch.test.ts` — integration test. Seeds a 2-pokemon party fixture (host + guest both), runs a battle turn that knocks out one side's active pokemon, asserts the fainted envelope is delivered, submits a switch:2 action, asserts the battle continues to turn 2.
+- `test/friendly-battle-daemon-surrender.test.ts` — integration test. Seeds a 1-pokemon party, runs handshake, one side submits `surrender`, asserts both daemons see `battle_finished{winner: other_side, reason: 'surrender'}` and exit cleanly.
+
+---
+
+## Tasks
+
+### Task 1 — Extend `DaemonAction` union
+
+**Files**: `src/friendly-battle/daemon-protocol.ts`, `test/friendly-battle-daemon-protocol.test.ts`
+
+Add `switch` and `surrender` variants:
+
+```ts
+export type DaemonAction =
+  | { kind: 'move'; index: number }
+  | { kind: 'switch'; pokemonIndex: number }
+  | { kind: 'surrender' };
+```
+
+Extend the protocol test to round-trip each new variant through `encodeDaemonMessage` / `decodeDaemonMessage`.
+
+Commit message: `Add switch and surrender variants to friendly-battle DaemonAction`
+
+### Task 2 — Daemon `serializeDaemonAction` handles new variants
+
+**Files**: `src/friendly-battle/daemon.ts`, `test/friendly-battle-daemon-turn-loop.test.ts` (no change expected; just verify)
+
+Extend the switch statement:
+
+```ts
+function serializeDaemonAction(action: DaemonAction): string {
+  switch (action.kind) {
+    case 'move': return `move:${action.index}`;
+    case 'switch': return `switch:${action.pokemonIndex}`;
+    case 'surrender': return 'surrender';
+  }
+}
+```
+
+Verify the daemon turn-loop test still passes (move path unchanged).
+
+Commit: `Serialize switch and surrender DaemonActions for the TCP transport`
+
+### Task 3 — Daemon `eventToEnvelopeFields` zeros moveOptions on fainted_switch
+
+**Files**: `src/friendly-battle/daemon.ts`
+
+In the `choices_requested` case, check `event.phase`:
+
+```ts
+case 'choices_requested': {
+  const isFaintedSwitch = event.phase === 'awaiting_fainted_switch';
+  const moveOptions = isFaintedSwitch
+    ? []
+    : (runtime
+        ? buildMoveOptionsFromRuntime(runtime, role)
+        : (ownSnapshot ? buildMoveOptionsFromSnapshot(ownSnapshot) : []));
+  // partyOptions stays populated either way
+  return {
+    questionContext: isFaintedSwitch
+      ? 'Your Pokémon fainted — pick a replacement'
+      : `Turn ${event.turn}: Choose your action`,
+    moveOptions,
+    partyOptions,
+    animationFrames: [],
+    currentFrameIndex: 0,
+  };
+}
+```
+
+No test change needed — the integration test in Task 6 verifies the envelope shape.
+
+Commit: `Zero out moveOptions on fainted_switch envelopes`
+
+### Task 4 — `runAction` accepts `switch:N` / `surrender`
+
+**Files**: `src/cli/friendly-battle-turn.ts`, `test/friendly-battle-turn-driver.test.ts`
+
+Replace the PR45-deferred error branches with real parsing:
+
+- `switch:N` where N in 1..6 → `{kind: 'switch', pokemonIndex: N - 1}` (1-based SKILL.md token → 0-based battle adapter index, matching move handling)
+- `surrender` → `{kind: 'surrender'}`
+- Any other token → `REASON: unknown action token`, exit 1
+
+Update the two existing "PR45 not-implemented" tests in `friendly-battle-turn-driver.test.ts` to expect success instead. They'll need a live daemon to submit to — reuse the pattern from the `--wait-next-event returns the first choices_requested envelope` test, but after submitting a real move first so the action queue makes sense.
+
+Commit: `Implement friendly-battle-turn --action switch:N and --action surrender`
+
+### Task 5 — Skill contract regex accepts new action tokens
+
+**Files**: `test/friendly-battle-skill-contract.test.ts`
+
+Update the `accepted` predicate to also accept `switch:<N>` and `surrender`:
+
+```ts
+const accepted = (token: string): boolean => {
+  if (/^move:[\d<$]/.test(token) || token === 'move:') return true;
+  if (/^switch:[\d<$]/.test(token) || token === 'switch:') return true;
+  if (token === 'surrender') return true;
+  return false;
+};
+```
+
+Commit: `Allow switch and surrender tokens in the friendly-battle skill contract test`
+
+### Task 6 — SKILL.md adds switch menu + surrender confirm + forced-switch flows
+
+**Files**: `skills/friendly-battle/SKILL.md`
+
+Mirror `skills/gym/SKILL.md` Steps 4, 5, 6:
+
+- **Switch menu** (Step 4): When the user types `교체` or `switch` in AskUserQuestion's "Other" field during a normal turn, open a second AskUserQuestion listing live party members from `partyOptions`. On pick: `--action switch:<N>`. On invalid: re-ask.
+- **Surrender confirm** (Step 5): When the user types `항복` or `surrender`, show a yes/no AskUserQuestion. On confirm: `--action surrender`. On cancel: return to the move AskUserQuestion.
+- **Forced switch** (Step 6): When `wait_next_event` returns an envelope with `status === 'fainted_switch'`, immediately open the switch-menu AskUserQuestion (no move menu). Cancel is NOT allowed — the user must pick a live party member. Empty party or all-fainted → status should already be `defeat` from the adapter, not this branch.
+
+Commit: `Add switch menu, surrender confirm, and forced-switch flows to SKILL.md`
+
+### Task 7 — Integration test: fainted forced switch
+
+**Files**: `test/friendly-battle-daemon-fainted-switch.test.ts` (new)
+
+Spawn host + guest daemons with a 2-pokemon party seeded on both sides (one low-HP pokemon that will faint on a single strong hit, one healthy backup). Send `move:1` from both sides via IPC `submit_action`. Drain events via `wait_next_event` until one side's `status === 'fainted_switch'`. On that side, send `{op: 'submit_action', action: {kind: 'switch', pokemonIndex: 1}}`. Drain events again; expect the next `choices_requested` to have `status === 'select_action'` and the non-fainted side to have moveOptions for the next turn.
+
+Keep the test time-bounded to 15s total. Clean up daemons in afterEach.
+
+For the seed: use pokemon id 387 with `moves: [33, 45]` (tackle-ish) and id 155 as backup. Or simpler: both sides get [387, 155] and one of the moves is strong enough to KO.
+
+If finding real damage values is hard, use `TOKENMON_FORCE_DETERMINISTIC` or similar injection to force a one-shot KO. If no such hook exists, either create one via a daemon env flag or accept that the test is a two-turn setup (turn 1 weakens, turn 2 kills).
+
+Commit: `Add integration test for fainted forced-switch end-to-end`
+
+### Task 8 — Integration test: explicit surrender
+
+**Files**: `test/friendly-battle-daemon-surrender.test.ts` (new)
+
+Simpler than Task 7. Spawn host + guest with 1-pokemon parties. After handshake reaches `status === 'select_action'`, one side sends `{op: 'submit_action', action: {kind: 'surrender'}}`. The other side sends any `move:1`. Drain events; expect `battle_finished` with `winner` = the non-surrendering side and `reason: 'surrender'`.
+
+Commit: `Add integration test for explicit surrender end-to-end`
+
+### Task 9 — CI sanity + push + draft PR
+
+- `npm test` (full suite, 1195+N passes)
+- `npx tsc --noEmit`
+- `npm run build`
+- `git push origin feat/friendly-battle-pvp-fainted`
+- `gh pr create --draft --base feat/friendly-battle-pvp-skill --head feat/friendly-battle-pvp-fainted ...`
+
+Visual QA handoff note in PR body: the new switch-menu and surrender-confirm are AskUserQuestion UIs and require `visual-verdict` review before merge, same as PR44.
+
+---
+
+## Out of scope (still)
+
+- `--leave` clean disconnect → PR46
+- Two-machine smoke evidence → PR47
+- Daemon authentication beyond PR44's UNIX-socket 0600 perms
+- `TOKENMON_FORCE_DETERMINISTIC` gate for local-harness (deferred hygiene)
+
+## Known risks
+
+1. **One-shot KO test reliability**: depends on real battle damage math. If the damage roll is non-deterministic, the "knocks out on one hit" assumption may flake. Mitigation: use `TOKENMON_TEST=1` + a fixed PRNG seed if the test harness supports one; otherwise stage a two-turn setup where the second turn is the guaranteed KO.
+2. **Partial-state race**: if the fainted side's CLI calls `--wait-next-event` before the daemon has pushed the fainted_switch envelope, the shift times out. Mitigation: generous timeouts (5s+) and explicit polling for the right envelope type in the test.
+3. **Switch index off-by-one**: SKILL.md uses 1-based labels, daemon uses 0-based indexes. PR44 already handled this for `move:N`; same subtraction applies to `switch:N`. Tests must be explicit.

--- a/skills/friendly-battle/SKILL.md
+++ b/skills/friendly-battle/SKILL.md
@@ -2,7 +2,7 @@
 description: "Tokenmon friendly battle. Real PvP turn loop against another player on the same network. Korean: 친선전, 친선 배틀, 배틀, 대전, friendly battle"
 ---
 
-Open a friendly battle session and fight another player in real-time turn-based combat. One player opens a room (`open`), shares the session code + host:port with their opponent, who then joins (`join`). Switch / surrender / leave are not yet available (coming in PR45/46).
+Open a friendly battle session and fight another player in real-time turn-based combat. One player opens a room (`open`), shares the session code + host:port with their opponent, who then joins (`join`). Switch and surrender are now supported (PR45). Leave is coming in PR46.
 
 ## Execute
 
@@ -12,9 +12,9 @@ Read the first token of `$ARGUMENTS`:
 
 - `open` → go to **Step 1a** (open flow)
 - `join` → go to **Step 1b** (join flow); the second token must be `<code>@<host>:<port>`
-- `status` → go to **Step 3** (status flow)
-- `help` or empty → go to **Step 4** (help flow)
-- anything else → print `알 수 없는 명령어: <token>` and go to **Step 4**
+- `status` → go to **Step 7** (status flow)
+- `help` or empty → go to **Step 8** (help flow)
+- anything else → print `알 수 없는 명령어: <token>` and go to **Step 8**
 
 ---
 
@@ -94,7 +94,8 @@ If `phase === 'aborted'`: show the REASON from stderr and stop.
 
 2. Parse the returned envelope. Dispatch on `status`:
 
-   - **`select_action`**: build a move-select AskUserQuestion (see below).
+   - **`select_action`**: build a move-select AskUserQuestion (see **Step 3** below).
+   - **`fainted_switch`**: go directly to **Step 6** (forced switch — no move menu).
    - **`victory`**: show "승리! 배틀이 끝났습니다." and stop.
    - **`defeat`**: show "패배... 배틀이 끝났습니다." and stop.
    - **`aborted`**: read REASON from stderr, show it, and stop.
@@ -109,6 +110,8 @@ If `phase === 'aborted'`: show the REASON from stderr and stop.
    - Never add switch or surrender as buttons.
    - Rely on the auto-provided `Other` field for non-move intents.
 
+   **Non-negotiable input rule:** ALWAYS use **AskUserQuestion** for action selection. Never parse actions from plain chat. If the user types `1`, `공격`, `교체`, `항복`, or anything else in free chat during battle, ignore it as a battle command and re-open the correct AskUserQuestion UI.
+
    Parse the AskUserQuestion answer:
    - Button 1-4 on a shown move slot: call `--action`:
 
@@ -116,17 +119,74 @@ If `phase === 'aborted'`: show the REASON from stderr and stop.
 "$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --action "move:$N" --session "$SESSION_ID" --generation "$GEN"
 ```
 
-   - `Other` text matching `/^(교체|switch|change)$/i`: respond with "교체는 PR45에서 추가됩니다. 기술 버튼을 선택해 주세요." and re-ask the same AskUserQuestion.
-   - `Other` text matching `/^(항복|surrender|quit|gg)$/i`: respond with "항복은 PR45에서 추가됩니다. 기술 버튼을 선택해 주세요." and re-ask the same AskUserQuestion.
-   - Anything else in `Other`: show "알아들을 수 없어. 기술 버튼을 눌러줘." and re-ask.
+   - `Other` text matching `/^(교체|switch|change|s)$/i`: enter **Step 4** (switch menu).
+   - `Other` text matching `/^(항복|surrender|quit|giveup|gg)$/i`: enter **Step 5** (surrender confirm).
+   - Anything else in `Other`: show "알아들을 수 없어. 기술 버튼을 누르거나 \"교체\" / \"항복\" 을 입력해줘." and re-ask.
 
-4. After `--action` returns an ack envelope, parse `animationFrames`:
+3a. After `--action` returns an ack envelope, parse `animationFrames`:
    - If `animationFrames.length === 0`: loop back to step 1 immediately.
-   - If frames exist: display each frame's description as a message (no sleep loop for PR44). After displaying all frames, loop back to step 1.
+   - If frames exist: display each frame's description as a message. After displaying all frames, loop back to step 1.
 
 ---
 
-### Step 3 — Status flow
+### Step 4 — Switch flow (user opens switch menu during a normal turn)
+
+If the user's AskUserQuestion Other response matches `/^(교체|switch|change|s)$/i`, open a SECOND AskUserQuestion listing live party members from `partyOptions`:
+
+- Label each live option as `{index}. {name} HP:{hp}/{maxHp}`
+- Mark fainted members as unavailable (label with `기절`)
+- Show up to 4 party members; more via Other text match by name
+
+On button pick (index N, 1-based): run:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --action "switch:$N" --session "$SESSION_ID" --generation "$GEN"
+```
+
+On invalid Other (no name match): re-ask the switch AskUserQuestion.
+On cancel or no live members available: return to the move AskUserQuestion.
+
+After `--action switch:$N` returns an ack, loop back to Step 2 (wait-next-event).
+
+---
+
+### Step 5 — Surrender flow
+
+Show a confirm AskUserQuestion:
+
+- Question: `정말 항복할거야? 상대에게 승리가 돌아갑니다.`
+- Options: `항복 확정`, `취소`
+
+On `항복 확정`: run:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --action surrender --session "$SESSION_ID" --generation "$GEN"
+```
+
+On `취소`: return to the move AskUserQuestion (Step 3).
+
+After `--action surrender` returns an ack, loop back to Step 2 (wait-next-event).
+
+---
+
+### Step 6 — Forced switch flow (after a Pokémon faints)
+
+When `--wait-next-event` returns an envelope with `status === 'fainted_switch'`, skip the move AskUserQuestion entirely and go straight to the party AskUserQuestion from Step 4 — but with cancel disabled. The user MUST pick a live party member.
+
+- Show `questionContext` (e.g. "Your Pokémon fainted — pick a replacement") as the question text.
+- List all party members from `partyOptions`. Mark fainted members as unavailable.
+- Do NOT offer a cancel option.
+- On pick (index N, 1-based): run:
+
+```bash
+"$P/bin/tsx-resolve.sh" "$P/src/cli/friendly-battle-turn.ts" --action "switch:$N" --session "$SESSION_ID" --generation "$GEN"
+```
+
+After `--action switch:$N` returns an ack, loop back to Step 2. The daemon handles the forced switch without an extra AI turn.
+
+---
+
+### Step 7 — Status flow
 
 Requires a stored `sessionId` from the current session. If no session is active, tell the user to run `/tkm:friendly-battle open` or `/tkm:friendly-battle join` first and stop.
 
@@ -140,7 +200,7 @@ Parse the JSON envelope and report `phase` and `status` to the user. This comman
 
 ---
 
-### Step 4 — Help flow
+### Step 8 — Help flow
 
 Show:
 
@@ -151,7 +211,8 @@ Show:
 /tkm:friendly-battle help                       — 이 도움말 표시
 
 /open 실행 후 출력된 세션 코드와 host:port 를 상대방과 공유하세요.
-교체 / 항복 / 나가기는 PR45/46에서 추가됩니다.
+교체(switch) / 항복(surrender)은 배틀 중 기술 선택 AskUserQuestion의 Other에 입력하세요.
+나가기(leave)는 PR46에서 추가됩니다.
 ```
 
 ---
@@ -193,3 +254,11 @@ Show:
 | `/tkm:friendly-battle join <code>@<host>:<port>` | Join an open room |
 | `/tkm:friendly-battle status` | Check current session phase |
 | `/tkm:friendly-battle help` | Show this help |
+
+### Battle actions (via `--action` in bash blocks)
+
+| Token | Description |
+|---|---|
+| `move:<N>` | Use move slot N (1-based, 1-4) |
+| `switch:<N>` | Switch to party member N (1-based, 1-6) |
+| `surrender` | Forfeit the battle (opponent wins) |

--- a/src/cli/friendly-battle-turn.ts
+++ b/src/cli/friendly-battle-turn.ts
@@ -504,16 +504,15 @@ async function runAction(flags: Record<string, string | boolean | undefined>): P
   const generation = validateGeneration(asStringFlag(flags, 'generation'));
   const token = requireFlag(flags, 'action');
 
-  let action: { kind: 'move'; index: number };
-  const moveMatch = /^move:([1-4])$/.exec(token);
-  if (moveMatch) {
-    action = { kind: 'move', index: Number.parseInt(moveMatch[1], 10) - 1 };
-  } else if (/^switch:\d+$/.test(token)) {
-    process.stderr.write(`REASON: switch action not implemented until PR45\n`);
-    process.exit(2);
+  let action: import('../friendly-battle/daemon-protocol.js').DaemonAction;
+  if (/^move:([1-4])$/.test(token)) {
+    const match = /^move:([1-4])$/.exec(token)!;
+    action = { kind: 'move', index: Number.parseInt(match[1], 10) - 1 };
+  } else if (/^switch:([1-6])$/.test(token)) {
+    const match = /^switch:([1-6])$/.exec(token)!;
+    action = { kind: 'switch', pokemonIndex: Number.parseInt(match[1], 10) - 1 };
   } else if (token === 'surrender') {
-    process.stderr.write(`REASON: surrender action not implemented until PR45\n`);
-    process.exit(2);
+    action = { kind: 'surrender' };
   } else {
     process.stderr.write(`REASON: unknown action token ${JSON.stringify(token)}\n`);
     process.exit(1);

--- a/src/friendly-battle/battle-adapter.ts
+++ b/src/friendly-battle/battle-adapter.ts
@@ -255,12 +255,16 @@ function finalizeResolution(
   return events;
 }
 
-function getWaitingFor(runtime: FriendlyBattleBattleRuntime): FriendlyBattleRole[] {
+export function getFriendlyBattleWaitingForRoles(runtime: FriendlyBattleBattleRuntime): FriendlyBattleRole[] {
   const expectedRoles: FriendlyBattleRole[] = runtime.phase === 'awaiting_fainted_switch'
     ? computeRequiredSwitchWaiters(runtime.state)
     : ['host', 'guest'];
 
   return expectedRoles.filter((role) => runtime.pendingChoices[role] === undefined);
+}
+
+function getWaitingFor(runtime: FriendlyBattleBattleRuntime): FriendlyBattleRole[] {
+  return getFriendlyBattleWaitingForRoles(runtime);
 }
 
 function computeRequiredSwitchWaiters(state: BattleState): FriendlyBattleRole[] {

--- a/src/friendly-battle/daemon-protocol.ts
+++ b/src/friendly-battle/daemon-protocol.ts
@@ -7,8 +7,9 @@ export type DaemonRequest =
   | { op: 'ping' };
 
 export type DaemonAction =
-  | { kind: 'move'; index: number };
-  // switch/surrender land in PR45 — add variants there, not here
+  | { kind: 'move'; index: number }
+  | { kind: 'switch'; pokemonIndex: number }
+  | { kind: 'surrender' };
 
 export type DaemonResponse =
   | { op: 'event'; envelope: FriendlyBattleTurnJson }

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -272,8 +272,9 @@ function eventStatus(
 
 function serializeDaemonAction(action: DaemonAction): string {
   switch (action.kind) {
-    case 'move':
-      return `move:${action.index}`;
+    case 'move': return `move:${action.index}`;
+    case 'switch': return `switch:${action.pokemonIndex}`;
+    case 'surrender': return 'surrender';
   }
 }
 

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -211,14 +211,19 @@ function eventToEnvelopeFields(
         currentFrameIndex: 0,
       };
     case 'choices_requested': {
-      const moveOptions = runtime
-        ? buildMoveOptionsFromRuntime(runtime, role)
-        : (ownSnapshot ? buildMoveOptionsFromSnapshot(ownSnapshot) : []);
+      const isFaintedSwitch = event.phase === 'awaiting_fainted_switch';
+      const moveOptions = isFaintedSwitch
+        ? []
+        : (runtime
+            ? buildMoveOptionsFromRuntime(runtime, role)
+            : (ownSnapshot ? buildMoveOptionsFromSnapshot(ownSnapshot) : []));
       const partyOptions = runtime
         ? buildPartyOptionsFromRuntime(runtime, role)
         : (ownSnapshot ? buildPartyOptionsFromSnapshot(ownSnapshot) : []);
       return {
-        questionContext: `Turn ${event.turn}: Choose your action`,
+        questionContext: isFaintedSwitch
+          ? 'Your Pokémon fainted — pick a replacement'
+          : `Turn ${event.turn}: Choose your action`,
         moveOptions,
         partyOptions,
         animationFrames: [],

--- a/src/friendly-battle/daemon.ts
+++ b/src/friendly-battle/daemon.ts
@@ -24,6 +24,7 @@ import {
 } from './spike/tcp-direct.js';
 import {
   createFriendlyBattleBattleRuntime,
+  getFriendlyBattleWaitingForRoles,
   submitFriendlyBattleChoice,
 } from './battle-adapter.js';
 import {
@@ -516,15 +517,28 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
       // Host turn loop
       // ---------------------------------------------------------------------------
       while (runtime.phase !== 'completed') {
-        // Wait for both host action (from UNIX socket) and guest choice (from TCP)
-        const [hostEnvelope, guestEnvelope] = await Promise.all([
-          localActionQueue.shift(timeoutMs, 'host action'),
-          host_transport.waitForGuestChoice(timeoutMs),
-        ]);
+        // Consult the adapter to learn which roles still need to submit this turn.
+        // During awaiting_fainted_switch only the fainted side(s) submit; both
+        // submit during normal turns. Skipping the non-waiting side avoids the
+        // "not waiting for X" error that the unconditional Promise.all caused.
+        const waitingFor = getFriendlyBattleWaitingForRoles(runtime);
 
-        // submitFriendlyBattleChoice requires two calls; first returns [], second returns events
-        submitFriendlyBattleChoice(runtime, hostEnvelope);
-        const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
+        const hostPromise = waitingFor.includes('host')
+          ? localActionQueue.shift(timeoutMs, 'host action')
+          : Promise.resolve(null as FriendlyBattleChoiceEnvelope | null);
+
+        const guestPromise = waitingFor.includes('guest')
+          ? host_transport.waitForGuestChoice(timeoutMs)
+          : Promise.resolve(null as FriendlyBattleChoiceEnvelope | null);
+
+        const [hostEnvelope, guestEnvelope] = await Promise.all([hostPromise, guestPromise]);
+
+        // Submit whichever side(s) actually had pending actions this turn.
+        // The final submit (when all required roles have submitted) returns the
+        // resolved event list; earlier submits return [].
+        let resolvedEvents: FriendlyBattleBattleEvent[] = [];
+        if (hostEnvelope) resolvedEvents = submitFriendlyBattleChoice(runtime, hostEnvelope);
+        if (guestEnvelope) resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
 
         // Push events to local queue and send to guest
         for (const event of resolvedEvents) {
@@ -589,19 +603,31 @@ async function runDaemon(role: FriendlyBattleRole, options: DaemonOptions): Prom
     record.status = 'select_action';
     writeRecord();
 
-    // Synthesize an initial choices_requested event from own snapshot so the
-    // guest has something to display before the first real TCP event arrives.
-    const initialChoicesEvent: FriendlyBattleBattleEvent = {
-      type: 'choices_requested',
-      turn: 1,
-      waitingFor: ['host', 'guest'],
-      phase: 'waiting_for_choices',
-    };
-    localEventQueue.push(initialChoicesEvent);
-
     // We don't actually need the battleId from started for anything, but keep
     // the variable to silence unused-import TS noise
     void started;
+
+    // Drain the TCP init events (battle_initialized + choices_requested) that
+    // the host sent before the guest connected. These are buffered in the TCP
+    // transport and must be flushed into the local event queue NOW so they are
+    // not interleaved with the real turn-resolution events that arrive after the
+    // guest's first action.  We drain until the first choices_requested event,
+    // which mirrors the inner-pump exit condition used inside the turn loop.
+    //
+    // Before this drain the guest has no events in localEventQueue. After it,
+    // the queue contains the real initial events from the host (battle_initialized
+    // + choices_requested(waiting_for_choices)) so the first wait_next_event call
+    // from the IPC client returns the correct event.
+    {
+      let initDone = false;
+      while (!initDone) {
+        const initEvent = await guest_transport.waitForBattleEvent(timeoutMs);
+        localEventQueue.push(initEvent);
+        if (initEvent.type === 'choices_requested' || initEvent.type === 'battle_finished') {
+          initDone = true;
+        }
+      }
+    }
 
     // ---------------------------------------------------------------------------
     // Guest turn loop

--- a/src/friendly-battle/session-store.ts
+++ b/src/friendly-battle/session-store.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve, sep } from 'node:path';
+import { randomUUID } from 'node:crypto';
 
 export type FriendlyBattlePhase =
   | 'waiting_for_guest'
@@ -92,9 +93,19 @@ export function friendlyBattleSessionRecordPath(sessionId: string, generation: s
 export function writeFriendlyBattleSessionRecord(record: FriendlyBattleSessionRecord): void {
   const path = friendlyBattleSessionRecordPath(record.sessionId, record.generation);
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-  const tmpPath = `${path}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(record, null, 2), 'utf8');
-  renameSync(tmpPath, path);
+  // Unique tmp suffix per writer so two processes (e.g. daemon + test helper)
+  // racing on the same sessionId never collide on the same .tmp path and
+  // hit ENOENT when a second writer renames the first writer's file away.
+  const tmpPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(tmpPath, JSON.stringify(record, null, 2), 'utf8');
+    renameSync(tmpPath, path);
+  } finally {
+    // Best-effort: if renameSync threw, unlink the orphaned tmp.
+    if (existsSync(tmpPath)) {
+      try { unlinkSync(tmpPath); } catch { /* swallow */ }
+    }
+  }
 }
 
 export function readFriendlyBattleSessionRecord(

--- a/test/friendly-battle-daemon-fainted-switch.test.ts
+++ b/test/friendly-battle-daemon-fainted-switch.test.ts
@@ -1,0 +1,67 @@
+// test/friendly-battle-daemon-fainted-switch.test.ts
+//
+// End-to-end integration test: fainted forced-switch through the daemon + IPC stack.
+//
+// STATUS: Marked .todo() — see detailed explanation below.
+//
+// Root cause analysis
+// ───────────────────
+// The host daemon's turn loop (daemon.ts lines 518-543) unconditionally waits for
+// BOTH a host IPC action (localActionQueue.shift) AND a guest TCP choice
+// (waitForGuestChoice) on every iteration, regardless of the current phase:
+//
+//   while (runtime.phase !== 'completed') {
+//     const [hostEnvelope, guestEnvelope] = await Promise.all([
+//       localActionQueue.shift(timeoutMs, 'host action'),
+//       host_transport.waitForGuestChoice(timeoutMs),
+//     ]);
+//     submitFriendlyBattleChoice(runtime, hostEnvelope);   // ← throws during single-side fainted_switch
+//     const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
+//
+// When only ONE side's active pokemon has fainted (the common case), the
+// battle-adapter's submitFriendlyBattleChoice validates:
+//
+//   const waitingFor = getWaitingFor(runtime); // e.g. ['guest'] — only the fainted side
+//   if (!waitingFor.includes(envelope.actor)) {
+//     throw new Error(`Friendly battle is not waiting for ${envelope.actor}`);
+//   }
+//
+// If the host's pokemon DIDN'T faint, submitting the host envelope throws
+// "not waiting for host". If the guest's pokemon DIDN'T faint, submitting
+// the guest envelope throws "not waiting for guest".
+//
+// The daemon would need to check runtime.phase / getWaitingFor BEFORE calling
+// Promise.all so it can skip the irrelevant side during awaiting_fainted_switch.
+// That is a source change to daemon.ts, which is out of scope for this PR.
+//
+// Proposed follow-up
+// ──────────────────
+// In the next daemon iteration (PR45.5 or PR46), update the host turn loop to:
+//
+//   const waitingFor = getWaitingForRoles(runtime);  // expose from battle-adapter
+//   const [hostEnvelope, guestEnvelope] = await Promise.all([
+//     waitingFor.includes('host') ? localActionQueue.shift(timeoutMs, 'host action') : Promise.resolve(null),
+//     waitingFor.includes('guest') ? host_transport.waitForGuestChoice(timeoutMs) : Promise.resolve(null),
+//   ]);
+//   if (hostEnvelope) submitFriendlyBattleChoice(runtime, hostEnvelope);
+//   if (guestEnvelope) {
+//     const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
+//     ...
+//   }
+//
+// Until then, the integration test for single-side fainted switch cannot pass
+// through the daemon layer. The battle-adapter and battle-state layers are
+// correct and covered by unit tests (friendly-battle-battle-adapter.test.ts,
+// turn-battle.test.ts). This test is deferred.
+
+import { describe, it } from 'node:test';
+
+describe('friendly-battle daemon fainted forced-switch (end-to-end)', () => {
+  it.todo(
+    'guest fainted switch: after KO, guest sees fainted_switch status and battle continues after switch action',
+    // Blocked: daemon.ts host turn loop does not handle single-side awaiting_fainted_switch.
+    // When only the guest's pokemon has fainted, submitFriendlyBattleChoice throws
+    // "Friendly battle is not waiting for host" when the host's action is submitted.
+    // See file-level comment for full analysis and proposed fix.
+  );
+});

--- a/test/friendly-battle-daemon-fainted-switch.test.ts
+++ b/test/friendly-battle-daemon-fainted-switch.test.ts
@@ -2,66 +2,391 @@
 //
 // End-to-end integration test: fainted forced-switch through the daemon + IPC stack.
 //
-// STATUS: Marked .todo() — see detailed explanation below.
+// The host daemon's turn loop was fixed to consult getFriendlyBattleWaitingForRoles
+// before awaiting choices, so only the role(s) that need to submit are awaited each
+// iteration. This prevents the "not waiting for X" error during awaiting_fainted_switch
+// when only the fainted side needs to submit a switch action.
 //
-// Root cause analysis
-// ───────────────────
-// The host daemon's turn loop (daemon.ts lines 518-543) unconditionally waits for
-// BOTH a host IPC action (localActionQueue.shift) AND a guest TCP choice
-// (waitForGuestChoice) on every iteration, regardless of the current phase:
+// The guest daemon's startup path was also fixed to eagerly drain the TCP init events
+// (battle_initialized + choices_requested) that the host sends before the guest's first
+// action. Without this drain, the init events would interleave with the real turn
+// resolution events and confuse the post-turn event ordering.
 //
-//   while (runtime.phase !== 'completed') {
-//     const [hostEnvelope, guestEnvelope] = await Promise.all([
-//       localActionQueue.shift(timeoutMs, 'host action'),
-//       host_transport.waitForGuestChoice(timeoutMs),
-//     ]);
-//     submitFriendlyBattleChoice(runtime, hostEnvelope);   // ← throws during single-side fainted_switch
-//     const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
+// Party setup:
+//   Host: Turtwig lv80 (starter) + Turtwig lv5 (backup) — from hostClaudeDir
+//   Guest: Cyndaquil lv1 (starter, guaranteed KO by lv80 Tackle) + Chikorita lv5 (backup)
+//   Both sides use separate CLAUDE_CONFIG_DIR so each loads its own profile.
 //
-// When only ONE side's active pokemon has fainted (the common case), the
-// battle-adapter's submitFriendlyBattleChoice validates:
-//
-//   const waitingFor = getWaitingFor(runtime); // e.g. ['guest'] — only the fainted side
-//   if (!waitingFor.includes(envelope.actor)) {
-//     throw new Error(`Friendly battle is not waiting for ${envelope.actor}`);
-//   }
-//
-// If the host's pokemon DIDN'T faint, submitting the host envelope throws
-// "not waiting for host". If the guest's pokemon DIDN'T faint, submitting
-// the guest envelope throws "not waiting for guest".
-//
-// The daemon would need to check runtime.phase / getWaitingFor BEFORE calling
-// Promise.all so it can skip the irrelevant side during awaiting_fainted_switch.
-// That is a source change to daemon.ts, which is out of scope for this PR.
-//
-// Proposed follow-up
-// ──────────────────
-// In the next daemon iteration (PR45.5 or PR46), update the host turn loop to:
-//
-//   const waitingFor = getWaitingForRoles(runtime);  // expose from battle-adapter
-//   const [hostEnvelope, guestEnvelope] = await Promise.all([
-//     waitingFor.includes('host') ? localActionQueue.shift(timeoutMs, 'host action') : Promise.resolve(null),
-//     waitingFor.includes('guest') ? host_transport.waitForGuestChoice(timeoutMs) : Promise.resolve(null),
-//   ]);
-//   if (hostEnvelope) submitFriendlyBattleChoice(runtime, hostEnvelope);
-//   if (guestEnvelope) {
-//     const resolvedEvents = submitFriendlyBattleChoice(runtime, guestEnvelope);
-//     ...
-//   }
-//
-// Until then, the integration test for single-side fainted switch cannot pass
-// through the daemon layer. The battle-adapter and battle-state layers are
-// correct and covered by unit tests (friendly-battle-battle-adapter.test.ts,
-// turn-battle.test.ts). This test is deferred.
+// Expected flow:
+//   1. Both reach select_action (host via real init events; guest via real TCP init drain)
+//   2. Both submit move:0 (Tackle)
+//   3. Host's lv80 Turtwig one-shots guest's lv1 Cyndaquil → awaiting_fainted_switch
+//   4. Guest sees fainted_switch; host also sees it (the event phase is awaiting_fainted_switch)
+//   5. Guest submits switch:1 (Chikorita lv5)
+//   6. Both drain to select_action (next turn) — battle continues
 
-import { describe, it } from 'node:test';
+import { after, afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { sendDaemonIpcRequest } from '../src/friendly-battle/daemon-ipc.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const DAEMON_ENTRY = resolve(REPO_ROOT, 'src/friendly-battle/daemon.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Host: Turtwig lv80 (strong starter) + Turtwig lv5 backup
+function makeHostClaudeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tkm-fb-host-'));
+  const genDir = join(dir, 'tokenmon', 'gen4');
+  mkdirSync(genDir, { recursive: true });
+  writeFileSync(
+    join(genDir, 'config.json'),
+    JSON.stringify({ party: ['387', '387b'], starter_chosen: true }),
+  );
+  writeFileSync(
+    join(genDir, 'state.json'),
+    JSON.stringify({
+      pokemon: {
+        '387': { id: 387, xp: 500_000, level: 80, friendship: 0, ev: 0, moves: [33, 45, 53, 89] },
+        '387b': { id: 387, xp: 0, level: 5, friendship: 0, ev: 0, moves: [33] },
+      },
+    }),
+  );
+  return dir;
+}
+
+// Guest: Cyndaquil lv1 (guaranteed KO by host's lv80) + Chikorita lv5 backup
+function makeGuestClaudeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tkm-fb-guest-'));
+  const genDir = join(dir, 'tokenmon', 'gen4');
+  mkdirSync(genDir, { recursive: true });
+  writeFileSync(
+    join(genDir, 'config.json'),
+    JSON.stringify({ party: ['155', '152'], starter_chosen: true }),
+  );
+  writeFileSync(
+    join(genDir, 'state.json'),
+    JSON.stringify({
+      pokemon: {
+        '155': { id: 155, xp: 0, level: 1, friendship: 0, ev: 0, moves: [33] },
+        '152': { id: 152, xp: 0, level: 5, friendship: 0, ev: 0, moves: [33] },
+      },
+    }),
+  );
+  return dir;
+}
+
+function encodeOptionsJson(options: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(options)).toString('base64');
+}
+
+interface DaemonInfo {
+  child: ChildProcess;
+  sessionId: string;
+  socketPath: string;
+  port?: number;
+}
+
+function spawnDaemon(
+  role: 'host' | 'guest',
+  options: Record<string, unknown>,
+  claudeDir: string,
+): Promise<DaemonInfo> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', DAEMON_ENTRY, '--role', role],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: claudeDir,
+          TSX_DISABLE_CACHE: '1',
+          TOKENMON_TEST: '1',
+          TKM_FB_OPTIONS_B64: encodeOptionsJson(options),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      },
+    );
+
+    let stdoutBuf = '';
+    let settled = false;
+
+    child.stdout!.setEncoding('utf8');
+    child.stdout!.on('data', (chunk: string) => {
+      stdoutBuf += chunk;
+      const newline = stdoutBuf.indexOf('\n');
+      if (newline < 0) return;
+      const line = stdoutBuf.slice(0, newline).trim();
+      if (!line.startsWith('DAEMON_READY ')) return;
+      const parts = line.split(' ');
+      const sessionId = parts[1];
+      const socketPath = parts[2];
+      const port = parts[3] ? Number.parseInt(parts[3], 10) : undefined;
+      if (!sessionId || !socketPath) {
+        reject(new Error(`Malformed DAEMON_READY line: ${JSON.stringify(line)}`));
+        return;
+      }
+      if (!settled) {
+        settled = true;
+        resolve({ child, sessionId, socketPath, port });
+      }
+    });
+
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (_chunk: string) => {
+      // Uncomment for debugging: process.stderr.write(`[${role}] ${_chunk}`);
+    });
+
+    child.once('error', (err) => {
+      if (!settled) { settled = true; reject(err); }
+    });
+
+    child.once('close', (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`${role} daemon exited with code ${code} before DAEMON_READY`));
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill('SIGTERM');
+        reject(new Error(`${role} daemon did not emit DAEMON_READY within 10s`));
+      }
+    }, 10_000);
+    if (timer.unref) timer.unref();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup bookkeeping
+// ---------------------------------------------------------------------------
+
+const liveChildren: ChildProcess[] = [];
+
+afterEach(() => {
+  for (const child of liveChildren.splice(0)) {
+    if (child.exitCode === null && !child.killed) child.kill('SIGKILL');
+  }
+});
+
+after(() => {
+  for (const child of liveChildren) {
+    if (child.exitCode === null && !child.killed) child.kill('SIGKILL');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
 
 describe('friendly-battle daemon fainted forced-switch (end-to-end)', () => {
-  it.todo(
+  it(
     'guest fainted switch: after KO, guest sees fainted_switch status and battle continues after switch action',
-    // Blocked: daemon.ts host turn loop does not handle single-side awaiting_fainted_switch.
-    // When only the guest's pokemon has fainted, submitFriendlyBattleChoice throws
-    // "Friendly battle is not waiting for host" when the host's action is submitted.
-    // See file-level comment for full analysis and proposed fix.
+    { timeout: 20_000 },
+    async () => {
+      const hostClaudeDir = makeHostClaudeConfigDir();
+      const guestClaudeDir = makeGuestClaudeConfigDir();
+      try {
+        const sessionId = `test-${Date.now()}`;
+        const sessionCode = 'fainted-01';
+
+        // Spawn host (lv80 Turtwig leads)
+        const hostInfo = await spawnDaemon(
+          'host',
+          {
+            sessionId: `${sessionId}-host`,
+            sessionCode,
+            host: '127.0.0.1',
+            port: 0,
+            generation: 'gen4',
+            playerName: 'HostPlayer',
+            timeoutMs: 15_000,
+          },
+          hostClaudeDir,
+        );
+        liveChildren.push(hostInfo.child);
+        assert.ok(hostInfo.port && hostInfo.port > 0, `host port must be > 0, got ${hostInfo.port}`);
+
+        // Spawn guest (lv1 Cyndaquil leads — guaranteed KO by host's lv80 Turtwig Tackle)
+        const guestInfo = await spawnDaemon(
+          'guest',
+          {
+            sessionId: `${sessionId}-guest`,
+            sessionCode,
+            host: '127.0.0.1',
+            port: hostInfo.port,
+            generation: 'gen4',
+            playerName: 'GuestPlayer',
+            timeoutMs: 15_000,
+          },
+          guestClaudeDir,
+        );
+        liveChildren.push(guestInfo.child);
+
+        // ── Step 1: drain initial events until both sides reach select_action ──
+        // Host emits: battle_initialized → choices_requested(select_action)
+        // Guest now eagerly drains TCP init events on startup, so it also gets
+        // battle_initialized → choices_requested(select_action) from the real TCP flow.
+        async function drainToSelectAction(socketPath: string, label: string): Promise<void> {
+          for (let i = 0; i < 5; i++) {
+            const ev = await sendDaemonIpcRequest(
+              socketPath,
+              { op: 'wait_next_event', timeoutMs: 4_000 },
+              5_000,
+            );
+            if (ev.op === 'error') throw new Error(`${label} IPC error: ${(ev as { message: string }).message}`);
+            assert.equal(ev.op, 'event', `${label}: expected event op, got ${ev.op}`);
+            if (ev.op === 'event' && ev.envelope.status === 'select_action') {
+              assert.ok(
+                Array.isArray(ev.envelope.moveOptions) && ev.envelope.moveOptions.length > 0,
+                `${label}: choices_requested should include moveOptions`,
+              );
+              return;
+            }
+          }
+          throw new Error(`${label}: Never reached select_action`);
+        }
+
+        await Promise.all([
+          drainToSelectAction(hostInfo.socketPath, 'host'),
+          drainToSelectAction(guestInfo.socketPath, 'guest'),
+        ]);
+
+        // ── Step 2: both sides submit move index 0 concurrently ──
+        // The host's lv80 Turtwig uses Tackle on the guest's lv1 Cyndaquil.
+        // Damage range: ~523–616 vs 11 HP → guaranteed one-shot KO.
+        // The host daemon's fixed turn loop only awaits the guest switch (not
+        // a host action) during the resulting awaiting_fainted_switch phase.
+        const [hostAck, guestAck] = await Promise.all([
+          sendDaemonIpcRequest(
+            hostInfo.socketPath,
+            { op: 'submit_action', action: { kind: 'move', index: 0 } },
+            5_000,
+          ),
+          sendDaemonIpcRequest(
+            guestInfo.socketPath,
+            { op: 'submit_action', action: { kind: 'move', index: 0 } },
+            5_000,
+          ),
+        ]);
+
+        assert.equal(hostAck.op, 'ack', `host move ack expected, got ${hostAck.op}`);
+        assert.equal(guestAck.op, 'ack', `guest move ack expected, got ${guestAck.op}`);
+
+        // ── Step 3: drain events until fainted_switch appears on at least one side ──
+        // Both sides get turn_resolved (ongoing) first, then choices_requested
+        // with phase=awaiting_fainted_switch (status=fainted_switch).
+        async function drainUntilFaintedSwitch(socketPath: string, label: string): Promise<boolean> {
+          for (let i = 0; i < 10; i++) {
+            const ev = await sendDaemonIpcRequest(
+              socketPath,
+              { op: 'wait_next_event', timeoutMs: 4_000 },
+              5_000,
+            );
+            if (ev.op === 'error') throw new Error(`${label} IPC error at attempt ${i}: ${(ev as { message: string }).message}`);
+            assert.equal(ev.op, 'event', `${label}: expected event op after moves, got ${ev.op}`);
+            if (ev.op === 'event') {
+              const status = ev.envelope.status;
+              if (status === 'fainted_switch') return true;
+              // If both sides fainted simultaneously the battle may end immediately
+              if (status === 'victory' || status === 'defeat') return false;
+              // 'ongoing' (turn_resolved) — keep draining
+            }
+          }
+          throw new Error(`${label}: never reached fainted_switch or terminal within 10 events`);
+        }
+
+        const [hostFainted, guestFainted] = await Promise.all([
+          drainUntilFaintedSwitch(hostInfo.socketPath, 'host'),
+          drainUntilFaintedSwitch(guestInfo.socketPath, 'guest'),
+        ]);
+
+        // The guest's lv1 Cyndaquil should have fainted; host's lv80 is fine.
+        // The choices_requested(awaiting_fainted_switch) event has waitingFor: ['guest']
+        // but the host IPC also returns status=fainted_switch for the same event.
+        assert.ok(
+          hostFainted || guestFainted,
+          'at least one side should be in fainted_switch state after the KO turn',
+        );
+
+        // ── Step 4: submit switch:1 on the fainted side(s) ──
+        // The backup pokemon is at index 1 in each party.
+        const switchPromises: Promise<void>[] = [];
+
+        if (hostFainted) {
+          switchPromises.push(
+            sendDaemonIpcRequest(
+              hostInfo.socketPath,
+              { op: 'submit_action', action: { kind: 'switch', pokemonIndex: 1 } },
+              5_000,
+            ).then((ack) => {
+              assert.equal(ack.op, 'ack', `host switch ack expected, got ${ack.op}`);
+            }),
+          );
+        }
+
+        if (guestFainted) {
+          switchPromises.push(
+            sendDaemonIpcRequest(
+              guestInfo.socketPath,
+              { op: 'submit_action', action: { kind: 'switch', pokemonIndex: 1 } },
+              5_000,
+            ).then((ack) => {
+              assert.equal(ack.op, 'ack', `guest switch ack expected, got ${ack.op}`);
+            }),
+          );
+        }
+
+        await Promise.all(switchPromises);
+
+        // ── Step 5: battle continues — drain to select_action or terminal ──
+        async function drainToSelectActionAfterSwitch(
+          socketPath: string,
+          label: string,
+        ): Promise<void> {
+          for (let i = 0; i < 10; i++) {
+            const ev = await sendDaemonIpcRequest(
+              socketPath,
+              { op: 'wait_next_event', timeoutMs: 4_000 },
+              5_000,
+            );
+            if (ev.op === 'error') throw new Error(`${label} post-switch IPC error: ${(ev as { message: string }).message}`);
+            assert.equal(ev.op, 'event', `${label}: expected event after switch, got ${ev.op}`);
+            if (ev.op === 'event') {
+              const status = ev.envelope.status;
+              // select_action = battle continues to next turn; victory/defeat = clean finish
+              if (status === 'select_action' || status === 'victory' || status === 'defeat') {
+                return;
+              }
+              // 'ongoing' (turn_resolved after switch) — keep draining
+            }
+          }
+          throw new Error(`${label}: never reached select_action or terminal after switch`);
+        }
+
+        const postSwitchPromises: Promise<void>[] = [];
+        if (hostFainted) {
+          postSwitchPromises.push(drainToSelectActionAfterSwitch(hostInfo.socketPath, 'host'));
+        }
+        if (guestFainted) {
+          postSwitchPromises.push(drainToSelectActionAfterSwitch(guestInfo.socketPath, 'guest'));
+        }
+
+        await Promise.all(postSwitchPromises);
+      } finally {
+        rmSync(hostClaudeDir, { recursive: true, force: true });
+        rmSync(guestClaudeDir, { recursive: true, force: true });
+      }
+    },
   );
 });

--- a/test/friendly-battle-daemon-protocol.test.ts
+++ b/test/friendly-battle-daemon-protocol.test.ts
@@ -12,6 +12,8 @@ describe('friendly-battle daemon protocol', () => {
     const variants: DaemonRequest[] = [
       { op: 'wait_next_event', timeoutMs: 1000 },
       { op: 'submit_action', action: { kind: 'move', index: 2 } },
+      { op: 'submit_action', action: { kind: 'switch', pokemonIndex: 1 } },
+      { op: 'submit_action', action: { kind: 'surrender' } },
       { op: 'status' },
       { op: 'ping' },
     ];

--- a/test/friendly-battle-daemon-surrender.test.ts
+++ b/test/friendly-battle-daemon-surrender.test.ts
@@ -1,0 +1,296 @@
+// test/friendly-battle-daemon-surrender.test.ts
+//
+// End-to-end integration test: explicit surrender through the daemon + IPC stack.
+// Spawns host + guest daemons, drives a handshake, then has host surrender while
+// guest submits a normal move. Asserts guest wins with reason='surrender'.
+
+import { after, afterEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { sendDaemonIpcRequest } from '../src/friendly-battle/daemon-ipc.js';
+import type { DaemonResponse } from '../src/friendly-battle/daemon-protocol.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const DAEMON_ENTRY = resolve(REPO_ROOT, 'src/friendly-battle/daemon.ts');
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrored from friendly-battle-daemon-turn-loop.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeClaudeConfigDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tkm-fb-surrender-'));
+  const genDir = join(dir, 'tokenmon', 'gen4');
+  mkdirSync(genDir, { recursive: true });
+  writeFileSync(
+    join(genDir, 'config.json'),
+    JSON.stringify({ party: ['387'], starter_chosen: true }),
+  );
+  writeFileSync(
+    join(genDir, 'state.json'),
+    JSON.stringify({
+      pokemon: {
+        '387': { id: 387, xp: 100, level: 16, friendship: 0, ev: 0, moves: [33, 45] },
+      },
+    }),
+  );
+  return dir;
+}
+
+function encodeOptionsJson(options: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(options)).toString('base64');
+}
+
+interface DaemonInfo {
+  child: ChildProcess;
+  sessionId: string;
+  socketPath: string;
+  port?: number;
+}
+
+function spawnDaemon(
+  role: 'host' | 'guest',
+  options: Record<string, unknown>,
+  claudeDir: string,
+): Promise<DaemonInfo> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', DAEMON_ENTRY, '--role', role],
+      {
+        env: {
+          ...process.env,
+          CLAUDE_CONFIG_DIR: claudeDir,
+          TSX_DISABLE_CACHE: '1',
+          TOKENMON_TEST: '1',
+          TKM_FB_OPTIONS_B64: encodeOptionsJson(options),
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: false,
+      },
+    );
+
+    let stdoutBuf = '';
+    let settled = false;
+
+    child.stdout!.setEncoding('utf8');
+    child.stdout!.on('data', (chunk: string) => {
+      stdoutBuf += chunk;
+      const newline = stdoutBuf.indexOf('\n');
+      if (newline < 0) return;
+      const line = stdoutBuf.slice(0, newline).trim();
+      if (!line.startsWith('DAEMON_READY ')) return;
+      const parts = line.split(' ');
+      const sessionId = parts[1];
+      const socketPath = parts[2];
+      const port = parts[3] ? Number.parseInt(parts[3], 10) : undefined;
+      if (!sessionId || !socketPath) {
+        reject(new Error(`Malformed DAEMON_READY line: ${JSON.stringify(line)}`));
+        return;
+      }
+      if (!settled) {
+        settled = true;
+        resolve({ child, sessionId, socketPath, port });
+      }
+    });
+
+    child.stderr!.setEncoding('utf8');
+    child.stderr!.on('data', (_chunk: string) => {
+      // Uncomment for debugging: process.stderr.write(`[${role}] ${_chunk}`);
+    });
+
+    child.once('error', (err) => {
+      if (!settled) { settled = true; reject(err); }
+    });
+
+    child.once('close', (code) => {
+      if (!settled) {
+        settled = true;
+        reject(new Error(`${role} daemon exited with code ${code} before DAEMON_READY`));
+      }
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill('SIGTERM');
+        reject(new Error(`${role} daemon did not emit DAEMON_READY within 10s`));
+      }
+    }, 10_000);
+    if (timer.unref) timer.unref();
+  });
+}
+
+function waitForExit(child: ChildProcess, timeoutMs: number): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    if (child.exitCode !== null) {
+      resolve(child.exitCode);
+      return;
+    }
+    const timer = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`Process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+    if (timer.unref) timer.unref();
+    child.once('close', (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+// Drain events on a daemon socket until a terminal status (victory/defeat) is seen,
+// submitting additional moves if we see select_action (multi-turn fallback).
+async function drainUntilDone(socketPath: string, maxEvents = 20): Promise<DaemonResponse> {
+  for (let i = 0; i < maxEvents; i++) {
+    const ev = await sendDaemonIpcRequest(
+      socketPath,
+      { op: 'wait_next_event', timeoutMs: 10_000 },
+      11_000,
+    );
+    if (ev.op !== 'event') return ev;
+    const status = ev.envelope.status;
+    if (status === 'victory' || status === 'defeat') return ev;
+    if (status === 'select_action') {
+      // Unexpected second turn — submit a move to keep the battle moving
+      await sendDaemonIpcRequest(
+        socketPath,
+        { op: 'submit_action', action: { kind: 'move', index: 0 } },
+        5_000,
+      );
+    }
+  }
+  throw new Error(`Did not reach terminal status within ${maxEvents} events`);
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup bookkeeping
+// ---------------------------------------------------------------------------
+
+const liveChildren: ChildProcess[] = [];
+
+afterEach(() => {
+  for (const child of liveChildren.splice(0)) {
+    if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
+  }
+});
+
+after(() => {
+  for (const child of liveChildren) {
+    if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe('friendly-battle daemon surrender (end-to-end)', () => {
+  it(
+    'host surrender causes guest to win with reason=surrender',
+    { timeout: 30_000 },
+    async () => {
+      const claudeDir = makeClaudeConfigDir();
+      try {
+        const sessionId = `test-${Date.now()}`;
+        const sessionCode = 'surrender-01';
+
+        // Spawn host
+        const hostOptions = {
+          sessionId: `${sessionId}-host`,
+          sessionCode,
+          host: '127.0.0.1',
+          port: 0,
+          generation: 'gen4',
+          playerName: 'HostPlayer',
+          timeoutMs: 15_000,
+        };
+        const hostInfo = await spawnDaemon('host', hostOptions, claudeDir);
+        liveChildren.push(hostInfo.child);
+
+        assert.ok(hostInfo.port && hostInfo.port > 0, `host port must be > 0, got ${hostInfo.port}`);
+
+        // Spawn guest
+        const guestOptions = {
+          sessionId: `${sessionId}-guest`,
+          sessionCode,
+          host: '127.0.0.1',
+          port: hostInfo.port,
+          generation: 'gen4',
+          playerName: 'GuestPlayer',
+          timeoutMs: 15_000,
+        };
+        const guestInfo = await spawnDaemon('guest', guestOptions, claudeDir);
+        liveChildren.push(guestInfo.child);
+
+        // ── Step 1: drain initial events until both sides reach select_action ──
+        // Host emits: battle_initialized → choices_requested(select_action)
+        // Guest synthesizes: choices_requested(select_action)
+        async function drainToSelectAction(socketPath: string): Promise<void> {
+          for (let i = 0; i < 5; i++) {
+            const ev = await sendDaemonIpcRequest(
+              socketPath,
+              { op: 'wait_next_event', timeoutMs: 5_000 },
+              6_000,
+            );
+            if (ev.op === 'event' && ev.envelope.status === 'select_action') return;
+          }
+          throw new Error('Never reached select_action');
+        }
+
+        await Promise.all([
+          drainToSelectAction(hostInfo.socketPath),
+          drainToSelectAction(guestInfo.socketPath),
+        ]);
+
+        // ── Step 2: both sides submit concurrently, then drain concurrently ──
+        // The key insight from the working turn-loop test: both drainUntilDone calls
+        // run concurrently via Promise.all, mirroring the pattern that works.
+        const [hostAck, guestAck] = await Promise.all([
+          sendDaemonIpcRequest(
+            hostInfo.socketPath,
+            { op: 'submit_action', action: { kind: 'surrender' } },
+            2_000,
+          ),
+          sendDaemonIpcRequest(
+            guestInfo.socketPath,
+            { op: 'submit_action', action: { kind: 'move', index: 0 } },
+            2_000,
+          ),
+        ]);
+
+        assert.equal(hostAck.op, 'ack', `host surrender ack expected, got ${hostAck.op}`);
+        assert.equal(guestAck.op, 'ack', `guest move ack expected, got ${guestAck.op}`);
+
+        // Drain final events on both sides concurrently — mirrors turn-loop test pattern
+        const [hostFinalEv, guestFinalEv] = await Promise.all([
+          drainUntilDone(hostInfo.socketPath),
+          drainUntilDone(guestInfo.socketPath),
+        ]);
+
+        assert.equal(hostFinalEv.op, 'event');
+        assert.equal(guestFinalEv.op, 'event');
+
+        const hostStatus = hostFinalEv.op === 'event' ? hostFinalEv.envelope.status : undefined;
+        const guestStatus = guestFinalEv.op === 'event' ? guestFinalEv.envelope.status : undefined;
+
+        assert.equal(hostStatus, 'defeat', `host should see defeat after surrendering, got ${hostStatus}`);
+        assert.equal(guestStatus, 'victory', `guest should see victory after host surrenders, got ${guestStatus}`);
+
+        // ── Step 3: both daemons exit cleanly ──
+        const [hostExit, guestExit] = await Promise.all([
+          waitForExit(hostInfo.child, 5_000),
+          waitForExit(guestInfo.child, 5_000),
+        ]);
+
+        assert.equal(hostExit, 0, `host daemon should exit 0, got ${hostExit}`);
+        assert.equal(guestExit, 0, `guest daemon should exit 0, got ${guestExit}`);
+      } finally {
+        rmSync(claudeDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/test/friendly-battle-skill-contract.test.ts
+++ b/test/friendly-battle-skill-contract.test.ts
@@ -48,10 +48,12 @@ describe('friendly-battle SKILL.md contract', () => {
       tokens.add(match[1]);
     }
 
-    // PR44 supports only move:<N>. switch/surrender are deferred with explicit errors.
-    // Template placeholders like move:<N> or move:$N count as move family.
+    // PR45 adds switch:<N> and surrender; move:<N> was already supported.
+    // Template placeholders like move:<N>, move:$N, switch:<N>, switch:$N count as their family.
     const accepted = (token: string): boolean => {
       if (/^move:[\d<$]/.test(token) || token === 'move:') return true;
+      if (/^switch:[\d<$]/.test(token) || token === 'switch:') return true;
+      if (token === 'surrender') return true;
       return false;
     };
 

--- a/test/friendly-battle-turn-driver.test.ts
+++ b/test/friendly-battle-turn-driver.test.ts
@@ -806,23 +806,35 @@ describe('friendly-battle-turn per-action subcommands', () => {
     // afterEachFb kills daemons + rmSync
   });
 
-  it('--action switch:1 errors with PR45 not-implemented (exit 2)', async () => {
+  it('--action switch:1 submits a switch action to the daemon', async () => {
     const claudeDir = makeSeededDir();
     cleanupDirs.push(claudeDir);
 
-    const sessionId = `switch-${Date.now()}`;
+    const sessionCode = `switch-${randomUUID().slice(0, 8)}`;
+    const sessionId = `host-switch-${Date.now()}`;
+
+    const hostInfo = await spawnFbDaemon('host', {
+      sessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: 0,
+      generation: 'gen4',
+      playerName: 'Host',
+      timeoutMs: 15_000,
+    }, claudeDir);
+
     writeRecordInDir(claudeDir, {
       sessionId,
       role: 'host',
       generation: 'gen4',
-      sessionCode: 'switch-test',
+      sessionCode,
       phase: 'battle',
       status: 'select_action',
-      transport: { host: '127.0.0.1', port: 9999 },
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
       opponent: { playerName: 'Guest' },
       pid: process.pid,
-      daemonPid: 1 << 22,
-      socketPath: joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions', `${sessionId}.sock`),
+      daemonPid: hostInfo.child.pid!,
+      socketPath: hostInfo.socketPath,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -833,27 +845,54 @@ describe('friendly-battle-turn per-action subcommands', () => {
       '--generation', 'gen4',
     ]);
 
-    assert.equal(result.exitCode, 2, `expected exit 2 for switch, got ${result.exitCode}\nstderr: ${result.stderr}`);
-    assert.match(result.stderr, /PR45/, 'stderr mentions PR45');
+    // The CLI parses switch:1 correctly and forwards to the daemon.
+    // The daemon accepts the action (exit 0 + ack envelope) or rejects it at the
+    // battle-adapter layer if the phase is not awaiting_fainted_switch (exit 1 +
+    // REASON containing "not waiting"). Both outcomes prove the CLI layer parses correctly.
+    const cliParsedOk = result.exitCode === 0 || (result.exitCode === 1 && /not waiting/i.test(result.stderr));
+    assert.ok(
+      cliParsedOk,
+      `expected exit 0 (ack) or exit 1 with "not waiting" REASON, got exit ${result.exitCode}\nstderr: ${result.stderr}\nstdout: ${result.stdout}`,
+    );
+    // Must NOT be the old PR45 "not implemented" error
+    assert.ok(!/PR45/i.test(result.stderr), `stderr must not mention PR45: ${result.stderr}`);
+
+    hostInfo.child.kill('SIGTERM');
   });
 
-  it('--action surrender errors with PR45 not-implemented (exit 2)', async () => {
+  it('--action surrender submits a surrender action to the daemon', async () => {
     const claudeDir = makeSeededDir();
     cleanupDirs.push(claudeDir);
 
-    const sessionId = `surrender-${Date.now()}`;
+    const sessionCode = `surrender-${randomUUID().slice(0, 8)}`;
+    const sessionId = `host-surrender-${Date.now()}`;
+
+    const hostInfo = await spawnFbDaemon('host', {
+      sessionId,
+      sessionCode,
+      host: '127.0.0.1',
+      port: 0,
+      generation: 'gen4',
+      playerName: 'Host',
+      timeoutMs: 15_000,
+    }, claudeDir);
+
+    // Ensure the sessions directory exists before writing the record
+    // (the daemon creates it before DAEMON_READY, but guarantee it here)
+    mkdirSync(joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions'), { recursive: true });
+
     writeRecordInDir(claudeDir, {
       sessionId,
       role: 'host',
       generation: 'gen4',
-      sessionCode: 'surrender-test',
+      sessionCode,
       phase: 'battle',
       status: 'select_action',
-      transport: { host: '127.0.0.1', port: 9999 },
+      transport: { host: '127.0.0.1', port: hostInfo.port ?? 0 },
       opponent: { playerName: 'Guest' },
       pid: process.pid,
-      daemonPid: 1 << 22,
-      socketPath: joinPath(claudeDir, 'tokenmon', 'gen4', 'friendly-battle', 'sessions', `${sessionId}.sock`),
+      daemonPid: hostInfo.child.pid!,
+      socketPath: hostInfo.socketPath,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -864,7 +903,17 @@ describe('friendly-battle-turn per-action subcommands', () => {
       '--generation', 'gen4',
     ]);
 
-    assert.equal(result.exitCode, 2, `expected exit 2 for surrender, got ${result.exitCode}\nstderr: ${result.stderr}`);
-    assert.match(result.stderr, /PR45/, 'stderr mentions PR45');
+    // The CLI parses surrender correctly and forwards to the daemon.
+    // Accept exit 0 (ack) or exit 1 with daemon-layer error — both prove CLI parses correctly.
+    const cliParsedOk = result.exitCode === 0 || result.exitCode === 1;
+    assert.ok(
+      cliParsedOk,
+      `expected exit 0 (ack) or exit 1 (daemon error), got exit ${result.exitCode}\nstderr: ${result.stderr}`,
+    );
+    // Must NOT be the old PR45 "not implemented" error (exit 2)
+    assert.notEqual(result.exitCode, 2, `exit 2 means PR45 stub is still active: ${result.stderr}`);
+    assert.ok(!/PR45/i.test(result.stderr), `stderr must not mention PR45: ${result.stderr}`);
+
+    hostInfo.child.kill('SIGTERM');
   });
 });


### PR DESCRIPTION
## Summary

Activates the \`switch:N\` and \`surrender\` paths PR44 stubbed. \`/tkm:friendly-battle\` can now resolve a full battle including:
- forced switches after a pokémon faints (mid-turn)
- explicit user surrender (with confirm AskUserQuestion)

## What landed

**Surface exposure (Tasks 1-5)**
- \`DaemonAction\` union extended with \`switch\` and \`surrender\` variants
- \`serializeDaemonAction\` handles all 3 cases for the TCP transport
- \`eventToEnvelopeFields\` zeros out \`moveOptions\` when \`status === 'fainted_switch'\` so the skill only shows the party AskUserQuestion
- \`runAction\` parses \`switch:1..6\` (1-based UI → 0-based adapter index) and \`surrender\`
- Skill contract test accepts the new tokens

**SKILL.md flows (Task 6)**
- Step 4: switch menu (user types 교체/switch in Other → second AskUserQuestion of party members)
- Step 5: surrender confirm (user types 항복/surrender → yes/no AskUserQuestion)
- Step 6: forced switch (\`status === 'fainted_switch'\` → mandatory party AskUserQuestion, no cancel)

**Daemon bugs found and fixed mid-execution**
- Host turn loop unconditionally awaited both sides → broke during \`awaiting_fainted_switch\` where only one side submits. Fixed by consulting the newly-exported \`getFriendlyBattleWaitingForRoles\` from \`battle-adapter.ts\` and only awaiting the actual waiters.
- Guest startup interleaved the synthetic \`choices_requested\` with real TCP-buffered init events. Fixed by eagerly draining \`battle_initialized\` + \`choices_requested\` from the TCP buffer right after \`waitForStarted\` instead of synthesizing.

**Integration tests (Tasks 7-8)**
- \`test/friendly-battle-daemon-surrender.test.ts\` — host surrenders during a normal turn, asserts \`battle_finished{winner:guest, reason:surrender}\`
- \`test/friendly-battle-daemon-fainted-switch.test.ts\` — lv80 vs lv1 one-shot KO, asserts \`fainted_switch\` envelope, submits \`switch:2\`, battle continues to next turn

## Stacked PR
- Base: \`feat/friendly-battle-pvp-skill\` (PR #44)
- This branch: \`feat/friendly-battle-pvp-fainted\`
- **Do not merge until #44 lands first.**

## ⚠️ Visual QA merge gate

Switch menu, surrender confirm, and forced switch are all new AskUserQuestion UIs. Merging requires:
1. Two terminals with seeded multi-pokemon parties
2. Force a faint, screenshot the forced-switch AskUserQuestion + the resulting battle continuation
3. Trigger surrender flow, screenshot the confirm AskUserQuestion + the result
4. Run \`oh-my-claudecode:visual-verdict\` on the screenshots

This PR stays draft until visual QA passes.

## Verification
- \`npm test\` → 1197/1197 pass (1195 from PR44 + 2 new fainted/surrender tests)
- \`npx tsc --noEmit\` → exit 0
- \`npm run build\` → exit 0

## Out of scope
- \`--leave\` clean disconnect → PR46
- Two-machine smoke evidence → PR47

🤖 Generated with [Claude Code](https://claude.com/claude-code) via the autopilot skill