### PR TITLE
Add PR47 scaffold: two-machine smoke evidence + helper script

### DIFF
--- a/docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md
+++ b/docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md
@@ -239,6 +239,18 @@ master
 
 ## 8. Architecture revision (PR44 daemon reversal)
 
+## 9. PR47 scope narrowed after PR46 LAN mode merge
+
+PR46 commit `8631e4c` already landed the LAN-mode host behavior itself, so **PR47 no longer carries network-mode implementation scope**. The remaining PR47 deliverable is evidence collection plus a small helper wrapper:
+
+- `docs/friendly-battle/validation/two-machine-smoke.md`
+- `scripts/friendly-battle-smoke.sh`
+- loopback reference log captured locally, with real two-machine logs left as USER ACTION placeholders
+
+Current source of truth for that narrowed scope: [`pr47-smoke-evidence-plan.md`](./pr47-smoke-evidence-plan.md).
+
+In the stacked checklist, treat this as **PR47 Option A**: document the manual two-machine smoke procedure and collect evidence after LAN mode has already shipped.
+
 PR43까지는 "데몬 없음, gym 패턴 그대로, 단일 프로세스 foreground-blocking" 을 전제로 작업했다. PR44 실행에 들어가자마자 이 전제가 깨졌다.
 
 ### 8-1. 발견한 모순

--- a/docs/friendly-battle/roadmap/pr47-smoke-evidence-plan.md
+++ b/docs/friendly-battle/roadmap/pr47-smoke-evidence-plan.md
@@ -1,0 +1,205 @@
+# PR47 — Two-machine smoke evidence (Option A)
+
+> Status: plan drafted, implementation delegated to Codex
+> Base branch: `feat/friendly-battle-pvp-leave` (PR46, already contains LAN mode)
+> Head branch (new): `feat/friendly-battle-two-machine-smoke-evidence`
+
+## 1. Purpose
+
+PR42 의 `docs/friendly-battle/roadmap/current-gap-after-remote-snapshot-handshake.md` §4-4 가 명시적으로 요구한 **"실제 두 머신에서의 수동 smoke 로그"** 를 산출물로 남긴다. 이 PR 은 **문서 + 편의 스크립트 전용** — 본 코드 기능은 전부 PR43-PR46 에 들어있다. PR47 이 완료되면 PR42 의 gap §4-4 체크박스를 지울 수 있다.
+
+## 2. Non-goals
+
+- LAN mode 구현 (이미 PR46 의 `8631e4c` 에 포함됨)
+- WSL2 portproxy 자동화 (별도 PR48+ 로 분리)
+- Internet PvP / NAT traversal / relay (별도 PR 로 분리)
+- 새 CLI 플래그, 새 subcommand 없음
+- 자동화된 two-machine 테스트 (두 머신이 필요한 특성상 불가)
+
+## 3. Deliverables
+
+### 3-1. `docs/friendly-battle/validation/two-machine-smoke.md` (NEW)
+
+표준 sections:
+
+#### §1. Purpose
+- PR42 gap §4-4 를 만족시키는 evidence 문서
+- 이 파일이 존재한다는 사실이 "실제 두 머신에서 LAN PvP 가 검증됐다" 는 서명
+
+#### §2. Prerequisites
+- 두 머신이 같은 L2/L3 네트워크 (동일 WiFi, 동일 subnet)
+- 양쪽에 tkm 플러그인 설치됨 (`~/.claude/plugins/marketplaces/tkm` 또는 cache 경로)
+- 양쪽에 `tokenmon` 초기화 완료 (파티 세팅 포함)
+- (선택) 양쪽 `~/.claude/tokenmon/global-config.json` 의 `language` 가 의도한 로케일로 설정
+- 호스트 머신의 방화벽이 해당 포트 인바운드 TCP 허용
+
+#### §3. LAN IP discovery
+
+OS 별 command:
+
+- **Linux (Ubuntu / Debian)**: `hostname -I | awk '{print $1}'`
+- **Linux (범용)**: `ip -4 addr show | grep inet | grep -v 127 | awk '{print $2}' | cut -d/ -f1 | head -1`
+- **WSL2 inside**: `hostname -I | awk '{print $1}'` (주의: 이건 WSL2 내부 IP 이지 Windows LAN 노출 IP 아님)
+- **WSL2 Windows 호스트 쪽**: PowerShell 에서 `(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias 'Wi-Fi*' | Where-Object { $_.IPAddress -notlike '169.*' }).IPAddress | Select-Object -First 1`
+- **macOS**: `ipconfig getifaddr en0` (Wi-Fi) 또는 `en1` (Ethernet)
+
+#### §4. Firewall setup
+
+- **Linux ufw**: `sudo ufw allow <port>/tcp`
+- **Linux iptables**: `sudo iptables -A INPUT -p tcp --dport <port> -j ACCEPT`
+- **macOS**: Application-level PF — `pfctl` 은 cli 가 복잡하므로 "시스템 설정 → 네트워크 → 방화벽 → node 허용" 권장
+- **Windows Defender Firewall**: `New-NetFirewallRule -DisplayName "tkm friendly battle" -Direction Inbound -LocalPort <port> -Protocol TCP -Action Allow`
+- **WSL2 주의**: Windows 호스트 방화벽 + WSL2 mirrored networking 권장 (`.wslconfig` 에 `networkingMode=mirrored` 추가)
+
+#### §5. Walkthrough — host + guest step-by-step
+
+Host 머신에서:
+```bash
+# Claude Code 세션 열고
+/tkm:friendly-battle open
+```
+→ 출력된 `세션 코드` + `호스트 주소` 메모
+
+Guest 머신에서:
+```bash
+/tkm:friendly-battle join <code>@<host-lan-ip>:<port>
+```
+
+이후 양쪽 AskUserQuestion 으로 기술 선택 → 배틀 진행.
+
+#### §6. Success log sample
+
+실제 두 머신에서 successful smoke 로그 1개. 다음을 캡처:
+- 호스트 쪽의 `{ "phase": "waiting_for_guest", ... }` envelope
+- 게스트 쪽의 `{ "phase": "battle", "status": "select_action", ... }` envelope
+- 첫 턴 `turn_resolved` 양쪽 로그
+- 배틀 종료 시점의 `battle_finished` envelope + skill 의 최종 메시지
+
+> **🛠 USER ACTION REQUIRED**: 이 섹션에 실제 두 머신에서 돌린 로그를 붙여넣어야 한다. 자동화 스크립트(§9)로 캡처 가능.
+
+#### §7. Failure scenarios (3 cases)
+
+각 케이스마다 재현 절차 + 예상 로그 + 실제 캡처 로그.
+
+**§7-1. Guest timeout** — Host 가 `open` 했지만 Guest 가 5분 내에 join 하지 않을 때
+- 재현: 호스트에서 open, 게스트 쪽 아무 액션 안 함, 5분 대기
+- 예상: 호스트 daemon 이 handshake timeout 으로 shutdown(1, aborted), skill 이 "게스트가 응답하지 않습니다" 메시지 표시
+- 로그 캡처 포인트: 호스트 daemon 의 REASON stderr + session record phase/status
+
+**§7-2. Bad session code** — Guest 가 잘못된 code 로 join
+- 재현: 호스트 open → 세션 코드 `abc123` 받음 → 게스트가 `xxx999@<host>:<port>` 로 join
+- 예상: 게스트 handshake 가 hello 교환 단계에서 `session_code_mismatch` 로 거부, guest daemon shutdown(1, aborted)
+- 로그 캡처 포인트: 게스트 stderr + 호스트 stderr 양쪽
+
+**§7-3. Mid-battle peer disconnect** — 배틀 중 한쪽이 Claude Code 세션 강제 종료 (Ctrl+C / 터미널 닫음)
+- 재현: 정상 open/join → 배틀 시작 → 3-4 턴 진행 → 한쪽 터미널에서 `Ctrl+C` 또는 터미널 창 닫기
+- 예상: 살아있는 쪽은 `battle_finished { reason: 'disconnect' }` 수신 → skill 이 "상대방이 배틀을 떠났습니다" 표시
+- 로그 캡처 포인트: 살아있는 쪽의 최종 envelope + 떠난 쪽의 daemon crash log
+
+> **🛠 USER ACTION REQUIRED**: 각 케이스를 실제로 재현해서 로그를 붙여넣어야 한다.
+
+#### §8. Troubleshooting
+
+- **"connection refused"**: 방화벽 차단 또는 잘못된 host:port. §4 firewall setup 재확인.
+- **"ENOENT on socket"**: 이미 끝난 daemon 에 접근 — PR46 에서 CLI 가 fallback envelope 을 반환하도록 수정됨. 발생하면 tkm 버전 확인.
+- **"host binding to 127.0.0.1"**: `/tkm:friendly-battle open local` 을 실수로 사용. `open` 만 쓰면 LAN 모드가 기본.
+- **WSL2 → 다른 머신 접속 실패**: WSL2 내부 IP 는 LAN 에서 안 보임. Windows portproxy 설정 또는 mirrored networking 모드 필요. (상세 명령어)
+- **"daemon dead" within seconds of open**: Node 버전 확인 (≥ 22 필요), CLAUDE_PLUGIN_ROOT 환경변수 확인
+
+#### §9. Smoke script reference
+
+`scripts/friendly-battle-smoke.sh` 의 usage 와 예시 output.
+
+---
+
+### 3-2. `scripts/friendly-battle-smoke.sh` (NEW)
+
+목적: 두 머신에서 수동 smoke 할 때 복붙 실수를 줄이는 편의 래퍼. **자동화가 아니라 편의 one-liner**.
+
+```sh
+#!/usr/bin/env bash
+# Usage:
+#   scripts/friendly-battle-smoke.sh host           # LAN 모드로 open, 세션 코드 + 주소 출력
+#   scripts/friendly-battle-smoke.sh host local     # loopback 모드로 open (같은 머신 테스트)
+#   scripts/friendly-battle-smoke.sh guest <code>@<host>:<port>
+#   scripts/friendly-battle-smoke.sh lan-ip         # 이 머신의 LAN IP 출력 (hostname -I 기반)
+```
+
+설계 원칙:
+- 순수 bash (추가 의존 없음)
+- tkm 플러그인 루트를 `CLAUDE_PLUGIN_ROOT` 또는 marketplace/cache 경로 자동 감지
+- `run-friendly-battle-turn.sh` 를 wrapping — 프로토콜 재발명 없음
+- 실패 경로에서 선명한 stderr + 비영 exit code
+- shellcheck-clean
+
+구현 스켈레톤 (Codex 가 실제로 작성):
+```sh
+set -euo pipefail
+P="${CLAUDE_PLUGIN_ROOT:-$(ls -d ~/.claude/plugins/marketplaces/tkm 2>/dev/null || ls -d ~/.claude/plugins/cache/tkm/tkm/*/ 2>/dev/null | sort -V | tail -1)}"
+[ -n "${P:-}" ] || { echo "error: tkm plugin root not found" >&2; exit 1; }
+# ... dispatch logic
+```
+
+---
+
+### 3-3. `docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md` (UPDATE)
+
+이 파일 §8 이후에 §9 또는 notes 블록 추가:
+- "LAN mode landed in PR46 (`8631e4c`) — PR47 scope narrowed to evidence collection + smoke helper only"
+- PR47 의 deliverable 리스트를 현재 계획 파일로 포인터
+- §6 의 체크리스트에 "PR47 Option A" 표기
+
+`pr47-smoke-evidence-plan.md` (이 파일) 을 정식 plan doc 으로 인정.
+
+---
+
+### 3-4. (Optional) `docs/friendly-battle/validation/local-two-terminal-visual-qa.md` (UPDATE)
+
+기존의 local QA 가이드에 "two-machine smoke 는 §9 로" pointer 추가. **선택사항**. Codex 가 시간 남으면.
+
+---
+
+## 4. Task list (for Codex executor)
+
+Codex 에게 넘길 task 순서:
+
+1. **T1**: `scripts/friendly-battle-smoke.sh` 작성 — 위의 CLI 계약대로. 실행 권한 +x. shellcheck 통과.
+2. **T2**: `docs/friendly-battle/validation/two-machine-smoke.md` 작성 — §1-§9 전체. §6 과 §7 의 실제 로그 자리에는 `<!-- USER: paste real two-machine log here -->` 주석 블록으로 placeholder. §9 의 smoke script usage 는 실제 T1 결과와 일치.
+3. **T3**: roadmap `pr-stack-after-remote-snapshot-handshake.md` 업데이트 — PR47 scope narrowed note 추가.
+4. **T4**: (local smoke capture) — 이 머신에서 `/tkm:friendly-battle open local` 을 실제로 돌려서 host/guest 양쪽 envelope 1턴치를 캡처. 이걸 §6 의 "loopback-only reference log" 로 붙여넣음 (실제 two-machine 로그 자리는 placeholder 로 유지). 시뮬레이션 이상의 증거가 되므로 doc 의 가치가 올라감.
+5. **T5**: `npm run build` + `CI=1 npm test` 돌려서 회귀 없음 확인 (docs/script 만 바꿨으니 당연히 pass 해야 함).
+6. **T6**: 새 브랜치 `feat/friendly-battle-two-machine-smoke-evidence` 생성, commit, push. **PR 자동 생성 금지** — autopilot 끝난 뒤 사용자가 PR 열지 결정.
+
+## 5. Out of scope (explicitly)
+
+- 실제 두 머신에서 돌린 로그 캡처 — 사용자가 나중에 직접 채워야 함 (autopilot 범위 밖, placeholder 만 남김)
+- PR 자동 생성 — 사용자가 PR stack 구조 검토 후 수동으로
+- LAN mode 코드 수정 — 이미 merged
+- 기존 skill/daemon 파일 수정 — 건드리면 안 됨
+
+## 6. Success criteria
+
+- [ ] `scripts/friendly-battle-smoke.sh` 실행 가능, `host local` 모드로 로컬 smoke 한 번 성공
+- [ ] `docs/friendly-battle/validation/two-machine-smoke.md` 가 8 sections 모두 작성됨 + USER ACTION 자리 표시
+- [ ] roadmap doc 가 PR47 narrow scope 반영
+- [ ] tests 1200/1200 pass, build clean
+- [ ] 새 브랜치 push 완료, 원격에 존재
+- [ ] 사용자가 PR 올릴 준비 완료 상태
+
+## 7. 예상 소요
+
+Codex 에게 전체 위임 시 ~15-25분 추정 (docs 작성 + script + 로컬 smoke 캡처 + 빌드/테스트).
+
+---
+
+## Appendix: Reference paths for Codex
+
+- Worktree root: the checkout of `feat/friendly-battle-pvp-leave` where PR47 is stacked
+- Current branch: `feat/friendly-battle-pvp-leave` (PR46 head, where LAN mode lives)
+- Plugin source install: `~/.claude/plugins/marketplaces/tkm`
+- Plugin cache install: `~/.claude/plugins/cache/tkm/tkm/0.6.2/`
+- Existing roadmap docs: `docs/friendly-battle/roadmap/pr{43,44,45,46}-*-plan.md`
+- Existing validation doc: `docs/friendly-battle/validation/local-two-terminal-visual-qa.md`
+- Friendly-battle SKILL: `skills/friendly-battle/SKILL.md` — **do not modify**
+- Helper script for reference: `bin/run-friendly-battle-turn.sh`
+- Session record dir: `~/.claude/tokenmon/<gen>/friendly-battle/sessions/` (for smoke log capture)

--- a/docs/friendly-battle/validation/two-machine-smoke.md
+++ b/docs/friendly-battle/validation/two-machine-smoke.md
@@ -1,0 +1,216 @@
+# Two-Machine Friendly Battle Smoke
+
+상태: Draft
+대상 PR: PR47 Option A
+선행 계획 문서: [`../roadmap/pr47-smoke-evidence-plan.md`](../roadmap/pr47-smoke-evidence-plan.md)
+
+## 1. Purpose
+
+이 문서는 PR42 gap 문서 `current-gap-after-remote-snapshot-handshake.md` §4-4 가 요구한 "실제 두 머신에서의 수동 smoke 로그"를 남기기 위한 evidence scaffold 이다. PR47 자체는 LAN mode 구현 PR 이 아니라, PR46 (`8631e4c`) 에서 LAN mode 가 이미 landed 한 뒤 실제 두 머신 검증 로그를 정리할 자리와 재현 절차를 제공하는 문서 + helper script 범위로 제한된다.
+
+이 파일이 실제 로그로 채워지면 "같은 네트워크의 두 머신에서 `/tkm:friendly-battle open` / `join` 흐름이 검증됐다"는 증거 문서가 된다.
+
+## 2. Prerequisites
+
+- 두 머신이 같은 L2/L3 네트워크에 있어야 한다. 같은 Wi-Fi 또는 같은 subnet 이 권장된다.
+- 양쪽에 tkm 플러그인이 설치되어 있어야 한다. 일반 경로는 `~/.claude/plugins/marketplaces/tkm`, cache 설치라면 `~/.claude/plugins/cache/tkm/tkm/<version>/` 이다.
+- 양쪽에 tokenmon 초기화가 완료되어 있어야 한다. 최소한 파티 구성이 끝나 있어야 친선전이 진행된다.
+- 필요하다면 양쪽 `~/.claude/tokenmon/global-config.json` 의 `language` 값이 원하는 로케일인지 확인한다.
+- 호스트 머신 방화벽은 선택된 포트의 inbound TCP 를 허용해야 한다.
+- Node.js 22+ 와 Claude Code 세션이 정상 동작해야 한다. daemon 이 즉시 죽는 패턴은 대개 Node 버전 부족 또는 plugin root 해석 실패와 연결된다.
+
+## 3. LAN IP discovery
+
+호스트가 LAN mode 로 방을 열 때 게스트에게 전달할 주소는 `127.0.0.1` 이 아니라 실제 LAN IPv4 여야 한다.
+
+- Linux (Ubuntu / Debian): `hostname -I | awk '{print $1}'`
+- Linux (generic fallback): `ip -4 addr show | grep inet | grep -v 127 | awk '{print $2}' | cut -d/ -f1 | head -1`
+- WSL2 inside: `hostname -I | awk '{print $1}'`
+  WSL2 내부 IP 는 다른 물리 머신에서 바로 보이지 않을 수 있다. 이 값만 복사해서 전달하면 guest 쪽에서 `connection refused` 가 날 수 있다.
+- WSL2 Windows host side (PowerShell): `(Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias 'Wi-Fi*' | Where-Object { $_.IPAddress -notlike '169.*' }).IPAddress | Select-Object -First 1`
+- macOS Wi-Fi: `ipconfig getifaddr en0`
+- macOS Ethernet: `ipconfig getifaddr en1`
+
+Helper script 로 현재 머신의 기본 LAN IPv4 를 출력하려면:
+
+```bash
+scripts/friendly-battle-smoke.sh lan-ip
+```
+
+스크립트는 먼저 `hostname -I | awk '{print $1}'` 를 시도하고, 값이 비면 Node `os.networkInterfaces()` fallback 으로 첫 non-loopback IPv4 를 찾는다.
+
+## 4. Firewall setup
+
+호스트가 LAN mode 로 열면 TCP listen 은 `0.0.0.0:<ephemeral-port>` 에 바인딩된다. 게스트가 다른 머신이라면 호스트 방화벽이 해당 포트를 허용해야 한다.
+
+- Linux ufw: `sudo ufw allow <port>/tcp`
+- Linux iptables: `sudo iptables -A INPUT -p tcp --dport <port> -j ACCEPT`
+- macOS: 시스템 설정에서 `node` 또는 Claude Code 가 inbound 연결을 허용하도록 설정하는 편이 가장 단순하다.
+- Windows Defender Firewall: `New-NetFirewallRule -DisplayName "tkm friendly battle" -Direction Inbound -LocalPort <port> -Protocol TCP -Action Allow`
+- WSL2: Windows 쪽 방화벽도 함께 열어야 한다. mirrored networking 을 쓰지 않는다면 `netsh interface portproxy` 로 Windows LAN 포트를 WSL2 IP 로 forward 해야 한다.
+
+예시 WSL2 portproxy:
+
+```powershell
+netsh interface portproxy add v4tov4 listenaddress=0.0.0.0 listenport=<port> connectaddress=<wsl-ip> connectport=<port>
+New-NetFirewallRule -DisplayName "tkm friendly battle <port>" -Direction Inbound -LocalPort <port> -Protocol TCP -Action Allow
+```
+
+## 5. Walkthrough — host + guest step-by-step
+
+Host 머신:
+
+```bash
+/tkm:friendly-battle open
+```
+
+또는 helper script:
+
+```bash
+scripts/friendly-battle-smoke.sh host
+```
+
+호스트는 session code 와 host:port 를 출력한다. LAN mode 에서는 방화벽 경고와 함께 실제 LAN IP 를 공유해야 한다.
+
+Guest 머신:
+
+```bash
+/tkm:friendly-battle join <code>@<host-lan-ip>:<port>
+```
+
+또는 helper script:
+
+```bash
+scripts/friendly-battle-smoke.sh guest <code>@<host-lan-ip>:<port>
+```
+
+정상 흐름:
+
+1. Host 가 room 을 연다.
+2. Guest 가 `<code>@<host>:<port>` 로 join 한다.
+3. 양쪽 모두 `phase='battle'`, `status='select_action'` envelope 을 받는다.
+4. 첫 턴 선택 이후 `turn_resolved` 관련 frame / envelope 이 양쪽에 찍힌다.
+5. 배틀 종료 시 `battle_finished` 또는 terminal envelope 이 남는다.
+
+## 6. Success log sample
+
+실제 두 머신 successful smoke 로그 자리:
+
+<!-- USER: paste real two-machine log here -->
+
+### 6-1. Loopback reference capture
+
+실제 2-머신 smoke 를 돌리기 전 sanity check 용. 아래 blob 은 `scripts/friendly-battle-smoke.sh` 를 `feat/friendly-battle-two-machine-smoke-evidence` 브랜치에서 실제로 돌려서 얻은 출력이다. daemon 이 loopback 모드에서 정상적으로 떴고 `waiting_for_guest` envelope 를 반환한다는 것이 확인된다.
+
+```text
+$ scripts/friendly-battle-smoke.sh lan-ip
+192.168.125.30
+
+$ scripts/friendly-battle-smoke.sh host local
+MODE: local
+SESSION_CODE: c4f3b7
+HOST: 127.0.0.1
+PORT: 44185
+JOIN: c4f3b7@127.0.0.1:44185
+{"sessionId":"fb-48bcce07-4146-434f-bc5f-e66c00c8b1f3","role":"host","phase":"waiting_for_guest","status":"waiting_for_guest","questionContext":"Waiting for guest (code c4f3b7) — see /tkm:friendly-battle status","moveOptions":[],"partyOptions":[],"animationFrames":[],"currentFrameIndex":0}
+```
+
+확인 가능한 것:
+- daemon 이 ephemeral 포트(44185)에 bind 성공
+- session code 가 6-hex 형식으로 정상 생성
+- 초기 envelope 의 phase / status 가 `waiting_for_guest` 로 정확히 세팅
+- helper script 가 session_code / host / port / JOIN 문자열을 구조화해서 stdout 에 출력
+
+loopback 모드는 의도적으로 다른 머신 게스트가 접속할 수 없다 — 이 캡처는 "네가티브 컨트롤" 역할. 실제 LAN smoke 에서는 위 `HOST` 값이 `127.0.0.1` 대신 머신의 실제 LAN IP 로 나와야 한다.
+
+**Script bug fixed during this capture**: 최초 시도에서 `scripts/friendly-battle-smoke.sh host local` 이 `PORT: 44185` 를 daemon stderr 에 찍었는데도 helper script 의 PORT 파서가 `failed to parse host port` 로 실패했다. 원인은 `--init-host` 가 detached daemon fork 직후 즉시 종료되기 때문에 `while kill -0 $init_pid` 루프가 `PORT:` 라인이 stderr 파일에 flush 되기 전에 빠져나가는 race. fix 는 `wait $init_pid` 로 child 를 완전히 수거한 뒤 파싱을 한 번 더 시도하는 것. 같은 커밋에 포함.
+
+## 7. Failure scenarios (3 cases)
+
+### 7-1. Guest timeout
+
+재현:
+
+1. Host 에서 `/tkm:friendly-battle open` 또는 `scripts/friendly-battle-smoke.sh host` 실행
+2. Guest 쪽은 아무 것도 하지 않고 5분 이상 대기
+
+예상:
+
+- Host daemon 이 handshake timeout 으로 shutdown 된다.
+- Host 쪽은 `phase='aborted'` 와 함께 대기 실패를 보여주거나 REASON stderr 를 남긴다.
+
+실제 로그 자리:
+
+<!-- USER: paste real two-machine log here -->
+
+### 7-2. Bad session code
+
+재현:
+
+1. Host 에서 정상적으로 open
+2. Guest 가 실제 code 대신 임의의 잘못된 code 로 `join`
+
+예상:
+
+- Guest handshake 는 hello/hello_ack 단계에서 `session_code_mismatch` 또는 동급 거절로 종료된다.
+- Guest daemon 은 aborted 로 종료되고, Host 쪽에도 거절 흔적이 남는다.
+
+실제 로그 자리:
+
+<!-- USER: paste real two-machine log here -->
+
+### 7-3. Mid-battle peer disconnect
+
+재현:
+
+1. 정상 open / join
+2. 1~3턴 진행
+3. 한쪽 Claude Code 세션을 `Ctrl+C` 또는 터미널 종료로 끊는다
+
+예상:
+
+- 살아남은 쪽은 `battle_finished { reason: 'disconnect' }` 또는 `phase='aborted'` terminal envelope 을 본다.
+- 떠난 쪽은 daemon shutdown 로그 또는 CLI 종료 흔적을 남긴다.
+
+실제 로그 자리:
+
+<!-- USER: paste real two-machine log here -->
+
+## 8. Troubleshooting
+
+- `connection refused`
+  보통 잘못된 host:port 이거나 방화벽 차단이다. `host` 가 `127.0.0.1` 로 잘못 공유되지 않았는지 확인하고, §4 방화벽 규칙과 실제 bound port 를 다시 확인한다.
+- `ENOENT` on socket / daemon unreachable
+  이미 끝난 daemon 의 UNIX socket 에 붙으려는 경우다. 현재 `friendly-battle-turn --wait-next-event` 와 `--status` 는 ENOENT / ECONNREFUSED 시 record snapshot 기반 fallback envelope 을 반환하도록 되어 있으므로, raw crash 대신 terminal 상태를 확인해야 한다. 여전히 ENOENT crash 가 보인다면 PR46 이후 버전이 맞는지 확인한다.
+- host binding to `127.0.0.1`
+  `/tkm:friendly-battle open local` 또는 `scripts/friendly-battle-smoke.sh host local` 을 실수로 사용한 경우다. 같은 머신 테스트가 아니라면 `open` / `host` 기본 모드를 사용해야 한다.
+- WSL2 guest cannot connect from another machine
+  WSL2 내부 IP 는 외부 LAN 머신에 바로 노출되지 않는다. Windows 쪽 실제 LAN IP 를 전달하고, 필요하면 `netsh interface portproxy` 또는 mirrored networking (`.wslconfig` 의 `networkingMode=mirrored`) 을 사용한다.
+- daemon dies within seconds of open
+  실제 코드베이스에서 자주 맞는 패턴은 Node 버전 부족(22 미만), `CLAUDE_PLUGIN_ROOT` 가 잘못 잡혀 `run-friendly-battle-turn.sh` 가 엉뚱한 트리를 보는 경우, 또는 plugin 설치 경로에서 deps 가 누락된 경우다. `node -v`, `echo "$CLAUDE_PLUGIN_ROOT"`, `test -f "$CLAUDE_PLUGIN_ROOT/package.json"` 으로 먼저 확인한다.
+- daemon death after handshake with no obvious UI
+  `~/.claude/tokenmon/<generation>/friendly-battle/sessions/` 아래 session record 를 보면 `phase`, `status`, `daemonPid`, `updatedAt` 로 frozen state 를 확인할 수 있다. 종료 직후 `phase='finished'` 또는 `phase='aborted'` 로 굳어 있으면 CLI fallback envelope 으로도 동일 상태를 재현할 수 있다.
+
+## 9. Smoke script reference
+
+`scripts/friendly-battle-smoke.sh` 는 manual smoke 때 복붙 실수를 줄이는 thin wrapper 다. protocol 을 재구현하지 않고 기존 `bin/run-friendly-battle-turn.sh` 를 그대로 감싼다.
+
+Usage:
+
+```bash
+scripts/friendly-battle-smoke.sh host
+scripts/friendly-battle-smoke.sh host local
+scripts/friendly-battle-smoke.sh guest <code>@<host>:<port>
+scripts/friendly-battle-smoke.sh lan-ip
+```
+
+동작 요약:
+
+- `host`
+  LAN mode (`--listen-host 0.0.0.0`) 로 room 을 열고 `SESSION_CODE`, `HOST`, `PORT`, `JOIN` 안내를 출력한 뒤, handshake 완료 후 첫 턴의 battle / action / result envelope 1세트를 자동으로 찍는다.
+- `host local`
+  loopback mode (`--listen-host 127.0.0.1`) 로 동일한 흐름을 수행한다. 같은 머신에서 두 터미널 smoke 를 캡처할 때 사용한다.
+- `guest <code>@<host>:<port>`
+  지정된 host 에 join 한 뒤 첫 턴의 battle / action / result envelope 1세트를 자동으로 찍는다.
+- `lan-ip`
+  이 머신에서 공유해야 할 기본 LAN IPv4 를 출력한다.

--- a/scripts/friendly-battle-smoke.sh
+++ b/scripts/friendly-battle-smoke.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/friendly-battle-smoke.sh host
+  scripts/friendly-battle-smoke.sh host local
+  scripts/friendly-battle-smoke.sh guest <code>@<host>:<port>
+  scripts/friendly-battle-smoke.sh lan-ip
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/run-friendly-battle-turn.sh" ]; then
+    printf '%s\n' "${CLAUDE_PLUGIN_ROOT}"
+    return 0
+  fi
+
+  local script_dir repo_root
+  script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+  repo_root="$(CDPATH= cd -- "${script_dir}/.." && pwd)"
+  if [ -x "${repo_root}/bin/run-friendly-battle-turn.sh" ]; then
+    printf '%s\n' "${repo_root}"
+    return 0
+  fi
+
+  if [ -x "${HOME}/.claude/plugins/marketplaces/tkm/bin/run-friendly-battle-turn.sh" ]; then
+    printf '%s\n' "${HOME}/.claude/plugins/marketplaces/tkm"
+    return 0
+  fi
+
+  local cache_root candidate
+  cache_root="${HOME}/.claude/plugins/cache/tkm/tkm"
+  if [ -d "${cache_root}" ]; then
+    candidate="$(find "${cache_root}" -mindepth 1 -maxdepth 1 -type d | LC_ALL=C sort -V | tail -n 1 || true)"
+    if [ -n "${candidate}" ] && [ -x "${candidate}/bin/run-friendly-battle-turn.sh" ]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+lan_ip() {
+  local via_hostname
+  via_hostname="$(
+    hostname -I 2>/dev/null \
+      | awk '{print $1}'
+  )"
+  if [ -n "${via_hostname}" ]; then
+    printf '%s\n' "${via_hostname}"
+    return 0
+  fi
+
+  node -e '
+    const os = require("os");
+    let nets;
+    try {
+      nets = os.networkInterfaces();
+    } catch (error) {
+      process.stderr.write(`failed to inspect network interfaces: ${error.message}\n`);
+      process.exit(1);
+    }
+    for (const name of Object.keys(nets)) {
+      for (const addr of nets[name] || []) {
+        if (addr && addr.family === "IPv4" && !addr.internal) {
+          process.stdout.write(addr.address);
+          process.exit(0);
+        }
+      }
+    }
+    process.stderr.write("no non-loopback IPv4 address found\n");
+    process.exit(1);
+  '
+}
+
+detect_generation() {
+  local config_root
+  config_root="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+  CONFIG_ROOT="${config_root}" node -e '
+    const fs = require("fs");
+    const path = require("path");
+    try {
+      const file = path.join(process.env.CONFIG_ROOT, "tokenmon", "global-config.json");
+      const json = JSON.parse(fs.readFileSync(file, "utf8"));
+      process.stdout.write(json.active_generation || "gen1");
+    } catch {
+      process.stdout.write("gen1");
+    }
+  '
+}
+
+json_field() {
+  local json_text="$1"
+  local field="$2"
+  JSON_INPUT="${json_text}" JSON_FIELD="${field}" node -e '
+    const data = JSON.parse(process.env.JSON_INPUT);
+    const value = data[process.env.JSON_FIELD];
+    if (typeof value === "string" || typeof value === "number") {
+      process.stdout.write(String(value));
+      process.exit(0);
+    }
+    process.exit(1);
+  '
+}
+
+find_session_record() {
+  local generation="$1"
+  local role="$2"
+  local session_code="$3"
+  local field="$4"
+  local config_root sessions_dir
+
+  config_root="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+  sessions_dir="${config_root}/tokenmon/${generation}/friendly-battle/sessions"
+  [ -d "${sessions_dir}" ] || return 1
+
+  SESSIONS_DIR="${sessions_dir}" ROLE="${role}" SESSION_CODE="${session_code}" FIELD="${field}" node -e '
+    const fs = require("fs");
+    const path = require("path");
+    const dir = process.env.SESSIONS_DIR;
+    const files = fs.readdirSync(dir)
+      .filter((name) => name.endsWith(".json"))
+      .map((name) => path.join(dir, name))
+      .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(file, "utf8"));
+        if (data.role !== process.env.ROLE || data.sessionCode !== process.env.SESSION_CODE) continue;
+        const field = process.env.FIELD;
+        let value = data[field];
+        if (field === "port") value = data.transport && data.transport.port;
+        if (field === "sessionId") value = data.sessionId;
+        if (value !== undefined && value !== null && value !== "") {
+          process.stdout.write(String(value));
+          process.exit(0);
+        }
+      } catch {}
+    }
+    process.exit(1);
+  '
+}
+
+run_cli() {
+  "${PLUGIN_ROOT}/bin/run-friendly-battle-turn.sh" "$@"
+}
+
+drive_one_turn() {
+  local session_id="$1"
+  local generation="$2"
+  local battle_line action_line result_line
+
+  battle_line="$(run_cli --wait-next-event --session "${session_id}" --generation "${generation}" --timeout-ms 60000)"
+  printf '%s\n' "${battle_line}"
+
+  action_line="$(run_cli --action move:1 --session "${session_id}" --generation "${generation}")"
+  printf '%s\n' "${action_line}"
+
+  result_line="$(run_cli --wait-next-event --session "${session_id}" --generation "${generation}" --timeout-ms 60000)"
+  printf '%s\n' "${result_line}"
+}
+
+run_host() {
+  local mode="${1:-}"
+  local listen_host advertised_host session_code generation
+  local init_output init_stdout init_stderr init_pid init_rc session_id port
+
+  generation="$(detect_generation)"
+  session_code="$(node -e 'process.stdout.write(require("crypto").randomBytes(3).toString("hex"))')"
+  if [ "${mode}" = "local" ]; then
+    listen_host="127.0.0.1"
+    advertised_host="127.0.0.1"
+  else
+    listen_host="0.0.0.0"
+    advertised_host="$(lan_ip)"
+  fi
+
+  init_stdout="$(mktemp)"
+  init_stderr="$(mktemp)"
+  run_cli \
+    --init-host \
+    --session-code "${session_code}" \
+    --generation "${generation}" \
+    --listen-host "${listen_host}" \
+    --port 0 \
+    --timeout-ms 300000 \
+    --player-name Host \
+    >"${init_stdout}" \
+    2>"${init_stderr}" &
+  init_pid=$!
+
+  port=""
+  while kill -0 "${init_pid}" 2>/dev/null; do
+    port="$(awk '/^PORT: / { print $2; exit }' "${init_stderr}")"
+    if [ -z "${port}" ]; then
+      port="$(find_session_record "${generation}" host "${session_code}" port || true)"
+    fi
+    if [ -n "${port}" ]; then
+      break
+    fi
+    sleep 0.1
+  done
+
+  # --init-host exits as soon as the detached daemon is ready, so the process
+  # can die BEFORE the PORT line is flushed into init_stderr. Wait for the
+  # child to fully exit so the stderr file is complete, then re-parse once
+  # more before giving up.
+  wait "${init_pid}" 2>/dev/null || true
+  if [ -z "${port}" ]; then
+    port="$(awk '/^PORT: / { print $2; exit }' "${init_stderr}")"
+  fi
+  if [ -z "${port}" ]; then
+    port="$(find_session_record "${generation}" host "${session_code}" port || true)"
+  fi
+
+  if [ -z "${port}" ]; then
+    cat "${init_stderr}" >&2
+    rm -f "${init_stdout}" "${init_stderr}"
+    die "failed to parse host port"
+  fi
+
+  printf 'MODE: %s\n' "${mode:-lan}"
+  printf 'SESSION_CODE: %s\n' "${session_code}"
+  printf 'HOST: %s\n' "${advertised_host}"
+  printf 'PORT: %s\n' "${port}"
+  printf 'JOIN: %s@%s:%s\n' "${session_code}" "${advertised_host}" "${port}"
+
+  if ! wait "${init_pid}"; then
+    init_rc=$?
+    cat "${init_stderr}" >&2
+    rm -f "${init_stdout}" "${init_stderr}"
+    exit "${init_rc}"
+  fi
+
+  init_output="$(cat "${init_stdout}")"
+  session_id="$(json_field "${init_output}" sessionId || true)"
+  if [ -z "${session_id}" ]; then
+    session_id="$(find_session_record "${generation}" host "${session_code}" sessionId || true)"
+  fi
+  [ -n "${session_id}" ] || die "failed to parse host sessionId"
+  printf '%s\n' "${init_output}"
+  rm -f "${init_stdout}" "${init_stderr}"
+
+  drive_one_turn "${session_id}" "${generation}"
+}
+
+run_guest() {
+  local target="${1:-}"
+  local session_code host port generation init_output session_id
+
+  [ -n "${target}" ] || die "guest requires <code>@<host>:<port>"
+  case "${target}" in
+    *@*:*)
+      session_code="${target%%@*}"
+      host="${target#*@}"
+      port="${host##*:}"
+      host="${host%:*}"
+      ;;
+    *)
+      die "guest target must be <code>@<host>:<port>"
+      ;;
+  esac
+
+  [ -n "${session_code}" ] || die "missing session code"
+  [ -n "${host}" ] || die "missing host"
+  [ -n "${port}" ] || die "missing port"
+
+  generation="$(detect_generation)"
+  init_output="$(
+    run_cli \
+      --init-join \
+      --session-code "${session_code}" \
+      --host "${host}" \
+      --port "${port}" \
+      --generation "${generation}" \
+      --timeout-ms 30000 \
+      --player-name Guest
+  )"
+  session_id="$(json_field "${init_output}" sessionId)" || die "failed to parse guest sessionId"
+
+  printf 'JOIN: %s\n' "${target}"
+  printf '%s\n' "${init_output}"
+
+  drive_one_turn "${session_id}" "${generation}"
+}
+
+PLUGIN_ROOT="$(resolve_plugin_root)" || die "tkm plugin root not found"
+
+subcommand="${1:-}"
+case "${subcommand}" in
+  host)
+    shift
+    if [ "$#" -gt 1 ]; then
+      usage >&2
+      exit 1
+    fi
+    run_host "${1:-}"
+    ;;
+  guest)
+    shift
+    if [ "$#" -ne 1 ]; then
+      usage >&2
+      exit 1
+    fi
+    run_guest "$1"
+    ;;
+  lan-ip)
+    shift
+    [ "$#" -eq 0 ] || {
+      usage >&2
+      exit 1
+    }
+    lan_ip
+    ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Scaffolds the two-machine smoke evidence PR that PR42 gap doc §4-4 asked for. LAN mode itself already landed in PR46 (commit 8631e4c), so this PR is documentation + a convenience helper script only — no code changes to the friendly-battle engine, daemon, or skill.

## What's in here

- `scripts/friendly-battle-smoke.sh` — host / host local / guest / lan-ip subcommands wrapping `bin/run-friendly-battle-turn.sh`. Gives a copy-paste-free way to kick off a smoke run on two real machines. Also contains a race-fix over the initial draft: the host subcommand now waits for `--init-host` to fully exit before re-parsing the `PORT:` line from stderr.

- `docs/friendly-battle/validation/two-machine-smoke.md` — §1-§9 evidence scaffold: prerequisites, LAN IP discovery per OS, firewall setup, walkthrough, success log sample, 3 failure scenarios (guest timeout / bad code / peer disconnect), troubleshooting, smoke script reference. Real two-machine logs are left as `<!-- USER: paste real two-machine log here -->` placeholders. §6-1 contains a real loopback reference capture taken from this branch to prove the helper script and the daemon path work.

- `docs/friendly-battle/roadmap/pr47-smoke-evidence-plan.md` — formal plan doc, matches the pr43-46 plan pattern in the same directory. Describes the narrow scope and the Option A decision to split the evidence PR off from the code PRs.

- `docs/friendly-battle/roadmap/pr-stack-after-remote-snapshot-handshake.md` — appended note that PR47 scope narrowed to evidence-only after LAN mode landed in PR46.

## Why evidence-only

The original PR47 in the roadmap required a LAN mode implementation plus evidence. LAN mode is already live in PR46, so PR47 collapses to "write the evidence scaffold + ship the helper + note the scope change". The PR is intentionally small because the hard product work is already merged upstream.

## Stacking

Based on `feat/friendly-battle-pvp-leave` (PR46). Merge PR43 → PR44 → PR45 → PR46 → PR47 in order when the stack is ready.

## Test plan

- [ ] Rebase cleanly on `feat/friendly-battle-pvp-leave`
- [ ] `scripts/friendly-battle-smoke.sh lan-ip` prints a non-loopback IPv4 on the test machine
- [ ] `scripts/friendly-battle-smoke.sh host local` starts a daemon, prints SESSION_CODE / HOST / PORT / JOIN, and emits the `waiting_for_guest` envelope on stdout
- [ ] User runs the doc walkthrough on two real machines and pastes logs into the `USER ACTION` placeholders (§6 and §7)
- [ ] 1200/1200 existing tests still pass (no source code changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)