### PR TITLE
fix: common 업적 달성 시 state에 기록 누락 및 조회 누락

### DIFF
--- a/src/cli/tokenmon.ts
+++ b/src/cli/tokenmon.ts
@@ -2,9 +2,9 @@
 import * as readline from 'readline';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import { readState, writeState } from '../core/state.js';
+import { readState, readCommonState, writeState } from '../core/state.js';
 import { readConfig, writeConfig, getDefaultConfig, readGlobalConfig, writeGlobalConfig } from '../core/config.js';
-import { getPokemonDB, getAchievementsDB, getAchievementName, getAchievementDescription, getAchievementRarityLabel, getRegionName, getRegionDescription, getPokemonName, getGenerationsDB, invalidateGenCache, pokemonIdByName, resolveNameToId, getDisplayName, formatMetInfo } from '../core/pokemon-data.js';
+import { getPokemonDB, getAchievementsDB, getCommonAchievementsDB, getAchievementName, getAchievementDescription, getAchievementRarityLabel, getRegionName, getRegionDescription, getPokemonName, getGenerationsDB, invalidateGenCache, pokemonIdByName, resolveNameToId, getDisplayName, formatMetInfo } from '../core/pokemon-data.js';
 import { levelToXp } from '../core/xp.js';
 import { playCry } from '../audio/play-cry.js';
 import { getCompletion, getPokedexList, syncPokedexFromUnlocked, getRegionSummary } from '../core/pokedex.js';
@@ -372,13 +372,25 @@ function cmdUnlockList(): void {
 
 function cmdAchievements(): void {
   const state = readState();
+  const commonState = readCommonState();
   const achDB = getAchievementsDB();
+  const commonAchDB = getCommonAchievementsDB();
+
+  // Merge per-gen and common achievements, deduplicate by id
+  const seen = new Set<string>();
+  const allAchievements: Array<{ id: string }> = [];
+  for (const ach of achDB.achievements) {
+    if (!seen.has(ach.id)) { seen.add(ach.id); allAchievements.push(ach); }
+  }
+  for (const ach of commonAchDB.achievements) {
+    if (!seen.has(ach.id)) { seen.add(ach.id); allAchievements.push(ach); }
+  }
 
   bold(t('cli.achievements.header'));
   console.log('');
 
-  for (const ach of achDB.achievements) {
-    const achieved = !!state.achievements[ach.id];
+  for (const ach of allAchievements) {
+    const achieved = !!state.achievements[ach.id] || !!commonState.achievements[ach.id];
     if (achieved) {
       console.log(`  ${GREEN}✓${RESET} ${BOLD}${getAchievementName(ach.id)}${RESET} ${getAchievementRarityLabel(ach.id)}`);
     } else {

--- a/src/core/achievements.ts
+++ b/src/core/achievements.ts
@@ -211,6 +211,7 @@ export function checkCommonAchievements(commonState: CommonState, config: Config
     if (!triggered) continue;
 
     commonState.achievements[ach.id] = true;
+    state.achievements[ach.id] = true;
 
     const event: AchievementEvent = {
       id: ach.id,


### PR DESCRIPTION
## Summary

- `checkCommonAchievements()`에서 업적 달성 시 `commonState.achievements`에만 기록하고 `state.achievements`에는 기록하지 않던 버그 수정
- `cmdAchievements()`에서 per-gen DB/state만 조회하여 common 전용 업적이 표시되지 않던 버그 수정

## 상세

**기록 누락 (`achievements.ts`)**

`checkAchievements()`는 `state`와 `commonState` 양쪽에 기록하지만, `checkCommonAchievements()`는 `commonState`에만 기록하여 비대칭이었습니다. `state.achievements`에도 함께 기록하도록 1줄 추가했습니다.

**조회 누락 (`tokenmon.ts`)**

`cmdAchievements()`가 `getAchievementsDB()` (per-gen)만 순회하고 `getCommonAchievementsDB()`는 순회하지 않아, common 전용 업적 15개가 목록에 나타나지 않았습니다. 양쪽 DB를 병합하고 `commonState.achievements`도 함께 확인하도록 수정했습니다.

## Test plan

- [x] 타입 체크 통과
- [x] `achievements` 명령어에서 common 업적 표시 확인
- [ ] 새로운 common 업적 달성 시 `state.json`에 기록 확인
- [ ] 기존 per-gen 업적 동작에 영향 없는지 확인